### PR TITLE
Check birthdate is not full of zeros

### DIFF
--- a/classes/GenerateJsonPaypalOrder.php
+++ b/classes/GenerateJsonPaypalOrder.php
@@ -182,7 +182,7 @@ class GenerateJsonPaypalOrder
         }
 
         // Add optional birthdate if provided
-        if (!empty($params['customer']->birthday)) {
+        if (!empty($params['customer']->birthday) && $params['customer']->birthday !== '0000-00-00') {
             $payload['payer']['birth_date'] = $params['customer']->birthday;
         }
 


### PR DESCRIPTION
Payload was incorrect during checkout because the birthdate was `0000-00-00` instead of being empty.