### PR TITLE
Catch parent guzzle exception

### DIFF
--- a/classes/api/Maasland.php
+++ b/classes/api/Maasland.php
@@ -112,8 +112,9 @@ class Maasland
         } catch (RequestException $e) {
             \PrestaShopLogger::addLog($e->getMessage());
 
-            return false;
-        } catch (ClientException $e) {
+            if (!$e->hasResponse()) {
+                return false;
+            }
             $response = $e->getResponse();
         }
 

--- a/tests/MaaslandCreateOrderTest.php
+++ b/tests/MaaslandCreateOrderTest.php
@@ -43,6 +43,13 @@ class Link
     }
 }
 
+class PrestaShopLogger
+{
+    public static function addLog()
+    {
+    }
+}
+
 class MaaslandCreateOrderTest extends TestCase
 {
     public function testCreateOrderDefaultScenario()


### PR DESCRIPTION
In some case, the API can be too slow to return a response in the given time.

This triggers a ConnectException which wasn't caught by the existing `catch` blocks. This PR catches the parent RequestException to cover more cases.

![Capture d’écran du 2019-07-19 10-22-03](https://user-images.githubusercontent.com/6768917/61624667-f815be80-ac70-11e9-93f1-fe8926aa8305.png)
