### PR TITLE
Disable paypal onboarding button when not logged in PS Checkout

### DIFF
--- a/_dev/components/panel/account-list.vue
+++ b/_dev/components/panel/account-list.vue
@@ -57,14 +57,21 @@
             <div class="col-12 col-sm-4 col-md-3 col-lg-3 m-auto">
               <div class="text-center float-right" v-if="paypalStatusAccount === false">
                 <a
-                  v-show="paypalIsLoaded"
+                  v-show="paypalIsLoaded && paypalOnboardingLink"
                   class="btn btn-primary-reverse btn-outline-primary light-button"
                   data-paypal-button="true"
-                  :href="$store.state.paypal.account.paypalOnboardingLink+'&displayMode=minibrowser'"
+                  :href="paypalOnboardingLink+'&displayMode=minibrowser'"
                   target="PPFrame"
                 >
                   {{ $t('panel.account-list.linkToPaypal') }}
                 </a>
+                <button
+                  v-show="!paypalOnboardingLink"
+                  class="btn btn-primary-reverse btn-outline-primary light-button"
+                  disabled
+                >
+                  {{ $t('panel.account-list.linkToPsCheckoutFirst') }}
+                </button>
                 <a
                   v-show="!paypalIsLoaded"
                   href="#"
@@ -96,6 +103,9 @@
       },
       paypalStatusAccount() {
         return this.$store.state.paypal.account.onboardingCompleted;
+      },
+      paypalOnboardingLink() {
+        return this.$store.state.paypal.account.paypalOnboardingLink;
       },
     },
     methods: {

--- a/classes/translations/Translations.php
+++ b/classes/translations/Translations.php
@@ -96,6 +96,7 @@ class Translations
                     'activatePayment' => $this->module->l('Log in or sign up to PayPal'),
                     'accountIsLinked' => $this->module->l('Your PrestaShop Checkout account is linked to your PayPal account'),
                     'linkToPaypal' => $this->module->l('Link to PayPal account'),
+                    'linkToPsCheckoutFirst' => $this->module->l('Link to PrestaShop Checkout first'),
                     'loading' => $this->module->l('Loading'),
                     'useAnotherAccount' => $this->module->l('Use another account'),
                 ),


### PR DESCRIPTION
To avoid URL issues when we're not logged on our PS Checkout account, we should disable the PayPal on-boarding.

![Capture d’écran du 2019-07-22 11-48-44](https://user-images.githubusercontent.com/6768917/61627465-bfc5ae80-ac77-11e9-9785-9fa7796b3dad.png)
