### PR TITLE
Remove 'locale' from Paypal Json Order to prevent issues. 

### DIFF
--- a/classes/GenerateJsonPaypalOrder.php
+++ b/classes/GenerateJsonPaypalOrder.php
@@ -109,7 +109,7 @@ class GenerateJsonPaypalOrder
             $items[] = $item;
         }
 
-        $isoCodeDispatcher = new IsoCodeDispatcher();
+        $countryCodeMatrice = new PaypalCountryCodeMatrice();
         $shippingCountryIsoCode = $this->getCountryIsoCodeById($params['addresses']['shipping']->id_country);
         $payerCountryIsoCode = $this->getCountryIsoCodeById($params['addresses']['invoice']->id_country);
 
@@ -151,7 +151,7 @@ class GenerateJsonPaypalOrder
                     'address_line_2' => $params['addresses']['shipping']->address2,
                     'admin_area_1' => (string) $this->getStateNameById($params['addresses']['shipping']->id_state),
                     'admin_area_2' => $params['addresses']['shipping']->city,
-                    'country_code' => $isoCodeDispatcher->getPaypalIsoCode($shippingCountryIsoCode),
+                    'country_code' => $countryCodeMatrice->getPaypalIsoCode($shippingCountryIsoCode),
                     'postal_code' => $params['addresses']['shipping']->postcode,
                 ],
             ],
@@ -166,7 +166,7 @@ class GenerateJsonPaypalOrder
                     'address_line_2' => $params['addresses']['invoice']->address2,
                     'admin_area_1' => (string) $this->getStateNameById($params['addresses']['invoice']->id_state), //The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.
                     'admin_area_2' => $params['addresses']['invoice']->city, // A city, town, or village. Smaller than admin_area_level_1
-                    'country_code' => $isoCodeDispatcher->getPaypalIsoCode($payerCountryIsoCode),
+                    'country_code' => $countryCodeMatrice->getPaypalIsoCode($payerCountryIsoCode),
                     'postal_code' => $params['addresses']['invoice']->postcode,
                 ],
             ],
@@ -175,7 +175,6 @@ class GenerateJsonPaypalOrder
             ],
             'application_context' => [
                 'brand_name' => \Configuration::get('PS_SHOP_NAME'),
-                'locale' => $params['language']->locale,
                 'shipping_preference' => 'SET_PROVIDED_ADDRESS',
             ],
         ];

--- a/classes/PaypalCountryCodeMatrice.php
+++ b/classes/PaypalCountryCodeMatrice.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\Module\PrestashopCheckout;
 
-class IsoCodeDispatcher
+class PaypalCountryCodeMatrice
 {
     /**
      * PrestaShop ISO code to PayPal ISO code

--- a/tests/IsoCodeDispatcherTest.php
+++ b/tests/IsoCodeDispatcherTest.php
@@ -24,9 +24,9 @@
  *  International Registered Trademark & Property of PrestaShop SA
  **/
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\PrestashopCheckout\IsoCodeDispatcher;
+use PrestaShop\Module\PrestashopCheckout\PaypalCountryCodeMatrice;
 
-class IsoCodeDispatcherTest extends TestCase
+class PaypalCountryCodeMatriceTest extends TestCase
 {
     /**
      * @dataProvider isoCodeDataProviderPaypal
@@ -35,7 +35,7 @@ class IsoCodeDispatcherTest extends TestCase
     {
         $this->assertSame(
             $resultExpect,
-            (new IsoCodeDispatcher())->getPaypalIsoCode($dataToValidate)
+            (new PaypalCountryCodeMatrice())->getPaypalIsoCode($dataToValidate)
         );
     }
 
@@ -70,7 +70,7 @@ class IsoCodeDispatcherTest extends TestCase
     {
         $this->assertSame(
             $resultExpect,
-            (new IsoCodeDispatcher())->getPrestashopIsoCode($dataToValidate)
+            (new PaypalCountryCodeMatrice())->getPrestashopIsoCode($dataToValidate)
         );
     }
 


### PR DESCRIPTION
Remove 'locale' from Paypal Json Order to prevent issues.  
'locale' is… mandatory for paypal. 
Also, rename IsoCodeDispatcher into PaypalCountryCodeMatrice