### PR TITLE
Remove store json encode, already handled by addJsDef

### DIFF
--- a/_dev/store/modules/configuration/index.js
+++ b/_dev/store/modules/configuration/index.js
@@ -1,7 +1,7 @@
 import actions from './actions';
 import mutations from './mutations';
 
-const store = JSON.parse(global.store);
+const {store} = global;
 
 const state = store.config;
 

--- a/_dev/store/modules/context/index.js
+++ b/_dev/store/modules/context/index.js
@@ -2,7 +2,7 @@ import getters from './getters';
 import actions from './actions';
 import mutations from './mutations';
 
-const store = JSON.parse(global.store);
+const {store} = global;
 
 const state = store.context;
 

--- a/_dev/store/modules/firebase/index.js
+++ b/_dev/store/modules/firebase/index.js
@@ -2,7 +2,7 @@ import getters from './getters';
 import actions from './actions';
 import mutations from './mutations';
 
-const store = JSON.parse(global.store);
+const {store} = global;
 
 const state = store.firebase;
 

--- a/_dev/store/modules/paypal/index.js
+++ b/_dev/store/modules/paypal/index.js
@@ -2,7 +2,7 @@ import actions from './actions';
 import mutations from './mutations';
 import getters from './getters';
 
-const store = JSON.parse(global.store);
+const {store} = global;
 
 const state = store.paypal;
 

--- a/_dev/store/modules/psx/index.js
+++ b/_dev/store/modules/psx/index.js
@@ -2,7 +2,7 @@ import actions from './actions';
 import mutations from './mutations';
 import getters from './getters';
 
-const store = JSON.parse(global.store);
+const {store} = global;
 
 const state = store.psx;
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -149,7 +149,7 @@ class ps_checkout extends PaymentModule
         }
 
         Media::addJsDef(array(
-            'store' => json_encode((new StorePresenter($this, $this->context))->present()),
+            'store' => (new StorePresenter($this, $this->context))->present(),
         ));
 
         $this->context->controller->addCss($this->_path . 'views/css/index.css');


### PR DESCRIPTION
Don't merge. Need some test (only the backoffice part) to check if everything still working properly.
In some shops, the json_encode() doesn't encode in the right way and we cannot parse it in javascript. So the store cannot be get by the vuejs app and the application cannot start.