### PR TITLE
Fix firebase refresh token

### DIFF
--- a/classes/Api/Firebase/Token.php
+++ b/classes/Api/Firebase/Token.php
@@ -73,7 +73,7 @@ class Token extends FirebaseClient
     {
         $refresh_token = \Configuration::get('PS_PSX_FIREBASE_REFRESH_TOKEN');
 
-        return ! empty($refresh_token);
+        return !empty($refresh_token);
     }
 
     /**

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -65,6 +65,7 @@ class Ps_checkout extends PaymentModule
         'PS_PSX_FIREBASE_ID_TOKEN' => '',
         'PS_PSX_FIREBASE_LOCAL_ID' => '',
         'PS_PSX_FIREBASE_REFRESH_TOKEN' => '',
+        'PS_PSX_FIREBASE_REFRESH_DATE' => '',
         'PS_CHECKOUT_PSX_FORM' => '',
         'PS_CHECKOUT_SHOP_UUID_V4' => '',
     ];


### PR DESCRIPTION
Do not make call without refresh token => if module is not configured or merchant logout from PsAccount
Refresh token date storage now work with multishop