### PR TITLE
Check hooks debug

### DIFF
--- a/_dev/pages/Debug.vue
+++ b/_dev/pages/Debug.vue
@@ -35,6 +35,19 @@
             </div>
           </div>
         </div>
+
+        <div class="card">
+          <h3 class="card-header">
+            <i class="material-icons">extension</i> Hooks
+          </h3>
+          <div class="card-block">
+            <div class="card-text m-auto">
+              <ul v-for="hook in hooks" v-bind:key="hook.name">
+                <li>{{ hook.name }} : {{ hook.isRegistered }}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -52,6 +65,9 @@
       },
       shopId() {
         return this.$store.state.context.shopId;
+      },
+      hooks() {
+        return this.$store.state.context.hooks;
       },
       roundingSettingsIsCorrect() {
         return this.$store.getters.roundingSettingsIsCorrect;

--- a/_dev/pages/Debug.vue
+++ b/_dev/pages/Debug.vue
@@ -42,9 +42,20 @@
           </h3>
           <div class="card-block">
             <div class="card-text m-auto">
-              <ul v-for="hook in hooks" v-bind:key="hook.name">
-                <li>{{ hook.name }} : {{ hook.isRegistered }}</li>
-              </ul>
+              <table>
+                <tr v-for="hook in hooks" v-bind:key="hook.name">
+                  <td v-if="hook.isRegistered">
+                    <span class="text-success">
+                      <i class="material-icons">check</i></span>
+                  </td>
+                  <td v-else>
+                    <span class="text-danger">
+                      <i class="material-icons">error_outline</i>
+                    </span>
+                  </td>
+                  <td>{{ hook.name }}</td>
+                </tr>
+              </table>
             </div>
           </div>
         </div>

--- a/classes/Presenter/Store/Modules/ContextModule.php
+++ b/classes/Presenter/Store/Modules/ContextModule.php
@@ -66,6 +66,7 @@ class ContextModule implements StorePresenterInterface
                 'readmeUrl' => $this->getReadme(),
                 'cguUrl' => $this->getCgu(),
                 'roundingSettingsIsCorrect' => $this->roundingSettingsIsCorrect(),
+                'hooks' => $this->getHooks()
             ],
         ];
 
@@ -135,5 +136,24 @@ class ContextModule implements StorePresenterInterface
     {
         return \Configuration::get('PS_ROUND_TYPE') === '1'
             && \Configuration::get('PS_PRICE_ROUND_MODE') === '2';
+    }
+
+    /**
+     * Check if hooks has been registered
+     *
+     * @return array
+     */
+    private function getHooks()
+    {
+        $hooks = [];
+
+        foreach ($this->module->hooks as $hook) {
+            $hooks[] = [
+                'name' => $hook,
+                'isRegistered' => $this->module->isRegisteredInHook($hook),
+            ];
+        }
+
+        return $hooks;
     }
 }

--- a/classes/Presenter/Store/Modules/ContextModule.php
+++ b/classes/Presenter/Store/Modules/ContextModule.php
@@ -66,7 +66,7 @@ class ContextModule implements StorePresenterInterface
                 'readmeUrl' => $this->getReadme(),
                 'cguUrl' => $this->getCgu(),
                 'roundingSettingsIsCorrect' => $this->roundingSettingsIsCorrect(),
-                'hooks' => $this->getHooks()
+                'hooks' => $this->getHooks(),
             ],
         ];
 
@@ -139,7 +139,7 @@ class ContextModule implements StorePresenterInterface
     }
 
     /**
-     * Check if hooks has been registered
+     * Check if hooks has been registeredgit
      *
      * @return array
      */
@@ -150,7 +150,11 @@ class ContextModule implements StorePresenterInterface
         foreach ($this->module->hooks as $hook) {
             $hooks[] = [
                 'name' => $hook,
-                'isRegistered' => $this->module->isRegisteredInHook($hook),
+                'isRegistered' => \Hook::isModuleRegisteredOnHook(
+                    $this->module,
+                    $hook,
+                    $this->context->shop->id
+                ),
             ];
         }
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -40,15 +40,17 @@ if (!defined('_PS_VERSION_')) {
 
 class Ps_checkout extends PaymentModule
 {
-    // hook list used by the module
-    const HOOK_LIST = [
+    /**
+     * @var array Hooks used
+     */
+    public $hooks = [
         'paymentOptions',
-        'paymentReturn',
+        'displayPaymentReturn',
         'actionFrontControllerSetMedia',
         'actionOrderSlipAdd',
-        'orderConfirmation',
+        'displayOrderConfirmation',
         'displayAdminAfterHeader',
-        'ActionAdminControllerSetMedia',
+        'actionAdminControllerSetMedia',
         'actionOrderStatusUpdate',
     ];
 
@@ -121,7 +123,7 @@ class Ps_checkout extends PaymentModule
         }
 
         return parent::install() &&
-            $this->registerHook(self::HOOK_LIST) &&
+            $this->registerHook($this->hooks) &&
             (new OrderStates())->installPaypalStates() &&
             (new TableManager())->createTable() &&
             $this->updatePosition(\Hook::getIdByName('paymentOptions'), false, 1) &&


### PR DESCRIPTION
Replace hook alias by real hook name
Add list of hooks used in debug page and registration status
Need help to improve display 🙃

I found a bug in multistore instance with Module::isRegisteredInHook() was not relevant 🤯so I use Hook::isModuleRegisteredOnHook() instead

Display can be improved
Action to register missing hooks can be added