### PR TITLE
Check hooks on Debug page

### DIFF
--- a/_dev/pages/Debug.vue
+++ b/_dev/pages/Debug.vue
@@ -35,6 +35,30 @@
             </div>
           </div>
         </div>
+
+        <div class="card">
+          <h3 class="card-header">
+            <i class="material-icons">extension</i> Hooks
+          </h3>
+          <div class="card-block">
+            <div class="card-text m-auto">
+              <table>
+                <tr v-for="hook in hooks" v-bind:key="hook.name">
+                  <td v-if="hook.isRegistered">
+                    <span class="text-success">
+                      <i class="material-icons">check</i></span>
+                  </td>
+                  <td v-else>
+                    <span class="text-danger">
+                      <i class="material-icons">error_outline</i>
+                    </span>
+                  </td>
+                  <td>{{ hook.name }}</td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -46,6 +70,9 @@
     computed: {
       moduleVersion() {
         return this.$store.state.context.moduleVersion;
+      },
+      hooks() {
+        return this.$store.state.context.hooks;
       },
       psVersion() {
         return this.$store.state.context.psVersion;

--- a/classes/Presenter/Store/Modules/ContextModule.php
+++ b/classes/Presenter/Store/Modules/ContextModule.php
@@ -66,6 +66,7 @@ class ContextModule implements PresenterInterface
                 'readmeUrl' => $this->getReadme(),
                 'cguUrl' => $this->getCgu(),
                 'roundingSettingsIsCorrect' => $this->roundingSettingsIsCorrect(),
+                'hooks' => $this->getHooks(),
             ],
         ];
 
@@ -135,5 +136,27 @@ class ContextModule implements PresenterInterface
     {
         return \Configuration::get('PS_ROUND_TYPE') === '1'
             && \Configuration::get('PS_PRICE_ROUND_MODE') === '2';
+    }
+
+    /**
+     * Check if hooks has been registered
+     *
+     * @return array
+     */
+    private function getHooks()
+    {
+        $hooks = [];
+        foreach ($this->module->hooks as $hook) {
+            $hooks[] = [
+                'name' => $hook,
+                'isRegistered' => \Hook::isModuleRegisteredOnHook(
+                    $this->module,
+                    $hook,
+                    $this->context->shop->id
+                ),
+            ];
+        }
+
+        return $hooks;
     }
 }

--- a/classes/Presenter/Store/Modules/ContextModule.php
+++ b/classes/Presenter/Store/Modules/ContextModule.php
@@ -146,7 +146,7 @@ class ContextModule implements PresenterInterface
     private function getHooks()
     {
         $hooks = [];
-        foreach ($this->module->hooks as $hook) {
+        foreach (\Ps_checkout::HOOK_LIST as $hook) {
             $hooks[] = [
                 'name' => $hook,
                 'isRegistered' => \Hook::isModuleRegisteredOnHook(

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -41,15 +41,17 @@ if (!defined('_PS_VERSION_')) {
 
 class Ps_checkout extends PaymentModule
 {
-    // hook list used by the module
-    const HOOK_LIST = [
+    /**
+     * @var array Hooks used
+     */
+    public $hooks = [
         'paymentOptions',
-        'paymentReturn',
+        'displayPaymentReturn',
         'actionFrontControllerSetMedia',
         'actionOrderSlipAdd',
-        'orderConfirmation',
+        'displayOrderConfirmation',
         'displayAdminAfterHeader',
-        'ActionAdminControllerSetMedia',
+        'actionAdminControllerSetMedia',
         'actionOrderStatusUpdate',
     ];
 
@@ -123,7 +125,7 @@ class Ps_checkout extends PaymentModule
         }
 
         return parent::install() &&
-            $this->registerHook(self::HOOK_LIST) &&
+            $this->registerHook($this->hooks) &&
             (new OrderStates())->installPaypalStates() &&
             (new TableManager())->createTable() &&
             $this->updatePosition(\Hook::getIdByName('paymentOptions'), false, 1) &&

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -41,10 +41,8 @@ if (!defined('_PS_VERSION_')) {
 
 class Ps_checkout extends PaymentModule
 {
-    /**
-     * @var array Hooks used
-     */
-    public $hooks = [
+    // hook list used by the module
+    const HOOK_LIST = [
         'paymentOptions',
         'displayPaymentReturn',
         'actionFrontControllerSetMedia',
@@ -125,7 +123,7 @@ class Ps_checkout extends PaymentModule
         }
 
         return parent::install() &&
-            $this->registerHook($this->hooks) &&
+            $this->registerHook(static::HOOK_LIST) &&
             (new OrderStates())->installPaypalStates() &&
             (new TableManager())->createTable() &&
             $this->updatePosition(\Hook::getIdByName('paymentOptions'), false, 1) &&

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -44,7 +44,6 @@ class Ps_checkout extends PaymentModule
     // hook list used by the module
     const HOOK_LIST = [
         'paymentOptions',
-        'displayPaymentReturn',
         'actionFrontControllerSetMedia',
         'actionOrderSlipAdd',
         'displayOrderConfirmation',
@@ -540,7 +539,7 @@ class Ps_checkout extends PaymentModule
     /**
      * Hook executed at the order confirmation
      */
-    public function hookOrderConfirmation($params)
+    public function hookDisplayOrderConfirmation($params)
     {
         if ($params['order']->module !== $this->name) {
             return false;

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -123,7 +123,7 @@ class Ps_checkout extends PaymentModule
         }
 
         return parent::install() &&
-            $this->registerHook(static::HOOK_LIST) &&
+            $this->registerHook(self::HOOK_LIST) &&
             (new OrderStates())->installPaypalStates() &&
             (new TableManager())->createTable() &&
             $this->updatePosition(\Hook::getIdByName('paymentOptions'), false, 1) &&


### PR DESCRIPTION
Replace hook alias by real hook name
Add list of hooks used in debug page and registration status
Need help to improve display 🙃

I found a bug in multistore instance with Module::isRegisteredInHook() was not relevant 🤯so I use Hook::isModuleRegisteredOnHook() instead

Display can be improved
Action to register missing hooks can be added