### PR TITLE
Run PHPStan with several versions of PrestaShop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ php:
   - 5.6
   - 7.2
 
+env:
+  - PRESTASHOP_VERSION=latest
+
+matrix:
+  include:
+    - php: 7.2
+      env: PRESTASHOP_VERSION=1.7.3.0
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -21,7 +29,7 @@ script:
   - vendor/bin/phpunit tests
   # PHP Stan
   - if [ ${TRAVIS_PHP_VERSION:0:2} == "7." ]; then
-      docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop;
+      docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:${PRESTASHOP_VERSION};
       docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.11.19 analyse --configuration=/web/module/tests/phpstan/phpstan.neon;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 matrix:
   include:
     - php: 7.2
-      env: PRESTASHOP_VERSION=1.7.3.0
+      # Does not check 1.7.0.0 to 1.7.0.2, as these versions aren't used on production.
+      env: PRESTASHOP_VERSION=1.7.0.3
 
 cache:
   directories:

--- a/classes/Presenter/Cart/CartPresenter.php
+++ b/classes/Presenter/Cart/CartPresenter.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\Module\PrestashopCheckout\Presenter\Cart;
 
 use PrestaShop\Module\PrestashopCheckout\Presenter\PresenterInterface;
-use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter as PsCartPresenter;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter as PsCartPresenter;
 
 /**
  * Present the cart waiting by the create order paypal builder

--- a/classes/Presenter/Cart/CartPresenter.php
+++ b/classes/Presenter/Cart/CartPresenter.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\Module\PrestashopCheckout\Presenter\Cart;
 
 use PrestaShop\Module\PrestashopCheckout\Presenter\PresenterInterface;
-use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter as PsCartPresenter;
+use PrestaShop\PrestaShop\Adapter\Cart\CartPresenter as PsCartPresenter;
 
 /**
  * Present the cart waiting by the create order paypal builder

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
 		- classes
 		- controllers
 		- ps_checkout.php
+	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		- '#Cannot assign offset "merchant…" to string|true.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
@@ -14,5 +15,6 @@ parameters:
 		- '#Call to an undefined method\(\) AdminController|FrontController::getCheckoutProcess\(\).#'
 		- '#Parameter \#1 \$id_hook of method ModuleCore::updatePosition\(\) expects bool, int given.#'
 		- '#Property TabCore::\$name \(string\) does not accept array.#'
+		- '#Access to an undefined property PaymentModule::\$currentOrderReference.#'
 
 	level: 5


### PR DESCRIPTION
In order to detect potiental backward compatibility issues with PrestaShop in the future, we run PHPStan with several versions of PS.

This PR contains 2 commits reverting changes, which is expected as proof.