### PR TITLE
Fix an error js on destroy onboarding component

### DIFF
--- a/_dev/src/components/block/onboarding.vue
+++ b/_dev/src/components/block/onboarding.vue
@@ -93,9 +93,17 @@
       const signupScript = document.getElementById('signup-js');
       const bizScript = document.getElementById('biz-js');
 
-      paypalScript.parentNode.removeChild(paypalScript);
-      signupScript.parentNode.removeChild(signupScript);
-      bizScript.parentNode.removeChild(bizScript);
+      if (paypalScript !== null) {
+        paypalScript.parentNode.removeChild(paypalScript);
+      }
+
+      if (signupScript !== null) {
+        signupScript.parentNode.removeChild(signupScript);
+      }
+
+      if (bizScript !== null) {
+        bizScript.parentNode.removeChild(bizScript);
+      }
     },
     created() {
       const paypalScript = document.createElement('script');


### PR DESCRIPTION
signup script and biz script are added to document only when paypal mini browser is launched otherwise they are not present