### PR TITLE
Add hook displayInvoiceLegalFreeText

### DIFF
--- a/classes/Entity/OrderMatrice.php
+++ b/classes/Entity/OrderMatrice.php
@@ -113,4 +113,25 @@ class OrderMatrice extends \ObjectModel
 
         return \Db::getInstance()->getValue($query);
     }
+
+    /**
+     * Check if this order has multiple entries associated due to bug before 1.2.11
+     *
+     * @param int $orderId
+     *
+     * @return bool
+     */
+    public static function hasInconsistencies($orderId)
+    {
+        // Before 1.2.11 id_order_prestashop field was limited to 255
+        if ((int) $orderId !== 255) {
+            return false;
+        }
+
+        // If more than one order found, there are inconsistencies for this order
+        return (bool) \Db::getInstance()->getValue('
+            SELECT COUNT(*)
+            FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice`
+            WHERE id_order_prestashop = ' . (int) $orderId);
+    }
 }

--- a/upgrade/upgrade-1.2.12.php
+++ b/upgrade/upgrade-1.2.12.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Update main function for module Version 1.2.12
+ *
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_2_12($module)
+{
+    return $module->registerHook('displayInvoiceLegalFreeText');
+}


### PR DESCRIPTION
Adds PayPal Order Id and PayPal Transaction Id to invoice thanks to hook displayInvoiceLegalFreeText.
Please note HTML is not allowed in this hook
https://github.com/PrestaShop/PrestaShop/blob/8ce8bd08f5681220d56670454cb533e0cd2226bc/pdf/invoice.tpl#L120