### PR TITLE
Multishop compatibility

### DIFF
--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -41,13 +41,16 @@
     <div class="pt-5" />
     <div class="pt-3" />
 
-    <div class="container">
+    <div
+      class="container"
+      v-if="isShopContext"
+    >
       <RoundingBanner />
     </div>
 
     <div
       class="container"
-      v-if="paymentMode === 'SANDBOX'"
+      v-if="isTestMode"
     >
       <b-alert
         variant="warning"
@@ -56,7 +59,37 @@
         <p>{{ $t('general.testModeOn') }}</p>
       </b-alert>
     </div>
-    <router-view />
+
+    <div
+      class="container"
+      v-if="!isShopContext"
+    >
+      <b-alert
+        variant="warning"
+        show
+      >
+        <h2>{{ $t('general.multiShop.title') }}</h2>
+        <p>{{ $t('general.multiShop.subtitle') }}</p>
+        <p>{{ $t('general.multiShop.chooseOne') }}</p>
+        <b-list-group
+          v-for="group in shopsTree"
+          :key="group.id"
+          class="mt-3 mb-3 col-4"
+        >
+          <p class="text-muted">{{ $t('general.multiShop.group') }} {{ group.name }}</p>
+          <b-list-group-item
+            v-for="shop in group.shops"
+            :key="shop.id"
+            :href="shop.url"
+          >
+            {{ $t('general.multiShop.configure') }} <b>{{ shop.name }}</b>
+          </b-list-group-item>
+        </b-list-group>
+        <p>{{ $t('general.multiShop.tips') }}</p>
+      </b-alert>
+    </div>
+
+    <router-view v-if="isShopContext" />
   </div>
 </template>
 
@@ -91,11 +124,18 @@
       onboardingFirebaseIsCompleted() {
         return this.$store.state.firebase.onboardingCompleted;
       },
-      paymentMode() {
-        return this.$store.state.configuration.paymentMode;
-      },
       accountIslinked() {
         return this.$store.state.paypal.accountIslinked;
+      },
+      isShopContext() {
+        return this.$store.state.context.isShopContext;
+      },
+      isTestMode() {
+        return this.$store.state.configuration.paymentMode === 'SANDBOX'
+          && this.$store.state.context.isShopContext;
+      },
+      shopsTree() {
+        return this.$store.state.context.shopsTree;
       },
     },
     watch: {

--- a/classes/Api/Firebase/Token.php
+++ b/classes/Api/Firebase/Token.php
@@ -41,14 +41,37 @@ class Token extends FirebaseClient
         $response = $this->post([
             'json' => [
                 'grant_type' => 'refresh_token',
-                'refresh_token' => \Configuration::get('PS_PSX_FIREBASE_REFRESH_TOKEN'),
+                'refresh_token' => \Configuration::get(
+                    'PS_PSX_FIREBASE_REFRESH_TOKEN',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
             ],
         ]);
 
         if (true === $response['status']) {
-            \Configuration::updateValue('PS_PSX_FIREBASE_ID_TOKEN', $response['body']['id_token']);
-            \Configuration::updateValue('PS_PSX_FIREBASE_REFRESH_TOKEN', $response['body']['refresh_token']);
-            \Configuration::updateValue('PS_PSX_FIREBASE_REFRESH_DATE', date('Y-m-d H:i:s'));
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_ID_TOKEN',
+                $response['body']['id_token'],
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_REFRESH_TOKEN',
+                $response['body']['refresh_token'],
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_REFRESH_DATE',
+                date('Y-m-d H:i:s'),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
         }
 
         return $response;
@@ -71,7 +94,12 @@ class Token extends FirebaseClient
      */
     public function hasRefreshToken()
     {
-        $refresh_token = \Configuration::get('PS_PSX_FIREBASE_REFRESH_TOKEN');
+        $refresh_token = \Configuration::get(
+            'PS_PSX_FIREBASE_REFRESH_TOKEN',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
 
         return !empty($refresh_token);
     }
@@ -83,7 +111,12 @@ class Token extends FirebaseClient
      */
     public function isExpired()
     {
-        $refresh_date = \Configuration::get('PS_PSX_FIREBASE_REFRESH_DATE');
+        $refresh_date = \Configuration::get(
+            'PS_PSX_FIREBASE_REFRESH_DATE',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
 
         if (empty($refresh_date)) {
             return true;
@@ -103,6 +136,11 @@ class Token extends FirebaseClient
             $this->refresh();
         }
 
-        return \Configuration::get('PS_PSX_FIREBASE_ID_TOKEN');
+        return \Configuration::get(
+            'PS_PSX_FIREBASE_ID_TOKEN',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 }

--- a/classes/Api/GenericClient.php
+++ b/classes/Api/GenericClient.php
@@ -80,8 +80,15 @@ class GenericClient
 
         $response = $responseHandler->handleResponse($response);
 
+        $logsEnabled = (bool) \Configuration::get(
+            'PS_CHECKOUT_DEBUG_LOGS_ENABLED',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+
         // If response is not successful only
-        if (\Configuration::get('PS_CHECKOUT_DEBUG_LOGS_ENABLED') && !$response['status']) {
+        if ($logsEnabled && !$response['status']) {
             /**
              * @var \Ps_checkout
              */

--- a/classes/Api/Payment/Client/PaymentClient.php
+++ b/classes/Api/Payment/Client/PaymentClient.php
@@ -46,8 +46,20 @@ class PaymentClient extends GenericClient
                         'Content-Type' => 'application/vnd.checkout.v1+json', // api version to use (psl side)
                         'Accept' => 'application/json',
                         'Authorization' => 'Bearer ' . (new Token())->getToken(),
-                        'Shop-Id' => \Configuration::get('PS_CHECKOUT_SHOP_UUID_V4'),
-                        'Hook-Url' => $this->link->getModuleLink('ps_checkout', 'DispatchWebHook', [], true),
+                        'Shop-Id' => \Configuration::get(
+                            'PS_CHECKOUT_SHOP_UUID_V4',
+                            null,
+                            null,
+                            (int) \Context::getContext()->shop->id
+                        ),
+                        'Hook-Url' => $this->link->getModuleLink(
+                            'ps_checkout',
+                            'DispatchWebHook',
+                            [],
+                            true,
+                            null,
+                            (int) \Context::getContext()->shop->id
+                        ),
                         'Bn-Code' => (new ShopContext())->getBnCode(),
                         'Module-Version' => \Ps_checkout::VERSION, // version of the module
                         'Prestashop-Version' => _PS_VERSION_, // prestashop version

--- a/classes/Api/Psx/Client/PsxClient.php
+++ b/classes/Api/Psx/Client/PsxClient.php
@@ -38,7 +38,12 @@ class PsxClient extends GenericClient
                     'Content-Type' => 'application/vnd.psx.v1+json', // api version to use (psl side)
                     'Accept' => 'application/json',
                     'Authorization' => 'Bearer ' . (new Token())->getToken(),
-                    'Shop-Id' => \Configuration::get('PS_CHECKOUT_SHOP_UUID_V4'),
+                    'Shop-Id' => \Configuration::get(
+                        'PS_CHECKOUT_SHOP_UUID_V4',
+                        null,
+                        null,
+                        (int) \Context::getContext()->shop->id
+                    ),
                     'Module-Version' => \Ps_checkout::VERSION, // version of the module
                     'Prestashop-Version' => _PS_VERSION_, // prestashop version
                 ],

--- a/classes/Builder/Payload/OnboardingPayloadBuilder.php
+++ b/classes/Builder/Payload/OnboardingPayloadBuilder.php
@@ -166,7 +166,13 @@ class OnboardingPayloadBuilder extends Builder
      */
     private function getCurrencyIsoCode()
     {
-        $currency = \Currency::getCurrency((int) \Configuration::get('PS_CURRENCY_DEFAULT'));
+        $currencyId = (int) \Configuration::get(
+            'PS_CURRENCY_DEFAULT',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+        $currency = \Currency::getCurrency($currencyId);
 
         return $currency['iso_code'];
     }

--- a/classes/Builder/Payload/OrderPayloadBuilder.php
+++ b/classes/Builder/Payload/OrderPayloadBuilder.php
@@ -116,12 +116,30 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
      */
     public function buildBaseNode()
     {
+        $shopName = \Configuration::get(
+            'PS_SHOP_NAME',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+
         $node = [
-            'intent' => \Configuration::get('PS_CHECKOUT_INTENT'), // capture or authorize
+            'intent' => \Configuration::get(
+                'PS_CHECKOUT_INTENT',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            ), // capture or authorize
             'custom_id' => (string) $this->cart['cart']['id'], // id_cart or id_order // link between paypal order and prestashop order
             'invoice_id' => '',
-            'description' => $this->truncate('Checking out with your cart from ' . \Configuration::get('PS_SHOP_NAME'), 127),
-            'soft_descriptor' => $this->truncate(\Configuration::get('PS_SHOP_NAME'), 22),
+            'description' => $this->truncate(
+                'Checking out with your cart from ' . $shopName,
+                127
+            ),
+            'soft_descriptor' => $this->truncate(
+                $shopName,
+                22
+            ),
             'amount' => [
                 'currency_code' => $this->cart['currency']['iso_code'],
                 'value' => $this->cart['cart']['totals']['total_including_tax']['amount'],
@@ -134,7 +152,21 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
         if (true === $this->isUpdate) {
             $node['id'] = $this->paypalOrderId;
         } else {
-            $node['roundingConfig'] = (string) \Configuration::get('PS_ROUND_TYPE') . '-' . (string) \Configuration::get('PS_PRICE_ROUND_MODE');
+            $roundType = (string) \Configuration::get(
+                'PS_ROUND_TYPE',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+
+            $roundMode = (string) \Configuration::get(
+                'PS_PRICE_ROUND_MODE',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+
+            $node['roundingConfig'] = $roundType . '-' . $roundMode;
         }
 
         // TODO: Disabled temporary: Need to handle country indicator
@@ -221,7 +253,12 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
     public function buildApplicationContextNode()
     {
         $node['application_context'] = [
-            'brand_name' => \Configuration::get('PS_SHOP_NAME'),
+            'brand_name' => \Configuration::get(
+                'PS_SHOP_NAME',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            ),
             'shipping_preference' => $this->expressCheckout ? 'GET_FROM_FILE' : 'SET_PROVIDED_ADDRESS',
         ];
 

--- a/classes/Environment/Env.php
+++ b/classes/Environment/Env.php
@@ -83,7 +83,12 @@ class Env
      */
     private function isLive()
     {
-        $mode = \Configuration::get('PS_CHECKOUT_MODE');
+        $mode = \Configuration::get(
+            'PS_CHECKOUT_MODE',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
 
         if ('LIVE' === $mode) {
             return true;

--- a/classes/ExpressCheckout.php
+++ b/classes/ExpressCheckout.php
@@ -72,7 +72,12 @@ class ExpressCheckout
             'checkoutLink' => $this->context->link->getPageLink('order', true, $this->context->language->id, ['paymentMethod' => 'paypal']),
             'expressCheckoutController' => $this->context->link->getModuleLink($this->module->name, 'ExpressCheckout'),
             'paypalIsActive' => $paypalAccountRepository->paypalPaymentMethodIsValid(),
-            'intent' => strtolower(\Configuration::get('PS_CHECKOUT_INTENT')),
+            'intent' => \Configuration::get(
+                'PS_CHECKOUT_INTENT',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            ),
             'currencyIsoCode' => $this->context->currency->iso_code,
             'isCardPaymentError' => (bool) \Tools::getValue('hferror'),
             'locale' => $language['locale'],

--- a/classes/OrderStates.php
+++ b/classes/OrderStates.php
@@ -71,7 +71,7 @@ class OrderStates
      */
     private function getPaypalStateId($state, $color)
     {
-        $stateId = \Configuration::get($state);
+        $stateId = \Configuration::getGlobalValue($state);
 
         // Is state ID already existing in the Configuration table ?
         if (false === $stateId) {
@@ -98,7 +98,7 @@ class OrderStates
 
         if (true === \Db::getInstance()->insert(self::ORDER_STATE_TABLE, $data)) {
             $insertedId = (int) \Db::getInstance()->Insert_ID();
-            \Configuration::updateValue($state, $insertedId);
+            \Configuration::updateGlobalValue($state, $insertedId);
 
             return $insertedId;
         }

--- a/classes/PersistentConfiguration.php
+++ b/classes/PersistentConfiguration.php
@@ -38,11 +38,41 @@ class PersistentConfiguration
      */
     public function savePaypalAccount(PaypalAccount $paypalAccount)
     {
-        return \Configuration::updateValue(PaypalAccount::PS_CHECKOUT_PAYPAL_ID_MERCHANT, $paypalAccount->getMerchantId())
-            && \Configuration::updateValue(PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_MERCHANT, $paypalAccount->getEmail())
-            && \Configuration::updateValue(PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_STATUS, $paypalAccount->getEmailIsVerified())
-            && \Configuration::updateValue(PaypalAccount::PS_CHECKOUT_PAYPAL_PAYMENT_STATUS, $paypalAccount->getPaypalPaymentStatus())
-            && \Configuration::updateValue(PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_STATUS, $paypalAccount->getCardPaymentStatus());
+        return \Configuration::updateValue(
+                PaypalAccount::PS_CHECKOUT_PAYPAL_ID_MERCHANT,
+                $paypalAccount->getMerchantId(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_MERCHANT,
+                $paypalAccount->getEmail(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_STATUS,
+                $paypalAccount->getEmailIsVerified(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PaypalAccount::PS_CHECKOUT_PAYPAL_PAYMENT_STATUS,
+                $paypalAccount->getPaypalPaymentStatus(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_STATUS,
+                $paypalAccount->getCardPaymentStatus(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
     }
 
     /**
@@ -54,10 +84,40 @@ class PersistentConfiguration
      */
     public function savePsAccount(PsAccount $psAccount)
     {
-        return \Configuration::updateValue(PsAccount::PS_PSX_FIREBASE_EMAIL, $psAccount->getEmail())
-            && \Configuration::updateValue(PsAccount::PS_PSX_FIREBASE_ID_TOKEN, $psAccount->getIdToken())
-            && \Configuration::updateValue(PsAccount::PS_PSX_FIREBASE_LOCAL_ID, $psAccount->getLocalId())
-            && \Configuration::updateValue(PsAccount::PS_PSX_FIREBASE_REFRESH_TOKEN, $psAccount->getRefreshToken())
-            && \Configuration::updateValue(PsAccount::PS_CHECKOUT_PSX_FORM, $psAccount->getPsxForm());
+        return \Configuration::updateValue(
+                PsAccount::PS_PSX_FIREBASE_EMAIL,
+                $psAccount->getEmail(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PsAccount::PS_PSX_FIREBASE_ID_TOKEN,
+                $psAccount->getIdToken(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PsAccount::PS_PSX_FIREBASE_LOCAL_ID,
+                $psAccount->getLocalId(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PsAccount::PS_PSX_FIREBASE_REFRESH_TOKEN,
+                $psAccount->getRefreshToken(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            )
+            && \Configuration::updateValue(
+                PsAccount::PS_CHECKOUT_PSX_FORM,
+                $psAccount->getPsxForm(),
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
     }
 }

--- a/classes/Presenter/Store/Modules/ConfigurationModule.php
+++ b/classes/Presenter/Store/Modules/ConfigurationModule.php
@@ -37,14 +37,49 @@ class ConfigurationModule implements PresenterInterface
         $configurationModule = [
             'config' => [
                 'paymentMethods' => $this->getPaymentMethods(),
-                'captureMode' => \Configuration::get('PS_CHECKOUT_INTENT'),
-                'paymentMode' => \Configuration::get('PS_CHECKOUT_MODE'),
-                'cardIsEnabled' => (bool) \Configuration::get('PS_CHECKOUT_CARD_PAYMENT_ENABLED'),
-                'debugLogsEnabled' => (bool) \Configuration::get('PS_CHECKOUT_DEBUG_LOGS_ENABLED'),
+                'captureMode' => \Configuration::get(
+                    'PS_CHECKOUT_INTENT',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
+                'paymentMode' => \Configuration::get(
+                    'PS_CHECKOUT_MODE',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
+                'cardIsEnabled' => (bool) \Configuration::get(
+                    'PS_CHECKOUT_CARD_PAYMENT_ENABLED',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
+                'debugLogsEnabled' => (bool) \Configuration::get(
+                    'PS_CHECKOUT_DEBUG_LOGS_ENABLED',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
                 'expressCheckout' => [
-                    'orderPage' => (bool) \Configuration::get('PS_CHECKOUT_EC_ORDER_PAGE'),
-                    'checkoutPage' => (bool) \Configuration::get('PS_CHECKOUT_EC_CHECKOUT_PAGE'),
-                    'productPage' => (bool) \Configuration::get('PS_CHECKOUT_EC_PRODUCT_PAGE'),
+                    'orderPage' => (bool) \Configuration::get(
+                        'PS_CHECKOUT_EC_ORDER_PAGE',
+                        null,
+                        null,
+                        (int) \Context::getContext()->shop->id
+                    ),
+                    'checkoutPage' => (bool) \Configuration::get(
+                        'PS_CHECKOUT_EC_CHECKOUT_PAGE',
+                        null,
+                        null,
+                        (int) \Context::getContext()->shop->id
+                    ),
+                    'productPage' => (bool) \Configuration::get(
+                        'PS_CHECKOUT_EC_PRODUCT_PAGE',
+                        null,
+                        null,
+                        (int) \Context::getContext()->shop->id
+                    ),
                 ],
             ],
         ];
@@ -59,7 +94,12 @@ class ConfigurationModule implements PresenterInterface
      */
     private function getPaymentMethods()
     {
-        $paymentMethods = \Configuration::get('PS_CHECKOUT_PAYMENT_METHODS_ORDER');
+        $paymentMethods = \Configuration::get(
+            'PS_CHECKOUT_PAYMENT_METHODS_ORDER',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
 
         if (empty($paymentMethods)) {
             $paymentMethods = [

--- a/classes/Presenter/Store/Modules/FirebaseModule.php
+++ b/classes/Presenter/Store/Modules/FirebaseModule.php
@@ -39,10 +39,22 @@ class FirebaseModule implements PresenterInterface
 
         $firebaseModule = [
             'firebase' => [
-                'email' => \Configuration::get('PS_PSX_FIREBASE_EMAIL'),
+                'email' => \Configuration::get(
+                    'PS_PSX_FIREBASE_EMAIL',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id),
                 'idToken' => $idToken,
-                'localId' => \Configuration::get('PS_PSX_FIREBASE_LOCAL_ID'),
-                'refreshToken' => \Configuration::get('PS_PSX_FIREBASE_REFRESH_TOKEN'),
+                'localId' => \Configuration::get(
+                    'PS_PSX_FIREBASE_LOCAL_ID',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id),
+                'refreshToken' => \Configuration::get(
+                    'PS_PSX_FIREBASE_REFRESH_TOKEN',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id),
                 'onboardingCompleted' => !empty($idToken),
             ],
         ];

--- a/classes/Presenter/Store/Modules/PsxModule.php
+++ b/classes/Presenter/Store/Modules/PsxModule.php
@@ -53,7 +53,15 @@ class PsxModule implements PresenterInterface
         return [
             'psx' => [
                 'onboardingCompleted' => (new PsAccountRepository())->psxFormIsCompleted(),
-                'psxFormData' => json_decode(\Configuration::get('PS_CHECKOUT_PSX_FORM'), true),
+                'psxFormData' => json_decode(
+                    \Configuration::get(
+                        'PS_CHECKOUT_PSX_FORM',
+                        null,
+                        null,
+                        (int) \Context::getContext()->shop->id
+                    ),
+                    true
+                ),
                 'languagesDetails' => $this->getJsonData(self::ALL_LANGUAGES_FILE),
                 'countriesDetails' => $this->getJsonData(self::ALL_COUNTRIES_FILE),
                 'countriesStatesDetails' => $this->getJsonData(self::ALL_COUNTRIES_STATES_FILE),

--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -126,7 +126,13 @@ class Refund
                 'currency_code' => $this->getCurrencyCode(),
                 'value' => $this->getAmount(),
             ],
-            'note_to_payer' => 'Refund by ' . \Configuration::get('PS_SHOP_NAME'),
+            'note_to_payer' => 'Refund by '
+                . \Configuration::get(
+                'PS_SHOP_NAME',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
         ];
 
         return $payload;
@@ -182,9 +188,12 @@ class Refund
             $orderDetailList[$key]['unit_price'] = $orderDetailList[$key]['amount'] / $quantityToRefund;
         }
 
-        $partialRefundOrderStateId = intval(\Configuration::get(self::REFUND_STATE));
-
-        return $this->refundPrestashopOrder($order, $orderDetailList, $partialRefundOrderStateId, $transactionId);
+        return $this->refundPrestashopOrder(
+            $order,
+            $orderDetailList,
+            (int) \Configuration::getGlobalValue(self::REFUND_STATE),
+            $transactionId
+        );
     }
 
     /**

--- a/classes/Repository/PaypalAccountRepository.php
+++ b/classes/Repository/PaypalAccountRepository.php
@@ -90,7 +90,12 @@ class PaypalAccountRepository
      */
     public function cardPaymentMethodIsEnabled()
     {
-        return (bool) \Configuration::get(PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_ENABLED);
+        return (bool) \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_ENABLED,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -121,7 +126,12 @@ class PaypalAccountRepository
      */
     public function getMerchantId()
     {
-        return \Configuration::get(PaypalAccount::PS_CHECKOUT_PAYPAL_ID_MERCHANT);
+        return \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_PAYPAL_ID_MERCHANT,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -131,7 +141,12 @@ class PaypalAccountRepository
      */
     public function getMerchantEmail()
     {
-        return \Configuration::get(PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_MERCHANT);
+        return \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_MERCHANT,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -141,7 +156,12 @@ class PaypalAccountRepository
      */
     public function getMerchantEmailStatus()
     {
-        return \Configuration::get(PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_STATUS);
+        return \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_PAYPAL_EMAIL_STATUS,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -151,7 +171,12 @@ class PaypalAccountRepository
      */
     public function getPaypalPaymentStatus()
     {
-        return \Configuration::get(PaypalAccount::PS_CHECKOUT_PAYPAL_PAYMENT_STATUS);
+        return \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_PAYPAL_PAYMENT_STATUS,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -161,6 +186,11 @@ class PaypalAccountRepository
      */
     public function getCardPaymentStatus()
     {
-        return \Configuration::get(PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_STATUS);
+        return \Configuration::get(
+            PaypalAccount::PS_CHECKOUT_CARD_PAYMENT_STATUS,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 }

--- a/classes/Repository/PsAccountRepository.php
+++ b/classes/Repository/PsAccountRepository.php
@@ -79,7 +79,12 @@ class PsAccountRepository
      */
     public function getEmail()
     {
-        return \Configuration::get(PsAccount::PS_PSX_FIREBASE_EMAIL);
+        return \Configuration::get(
+            PsAccount::PS_PSX_FIREBASE_EMAIL,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -89,7 +94,12 @@ class PsAccountRepository
      */
     public function getIdToken()
     {
-        return \Configuration::get(PsAccount::PS_PSX_FIREBASE_ID_TOKEN);
+        return \Configuration::get(
+            PsAccount::PS_PSX_FIREBASE_ID_TOKEN,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -99,7 +109,12 @@ class PsAccountRepository
      */
     public function getLocalId()
     {
-        return \Configuration::get(PsAccount::PS_PSX_FIREBASE_LOCAL_ID);
+        return \Configuration::get(
+            PsAccount::PS_PSX_FIREBASE_LOCAL_ID,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -109,7 +124,12 @@ class PsAccountRepository
      */
     public function getRefreshToken()
     {
-        return \Configuration::get(PsAccount::PS_PSX_FIREBASE_REFRESH_TOKEN);
+        return \Configuration::get(
+            PsAccount::PS_PSX_FIREBASE_REFRESH_TOKEN,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -122,9 +142,22 @@ class PsAccountRepository
     public function getPsxForm($toArray = false)
     {
         if ($toArray) {
-            return json_decode(\Configuration::get('PS_CHECKOUT_PSX_FORM'), true);
+            return json_decode(
+                \Configuration::get(
+                    'PS_CHECKOUT_PSX_FORM',
+                    null,
+                    null,
+                    (int) \Context::getContext()->shop->id
+                ),
+                true
+            );
         }
 
-        return \Configuration::get(PsAccount::PS_CHECKOUT_PSX_FORM);
+        return \Configuration::get(
+            PsAccount::PS_CHECKOUT_PSX_FORM,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
     }
 }

--- a/classes/Translations/Translations.php
+++ b/classes/Translations/Translations.php
@@ -56,6 +56,14 @@ class Translations
             'general' => [
                 'save' => $this->module->l('Save', 'translations'),
                 'testModeOn' => $this->module->l('Test mode is turned on', 'translations'),
+                'multiShop' => [
+                    'title' => $this->module->l('Multistore detected', 'translations'),
+                    'subtitle' => $this->module->l('Each shop must be configured separately, even if you configure the same account on all of them.', 'translations'),
+                    'chooseOne' => $this->module->l('Please select the first shop to configure from the list below :', 'translations'),
+                    'group' => 'Group:',
+                    'configure' => 'Configure',
+                    'tips' => $this->module->l('Once you are done with the first shop, you can configure the others: select them one by one with the shop selector, in the horizontal menu.', 'translations'),
+                ],
             ],
             'pages' => [
                 'accounts' => [

--- a/classes/ValidateOrder.php
+++ b/classes/ValidateOrder.php
@@ -225,10 +225,10 @@ class ValidateOrder
      */
     private function getPendingStatusId($paymentMethod)
     {
-        $stateId = \Configuration::get('PS_CHECKOUT_STATE_WAITING_CREDIT_CARD_PAYMENT');
+        $stateId = \Configuration::getGlobalValue('PS_CHECKOUT_STATE_WAITING_CREDIT_CARD_PAYMENT');
 
         if ($paymentMethod === self::PAYMENT_METHOD_PAYPAL) {
-            $stateId = \Configuration::get('PS_CHECKOUT_STATE_WAITING_PAYPAL_PAYMENT');
+            $stateId = \Configuration::getGlobalValue('PS_CHECKOUT_STATE_WAITING_PAYPAL_PAYMENT');
         }
 
         return intval($stateId);

--- a/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -37,7 +37,13 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
      */
     public function ajaxProcessUpdatePaymentMethodsOrder()
     {
-        Configuration::updateValue('PS_CHECKOUT_PAYMENT_METHODS_ORDER', Tools::getValue('paymentMethods'));
+        Configuration::updateValue(
+            'PS_CHECKOUT_PAYMENT_METHODS_ORDER',
+            Tools::getValue('paymentMethods'),
+            false,
+            null,
+            (int) Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -45,7 +51,13 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
      */
     public function ajaxProcessUpdateCaptureMode()
     {
-        Configuration::updateValue('PS_CHECKOUT_INTENT', Tools::getValue('captureMode'));
+        Configuration::updateValue(
+            'PS_CHECKOUT_INTENT',
+            Tools::getValue('captureMode'),
+            false,
+            null,
+            (int) Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -53,7 +65,13 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
      */
     public function ajaxProcessUpdatePaymentMode()
     {
-        Configuration::updateValue('PS_CHECKOUT_MODE', Tools::getValue('paymentMode'));
+        Configuration::updateValue(
+            'PS_CHECKOUT_MODE',
+            Tools::getValue('paymentMode'),
+            false,
+            null,
+            (int) Context::getContext()->shop->id
+        );
     }
 
     /**
@@ -64,8 +82,20 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
      */
     public function ajaxProcessEditRoundingSettings()
     {
-        Configuration::updateValue('PS_ROUND_TYPE', '1');
-        Configuration::updateValue('PS_PRICE_ROUND_MODE', '2');
+        Configuration::updateValue(
+            'PS_ROUND_TYPE',
+            '1',
+            false,
+            null,
+            (int) Context::getContext()->shop->id
+        );
+        Configuration::updateValue(
+            'PS_PRICE_ROUND_MODE',
+            '2',
+            false,
+            null,
+            (int) Context::getContext()->shop->id
+        );
 
         $this->ajaxDie(json_encode(true));
     }
@@ -260,7 +290,10 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
     {
         Configuration::updateValue(
             'PS_CHECKOUT_CARD_PAYMENT_ENABLED',
-            Tools::getValue('status') ? 1 : 0
+            Tools::getValue('status') ? 1 : 0,
+            false,
+            null,
+            (int) Context::getContext()->shop->id
         );
     }
 
@@ -271,7 +304,10 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
     {
         Configuration::updateValue(
             'PS_CHECKOUT_EC_ORDER_PAGE',
-            Tools::getValue('status') ? 1 : 0
+            Tools::getValue('status') ? 1 : 0,
+            false,
+            null,
+            (int) Context::getContext()->shop->id
         );
     }
 
@@ -282,7 +318,10 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
     {
         Configuration::updateValue(
             'PS_CHECKOUT_EC_CHECKOUT_PAGE',
-            Tools::getValue('status') ? 1 : 0
+            Tools::getValue('status') ? 1 : 0,
+            false,
+            null,
+            (int) Context::getContext()->shop->id
         );
     }
 
@@ -293,7 +332,10 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
     {
         Configuration::updateValue(
             'PS_CHECKOUT_EC_PRODUCT_PAGE',
-            Tools::getValue('status') ? 1 : 0
+            Tools::getValue('status') ? 1 : 0,
+            false,
+            null,
+            (int) Context::getContext()->shop->id
         );
     }
 
@@ -304,7 +346,10 @@ class AdminAjaxPrestashopCheckoutController extends ModuleAdminController
     {
         Configuration::updateValue(
             'PS_CHECKOUT_DEBUG_LOGS_ENABLED',
-            Tools::getValue('status') ? 1 : 0
+            Tools::getValue('status') ? 1 : 0,
+            false,
+            null,
+            (int) Context::getContext()->shop->id
         );
     }
 }

--- a/controllers/front/DispatchWebHook.php
+++ b/controllers/front/DispatchWebHook.php
@@ -194,8 +194,18 @@ class ps_checkoutDispatchWebHookModuleFrontController extends ModuleFrontControl
         /*
         *   @TODO : Get payload hash to confirm that it's not modified
         */
-        $localShopId = \Configuration::get(self::PS_CHECKOUT_SHOP_UID_LABEL);
-        $localMerchantId = \Configuration::get(self::PS_CHECKOUT_PAYPAL_ID_LABEL);
+        $localShopId = \Configuration::get(
+            self::PS_CHECKOUT_SHOP_UID_LABEL,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+        $localMerchantId = \Configuration::get(
+            self::PS_CHECKOUT_PAYPAL_ID_LABEL,
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
 
         if ($this->shopId !== $localShopId) {
             throw new UnauthorizedException('shopId wrong');

--- a/controllers/front/PaymentCard16.php
+++ b/controllers/front/PaymentCard16.php
@@ -68,7 +68,12 @@ class ps_checkoutPaymentCard16ModuleFrontController extends ModuleFrontControlle
             'clientToken' => $paypalOrder['body']['client_token'],
             'paypalOrderId' => $paypalOrder['body']['id'],
             'validateOrderLinkByCard' => $module->getValidateOrderLink($paypalOrder['body']['id'], 'card'),
-            'intent' => strtolower(\Configuration::get('PS_CHECKOUT_INTENT')),
+            'intent' => \Configuration::get(
+                'PS_CHECKOUT_INTENT',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            ),
             'currencyIsoCode' => $this->context->currency->iso_code,
             'isCardPaymentError' => (bool) Tools::getValue('hferror'),
             'modulePath' => $module->getPathUri(),

--- a/controllers/front/PaymentPaypal16.php
+++ b/controllers/front/PaymentPaypal16.php
@@ -68,7 +68,12 @@ class ps_checkoutPaymentPaypal16ModuleFrontController extends ModuleFrontControl
             'clientToken' => $paypalOrder['body']['client_token'],
             'paypalOrderId' => $paypalOrder['body']['id'],
             'validateOrderLinkByPaypal' => $module->getValidateOrderLink($paypalOrder['body']['id'], 'paypal'),
-            'intent' => strtolower(\Configuration::get('PS_CHECKOUT_INTENT')),
+            'intent' => Configuration::get(
+                'PS_CHECKOUT_INTENT',
+                null,
+                null,
+                (int) \Context::getContext()->shop->id
+            ),
             'currencyIsoCode' => $this->context->currency->iso_code,
             'isCardPaymentError' => (bool) Tools::getValue('hferror'),
             'modulePath' => $module->getPathUri(),

--- a/tests/PaymentCreateOrderTest.php
+++ b/tests/PaymentCreateOrderTest.php
@@ -73,9 +73,29 @@ class Logger
 
 class Configuration
 {
-    public static function get($key)
+    public static function get($key, $idLang = null, $idShopGroup = null, $idShop = null, $default = false)
     {
         return $key;
+    }
+}
+
+class Shop
+{
+    public $id;
+}
+
+class Context
+{
+    public $shop;
+
+    public function __construct()
+    {
+        $this->shop = new Shop();
+    }
+
+    public static function getContext()
+    {
+        return new self();
     }
 }
 

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
 		- '#Call to function is_array\(\) with Currency will always evaluate to false.#'
 		- '#Parameter \#1 \$id of class Customer constructor expects null, int given.#'
 		- '#Parameter \#1 \$hook_name of method ModuleCore::registerHook\(\) expects string, array<int, string> given.#'
+		- '#Parameter \#6 \$idShop of method LinkCore::getModuleLink\(\) expects null, int given.#'
 		- '#Call to an undefined method\(\) AdminController|FrontController::getCheckoutProcess\(\).#'
 		- '#Parameter \#1 \$id_hook of method ModuleCore::updatePosition\(\) expects bool, int given.#'
 		- '#Property TabCore::\$name \(string\) does not accept array.#'

--- a/upgrade/upgrade-1.2.10.php
+++ b/upgrade/upgrade-1.2.10.php
@@ -33,7 +33,7 @@ if (!defined('_PS_VERSION_')) {
 function upgrade_module_1_2_10($module)
 {
     foreach (OrderStates::ORDER_STATES as $key => $value) {
-        $idState = \Configuration::get($key);
+        $idState = \Configuration::getGlobalValue($key);
 
         $update = \Db::getInstance()->update(
             OrderStates::ORDER_STATE_TABLE,
@@ -46,12 +46,40 @@ function upgrade_module_1_2_10($module)
         }
     }
 
-    \Configuration::updateValue('PS_CHECKOUT_CARD_PAYMENT_ENABLED', true);
+    $shopsList = \Shop::getShops(false, null, true);
 
-    // New configurations for express checkout feature
-    \Configuration::updateValue('PS_CHECKOUT_EC_ORDER_PAGE', false);
-    \Configuration::updateValue('PS_CHECKOUT_EC_CHECKOUT_PAGE', false);
-    \Configuration::updateValue('PS_CHECKOUT_EC_PRODUCT_PAGE', false);
+    foreach ($shopsList as $shopId) {
+        \Configuration::updateValue(
+            'PS_CHECKOUT_CARD_PAYMENT_ENABLED',
+            true,
+            false,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+
+        // New configurations for express checkout feature
+        \Configuration::updateValue(
+            'PS_CHECKOUT_EC_ORDER_PAGE',
+            false,
+            false,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+        \Configuration::updateValue(
+            'PS_CHECKOUT_EC_CHECKOUT_PAGE',
+            false,
+            false,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+        \Configuration::updateValue(
+            'PS_CHECKOUT_EC_PRODUCT_PAGE',
+            false,
+            false,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+    }
 
     // register new hooks for express checkout
     $hooks = [


### PR DESCRIPTION
Force one configuration per shop
Access to module configuration page is not allowed if Context is All Shops or Group
OrderState not manage multishop that's why I use globalvalue