### PR TITLE
Change of OrderState should send mail if needed

### DIFF
--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -252,11 +252,7 @@ class Refund
 
         $this->addOrderPayment($order, $transactionId);
 
-        if (false === $orderHistory->save()) {
-            return false;
-        }
-
-        return true;
+        return $orderHistory->addWithemail();
     }
 
     /**

--- a/classes/ValidateOrder.php
+++ b/classes/ValidateOrder.php
@@ -192,8 +192,8 @@ class ValidateOrder
      */
     private function setOrderState($orderId, $status, $paymentMethod)
     {
-        $order = new \OrderHistory();
-        $order->id_order = $orderId;
+        $orderHistory = new \OrderHistory();
+        $orderHistory->id_order = $orderId;
 
         switch ($status) {
             case self::CAPTURE_STATUS_COMPLETED:
@@ -210,8 +210,8 @@ class ValidateOrder
                 break;
         }
 
-        $order->changeIdOrderState($orderState, $orderId);
-        $order->save();
+        $orderHistory->changeIdOrderState($orderState, $orderId);
+        $orderHistory->addWithemail();
 
         return $orderState;
     }

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -133,21 +133,21 @@ class OrderDispatcher implements Dispatcher
             throw new UnauthorizedException($orderError);
         }
 
-        $order = new \OrderHistory();
-        $order->id_order = $orderId;
-        $lastOrderState = $order->getLastOrderState($orderId);
+        $orderHistory = new \OrderHistory();
+        $orderHistory->id_order = $orderId;
+        $lastOrderState = $orderHistory->getLastOrderState($orderId);
 
         // Prevent duplicate state entry
         if ((int) self::PS_EVENTTYPE_TO_PS_STATE_ID[$eventType] === $lastOrderState->id) {
             return false;
         }
 
-        $order->changeIdOrderState(
+        $orderHistory->changeIdOrderState(
             self::PS_EVENTTYPE_TO_PS_STATE_ID[$eventType],
             $orderId
         );
 
-        if (true !== $order->save()) {
+        if (true !== $orderHistory->addWithemail()) {
             throw new UnauthorizedException('unable to change the order state');
         }
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -608,15 +608,11 @@ class Ps_checkout extends PaymentModule
 
         // change the order state to partial refund
         $orderHistory = new \OrderHistory();
-        $orderHistory->id_order = $params['order']->id;
+        $orderHistory->id_order = (int) $params['order']->id;
 
         $orderHistory->changeIdOrderState(intval(\Configuration::get('PS_CHECKOUT_STATE_PARTIAL_REFUND')), $params['order']->id);
 
-        if (false === $orderHistory->save()) {
-            return false;
-        }
-
-        return true;
+        return $orderHistory->addWithemail();
     }
 
     public function hookActionOrderStatusUpdate($params)


### PR DESCRIPTION
If module change OrderState to `_PS_OS_ERROR_` email associated should be send.
In case of OrderState with attribute `send_email` is set to `0` no email were send on change.
All OrderState added by ps_checkout has been created by default with `send_email` = `0`