### PR TITLE
Fix fatal error on DispatchWebHook

### DIFF
--- a/controllers/front/DispatchWebHook.php
+++ b/controllers/front/DispatchWebHook.php
@@ -79,7 +79,18 @@ class ps_checkoutDispatchWebHookModuleFrontController extends ModuleFrontControl
 
             $this->setAtributesHeaderValues($headerValues);
 
-            $bodyValues = \Tools::jsonDecode(file_get_contents('php://input'), true);
+            $bodyContent = file_get_contents('php://input');
+
+            if (empty($bodyContent)) {
+                throw new UnauthorizedException(WebHookValidation::BODY_DATA_ERROR);
+            }
+
+            $bodyValues = \Tools::jsonDecode($bodyContent, true);
+
+            if (empty($bodyValues)) {
+                throw new UnauthorizedException(WebHookValidation::BODY_DATA_ERROR);
+            }
+
             $errors = $validationValues->validateBodyDatas($bodyValues);
 
             // If there is errors, return them


### PR DESCRIPTION
FatalThrowableError
Type error: Argument 1 passed to PrestaShop\Module\PrestashopCheckout\WebHookValidation::validateBodyDatas() must be of the type array, null given, called in /var/www/html/modules/ps_checkout/controllers/front/DispatchWebHook.php on line 89

If no body is empty, `json_decode` return `null` but `WebHookValidation::validateBodyDatas()` accept only `array`