### PR TITLE
Fix fatal error on ps version older than 1.6.1.15

### DIFF
--- a/classes/Adapter/LinkAdapter.php
+++ b/classes/Adapter/LinkAdapter.php
@@ -1,3 +1,4 @@
+        return \Tools::getShopDomainSsl(true) . __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/' . $this->link->getAdminLink($controller, $withToken) . $paramsAsString;
 <?php
 /**
  * 2007-2020 PrestaShop and Contributors
@@ -64,6 +65,6 @@ class LinkAdapter
             $paramsAsString .= "&$key=$value";
         }
 
-        return $this->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $this->link->getAdminLink($controller, $withToken) . $paramsAsString;
+        return \Tools::getShopDomainSsl(true) . __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/' . $this->link->getAdminLink($controller, $withToken) . $paramsAsString;
     }
 }

--- a/classes/Adapter/LinkAdapter.php
+++ b/classes/Adapter/LinkAdapter.php
@@ -1,4 +1,3 @@
-        return \Tools::getShopDomainSsl(true) . __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/' . $this->link->getAdminLink($controller, $withToken) . $paramsAsString;
 <?php
 /**
  * 2007-2020 PrestaShop and Contributors


### PR DESCRIPTION
On ps version older than 1.6.1.15, the method getBaseLink from the class link is protected. We cannot use it ... instead we replace it by Tools::getShopDomainSsl().