### PR TITLE
Set address delivery on each product of the cart in order to get carriers in the checkout process

### DIFF
--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -140,6 +140,12 @@ class ps_checkoutExpressCheckoutModuleFrontController extends ModuleFrontControl
 
         $this->context->cart->id_address_delivery = $address->id;
         $this->context->cart->id_address_invoice = $address->id;
+
+        $products = $this->context->cart->getProducts();
+        foreach ($products as $product) {
+            $this->context->cart->setProductAddressDelivery($product['id_product'], $product['id_product_attribute'], $product['id_address_delivery'], $address->id);
+        }
+
         $this->context->cart->save();
     }
 


### PR DESCRIPTION
In case of express checkout, the module create automatically an address with the address from the PayPal account of the customer. In some cases, PrestaShop cannot retrieve the carrier list for this address.
We are forced to use the method setProductAddressDelivery() on each product in order to get the correct carrier list for the created address.