### PR TITLE
Fix webhook change order state

### DIFF
--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -133,15 +133,17 @@ class OrderDispatcher implements Dispatcher
             throw new UnauthorizedException($orderError);
         }
 
-        $orderHistory = new \OrderHistory();
-        $orderHistory->id_order = $orderId;
-        $lastOrderState = $orderHistory->getLastOrderState($orderId);
+        $order = new \Order($orderId);
+        $lastOrderStateId = (int) $order->getCurrentState();
+        $newOrderStateId = (int) self::PS_EVENTTYPE_TO_PS_STATE_ID[$eventType];
 
         // Prevent duplicate state entry
-        if ((int) self::PS_EVENTTYPE_TO_PS_STATE_ID[$eventType] === $lastOrderState->id) {
+        if ($lastOrderStateId === $newOrderStateId) {
             return false;
         }
 
+        $orderHistory = new \OrderHistory();
+        $orderHistory->id_order = $orderId;
         $orderHistory->changeIdOrderState(
             self::PS_EVENTTYPE_TO_PS_STATE_ID[$eventType],
             $orderId

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -41,7 +41,7 @@ class OrderDispatcher implements Dispatcher
     {
         $this->matriceEventAndOrderState = [
             self::PS_CHECKOUT_PAYMENT_AUTH_VOIDED => \Configuration::get('PS_OS_CANCELED'),
-            self::PS_CHECKOUT_PAYMENT_PENDING => \Configuration::get('PS_OS_PREPARATION'), // Processing in progress
+            self::PS_CHECKOUT_PAYMENT_PENDING => \Configuration::get('PS_CHECKOUT_STATE_WAITING_PAYPAL_PAYMENT'), // OS_PREPARATION should be used only before shipping !
             self::PS_CHECKOUT_PAYMENT_COMPLETED => \Configuration::get('PS_OS_PAYMENT'), // Payment accepted
             self::PS_CHECKOUT_PAYMENT_DENIED => \Configuration::get('PS_OS_ERROR'), // Payment error
         ];
@@ -150,7 +150,11 @@ class OrderDispatcher implements Dispatcher
         $newOrderStateId = (int) $this->matriceEventAndOrderState[$eventType];
 
         // Prevent duplicate state entry
-        if ($lastOrderStateId === $newOrderStateId) {
+        if ($lastOrderStateId === $newOrderStateId
+            || $order->hasBeenPaid()
+            || $order->hasBeenShipped()
+            || $order->hasBeenDelivered()
+            || $order->isInPreparation()) {
             return false;
         }
 


### PR DESCRIPTION
Quick fix to prevent OrderState change for Order is already paid, in preparation, shipped or delivered.

Fix usage of deprecated constants and function from PrestaShop Core

Note for `PS_CHECKOUT_PAYMENT_PENDING` should not  be associated to native "Processing in progress" OrderState (`PS_OS_PREPARATION` id 3), because this state is for order in preparation for shipping !
See in code **For now, if pending, do not change anything** so it can be wait
We should use one of our WAITING state, it seems depend on payment method :
- `PS_CHECKOUT_STATE_WAITING_PAYPAL_PAYMENT`
- `PS_CHECKOUT_STATE_WAITING_CREDIT_CARD_PAYMENT`
- `PS_CHECKOUT_STATE_WAITING_LOCAL_PAYMENT`
- `PS_CHECKOUT_STATE_WAITING_CAPTURE`