### PR TITLE
Quickfix refund

### DIFF
--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -117,7 +117,7 @@ class Refund
         $purchaseUnits = isset($response['purchase_units']) ? current($response['purchase_units']) : null;
         //@todo Quick fix before refactoring
         $capture = isset($purchaseUnits['payments']['captures']) ? current($purchaseUnits['payments']['captures']) : null;
-        $captureId = $capture['id'];
+        $captureId = isset($capture['id']) ? $capture['id'] : null;
 
         if (null === $captureId) {
             return false;

--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -76,6 +76,7 @@ class Refund
      */
     public function refundPaypalOrder()
     {
+        // API call here
         $payload = $this->getPayload();
 
         //@todo Quick fix before refactoring
@@ -88,6 +89,7 @@ class Refund
             ];
         }
 
+        // API call here
         $response = (new Order(\Context::getContext()->link))->refund($payload);
 
         if (422 === $response['httpCode']) {
@@ -104,6 +106,7 @@ class Refund
      */
     public function getCaptureId()
     {
+        // API call here
         $response = (new PaypalOrder($this->getPaypalOrderId()))->getOrder();
 
         if (false === $response['status']) {
@@ -130,6 +133,7 @@ class Refund
      */
     public function getPayload()
     {
+        // API call here
         $captureId = $this->getCaptureId();
 
         //@todo Quick fix before refactoring
@@ -268,6 +272,9 @@ class Refund
             return false;
         }
 
+        // @todo Add a new negative OrderPayment is wrong !
+        $this->addOrderPayment($order, $transactionId);
+
         // If refund from Prestashop, do not change Order History
         if (false === $this->refundFromWebhook) {
             return true;
@@ -279,9 +286,6 @@ class Refund
             $orderStateId,
             $order->id
         );
-
-        // @todo Add a new negative OrderPayment is wrong !
-        $this->addOrderPayment($order, $transactionId);
 
         return $orderHistory->addWithemail();
     }


### PR DESCRIPTION
Quickfix for Refund, it need to be reworked in next major

- Fix notice when call to API fail to retrieve CaptureId
(When order has been placed before logout in ps_checkout and after new onboarding, previous Order are not in the new account, so we cannot retrieve captureId)
- Fix missing save of transaction_id

Problems to be fixed with a refactoring:
- it's not correct to add a new OrderPayment with negative amount, it cause warning on BO Order page
![order-warning](https://user-images.githubusercontent.com/5262628/76421419-ecb00880-63a3-11ea-9045-0698dbd6b6a3.png)
- very bad idea to launch a refund on OrderState change, OrderState can change outside BO by others modules. (ERP etc...)