### PR TITLE
Quick fix transaction id

### DIFF
--- a/classes/ValidateOrder.php
+++ b/classes/ValidateOrder.php
@@ -67,22 +67,40 @@ class ValidateOrder
      */
     public function validateOrder($payload)
     {
+        // API call here
         $paypalOrder = new PaypalOrder($this->paypalOrderId);
         $order = $paypalOrder->getOrder();
+
+        if (empty($order)) {
+            // @todo quickfix : Call API return nothing or fail
+            $message = sprintf('Unable to retrieve Paypal Order for %s', $this->paypalOrderId);
+            \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+            throw new \PrestaShopException($message);
+        }
+
         $apiOrder = new Order(\Context::getContext()->link);
 
         switch ($paypalOrder->getOrderIntent()) {
             case self::INTENT_CAPTURE:
+                // API call here
                 $response = $apiOrder->capture($order['id'], $this->merchantId);
                 break;
             case self::INTENT_AUTHORIZE:
+                // API call here
                 $response = $apiOrder->authorize($order['id'], $this->merchantId);
                 break;
             default:
-                throw new \Exception(sprintf('Unknown Intent type %s', $paypalOrder->getOrderIntent()));
+                // @todo quickfix
+                $message = sprintf('Unknown Intent type %s, Paypal Order %s', $paypalOrder->getOrderIntent(), $this->paypalOrderId);
+                \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+                throw new \PrestaShopException($message);
         }
 
         if (false === $response['status']) {
+            // @todo Quickfix
+            $message = sprintf('Unable to capture/authorize Paypal Order %s', $this->paypalOrderId);
+            \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+
             return false;
         }
 
@@ -95,15 +113,19 @@ class ValidateOrder
             $payload['amount'],
             $this->getPaymentMessageTranslation($payload['paymentMethod'], $module),
             null,
-            $payload['extraVars'],
+            [
+                'transaction_id' => $response['body']['id'],
+            ],
             $payload['currencyId'],
             false,
             $payload['secureKey']
         );
 
-        if (false === $this->setOrdersMatrice($module->currentOrder, $payload['extraVars']['transaction_id'])) {
+        if (false === $this->setOrdersMatrice($module->currentOrder, $this->paypalOrderId)) {
             $this->setOrderState($module->currentOrder, self::CAPTURE_STATUS_DECLINED, $payload['paymentMethod']);
-            throw new \Exception(sprintf('Set Order Matrice error for Prestashop Order ID : %s and Paypal Order ID : %s', $module->currentOrder, $payload['extraVars']['transaction_id']));
+            $message = sprintf('Set Order Matrice error for Prestashop Order ID : %s and Paypal Order ID : %s', $module->currentOrder, $this->paypalOrderId);
+            \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+            throw new \PrestaShopException($message);
         }
 
         // TODO : patch the order in order to update the order id with the order id
@@ -116,6 +138,7 @@ class ValidateOrder
         );
 
         if ($orderState === _PS_OS_PAYMENT_) {
+            // @todo this may be useless, previous $module->validateOrder() should save transaction id
             $this->setTransactionId($module->currentOrderReference, $response['body']['id']);
         }
 

--- a/controllers/front/ValidateOrder.php
+++ b/controllers/front/ValidateOrder.php
@@ -53,6 +53,7 @@ class ps_checkoutValidateOrderModuleFrontController extends ModuleFrontControlle
         $isExpressCheckout = (bool) Tools::getValue('isExpressCheckout');
 
         if ($isExpressCheckout) {
+            // API call here
             $this->updatePaypalOrder($paypalOrderId);
         }
 
@@ -73,12 +74,12 @@ class ps_checkoutValidateOrderModuleFrontController extends ModuleFrontControlle
             'cartId' => (int) $cart->id,
             'amount' => $total,
             'paymentMethod' => $paymentMethod,
-            'extraVars' => ['transaction_id' => $paypalOrderId],
             'currencyId' => (int) $currency->id,
             'secureKey' => $customer->secure_key,
         ];
 
         // If the payment is rejected redirect the client to the last checkout step (422 error)
+        // API call here
         if (false === $payment->validateOrder($dataOrder)) {
             $this->redirectToCheckout(['hferror' => 1]);
         }


### PR DESCRIPTION
Fix mixed content of transaction_id was "PayPal Order Id instead" of "PayPal Transaction Id"
Add some logs to find root cause of some fails

Many API Call can fail without clear informations...

This part need to be refactored