### PR TITLE
Quickfix double refund due to webhook

### DIFF
--- a/classes/Builder/Payload/OrderPayloadBuilder.php
+++ b/classes/Builder/Payload/OrderPayloadBuilder.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\PrestashopCheckout\Builder\Payload;
 
 use PrestaShop\Module\PrestashopCheckout\PaypalCountryCodeMatrice;
+use PrestaShop\Module\PrestashopCheckout\PsCheckoutException;
 use PrestaShop\Module\PrestashopCheckout\Repository\PaypalAccountRepository;
 
 /**
@@ -449,7 +450,7 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
     private function checkPaypalOrderIdWhenUpdate()
     {
         if (true === $this->isUpdate && empty($this->paypalOrderId)) {
-            throw new \PrestaShopException('PayPal order ID is required when building payload for update an order');
+            throw new PsCheckoutException('PayPal order ID is required when building payload for update an order');
         }
     }
 

--- a/classes/Entity/PsAccount.php
+++ b/classes/Entity/PsAccount.php
@@ -20,6 +20,8 @@
 
 namespace PrestaShop\Module\PrestashopCheckout\Entity;
 
+use PrestaShop\Module\PrestashopCheckout\PsCheckoutException;
+
 /**
  * Not really an entity.
  * Allow to manage data regarding firebase account in database
@@ -73,11 +75,11 @@ class PsAccount
     public function __construct($idToken = null, $refreshToken = null, $email = null, $localId = null, $psxForm = null)
     {
         if (empty($idToken)) {
-            throw new \PrestaShopException('idToken cannot be empty');
+            throw new PsCheckoutException('idToken cannot be empty');
         }
 
         if (empty($refreshToken)) {
-            throw new \PrestaShopException('refreshToken cannot be empty');
+            throw new PsCheckoutException('refreshToken cannot be empty');
         }
 
         $this->setIdToken($idToken);

--- a/classes/OrderStates.php
+++ b/classes/OrderStates.php
@@ -103,7 +103,7 @@ class OrderStates
             return $insertedId;
         }
 
-        throw new \PrestaShopException('Not able to insert the new order state');
+        throw new PsCheckoutException('Not able to insert the new order state');
     }
 
     /**
@@ -164,7 +164,7 @@ class OrderStates
         ];
 
         if (false === \Db::getInstance()->insert(self::ORDER_STATE_LANG_TABLE, $data)) {
-            throw new \PrestaShopException('Not able to insert the new order state language');
+            throw new PsCheckoutException('Not able to insert the new order state language');
         }
     }
 

--- a/classes/Presenter/Store/Modules/PsxModule.php
+++ b/classes/Presenter/Store/Modules/PsxModule.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\PrestashopCheckout\Presenter\Store\Modules;
 
 use PrestaShop\Module\PrestashopCheckout\Presenter\PresenterInterface;
+use PrestaShop\Module\PrestashopCheckout\PsCheckoutException;
 use PrestaShop\Module\PrestashopCheckout\Repository\PsAccountRepository;
 
 /**
@@ -85,7 +86,7 @@ class PsxModule implements PresenterInterface
         );
 
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new \Exception(sprintf('The legacy to standard locales JSON could not be decoded %s', json_last_error_msg()));
+            throw new PsCheckoutException(sprintf('The legacy to standard locales JSON could not be decoded %s', json_last_error_msg()));
         }
 
         return $data;

--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -300,6 +300,17 @@ class Refund
      */
     public function addOrderPayment(\Order $order, $paypalTransactionId)
     {
+        //@todo Quickfix to prevent duplicate OrderPayment
+        /** @var \OrderPayment[] $orderPayments */
+        $orderPayments = $order->getOrderPaymentCollection();
+        foreach ($orderPayments as $orderPayment) {
+            if ($orderPayment->transaction_id === $paypalTransactionId) {
+                $message = sprintf('This PayPal transaction is already saved : %s', $orderPayment->transaction_id);
+                \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+                throw new \PrestaShopException($message);
+            }
+        }
+
         //@todo this is not correct to add a negative OrderPayment, it cause a Warning in Order page in BO
         //Maybe its done to save paypalTransactionId
         return $order->addOrderPayment(

--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -307,7 +307,7 @@ class Refund
             if ($orderPayment->transaction_id === $paypalTransactionId) {
                 $message = sprintf('This PayPal transaction is already saved : %s', $orderPayment->transaction_id);
                 \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-                throw new \PrestaShopException($message);
+                throw new PsCheckoutException($message);
             }
         }
 

--- a/classes/Updater/PaypalAccountUpdater.php
+++ b/classes/Updater/PaypalAccountUpdater.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\PrestashopCheckout\Updater;
 use PrestaShop\Module\PrestashopCheckout\Api\Payment\Shop;
 use PrestaShop\Module\PrestashopCheckout\Entity\PaypalAccount;
 use PrestaShop\Module\PrestashopCheckout\PersistentConfiguration;
+use PrestaShop\Module\PrestashopCheckout\PsCheckoutException;
 
 /**
  * Check and set the merchant status
@@ -48,7 +49,7 @@ class PaypalAccountUpdater
         $merchantId = $account->getMerchantId();
 
         if (empty($merchantId)) {
-            throw new \PrestaShopException('MerchantId cannot be empty');
+            throw new PsCheckoutException('MerchantId cannot be empty');
         }
 
         $this->setAccount($account);

--- a/classes/ValidateOrder.php
+++ b/classes/ValidateOrder.php
@@ -75,7 +75,7 @@ class ValidateOrder
             // @todo quickfix : Call API return nothing or fail
             $message = sprintf('Unable to retrieve Paypal Order for %s', $this->paypalOrderId);
             \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-            throw new \PrestaShopException($message);
+            throw new PsCheckoutException($message);
         }
 
         $apiOrder = new Order(\Context::getContext()->link);
@@ -93,7 +93,7 @@ class ValidateOrder
                 // @todo quickfix
                 $message = sprintf('Unknown Intent type %s, Paypal Order %s', $paypalOrder->getOrderIntent(), $this->paypalOrderId);
                 \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-                throw new \PrestaShopException($message);
+                throw new PsCheckoutException($message);
         }
 
         if (false === $response['status']) {
@@ -125,7 +125,7 @@ class ValidateOrder
             $this->setOrderState($module->currentOrder, self::CAPTURE_STATUS_DECLINED, $payload['paymentMethod']);
             $message = sprintf('Set Order Matrice error for Prestashop Order ID : %s and Paypal Order ID : %s', $module->currentOrder, $this->paypalOrderId);
             \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-            throw new \PrestaShopException($message);
+            throw new PsCheckoutException($message);
         }
 
         // TODO : patch the order in order to update the order id with the order id

--- a/classes/WebHookOrder.php
+++ b/classes/WebHookOrder.php
@@ -88,7 +88,7 @@ class WebHookOrder
             if ($orderPayment->transaction_id === $this->paypalTransactionId) {
                 $message = sprintf('This PayPal transaction is already saved : %s', $this->paypalTransactionId);
                 \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-                throw new \PrestaShopException($message);
+                throw new PsCheckoutException($message);
             }
         }
 

--- a/classes/WebHookOrder.php
+++ b/classes/WebHookOrder.php
@@ -80,6 +80,18 @@ class WebHookOrder
     public function updateOrder()
     {
         $order = new \Order($this->orderId);
+
+        //@todo Quickfix checking if this transaction is already saved
+        /** @var \OrderPayment[] $orderPayments */
+        $orderPayments = $order->getOrderPaymentCollection();
+        foreach ($orderPayments as $orderPayment) {
+            if ($orderPayment->transaction_id === $this->paypalTransactionId) {
+                $message = sprintf('This PayPal transaction is already saved : %s', $this->paypalTransactionId);
+                \PrestaShopLogger::addLog($message, 1, null, null, null, true);
+                throw new \PrestaShopException($message);
+            }
+        }
+
         $amountAlreadyRefunded = $this->getOrderSlipAmount($order);
         $expectiveTotalAmountToRefund = $amountAlreadyRefunded + $this->amount;
 


### PR DESCRIPTION
Sometime we receive a useless webhook cause duplicate refund due to queued tasks