### PR TITLE
Fix OrderState install if not found in Db

### DIFF
--- a/classes/OrderStates.php
+++ b/classes/OrderStates.php
@@ -71,10 +71,10 @@ class OrderStates
      */
     private function getPaypalStateId($state, $color)
     {
-        $stateId = \Configuration::getGlobalValue($state);
+        $stateId = (int) \Configuration::getGlobalValue($state);
 
         // Is state ID already existing in the Configuration table ?
-        if (false === $stateId) {
+        if (0 === $stateId || false === \OrderState::existsInDatabase($stateId, self::ORDER_STATE_TABLE)) {
             return $this->createPaypalStateId($state, $color);
         }
 


### PR DESCRIPTION
Some merchant reinstall module after a migration with third party tool, value in Configuration still there but not data in ps_order_state table cause error in payment