### PR TITLE
Fix webhook sent json encoded data

### DIFF
--- a/classes/WebHookNock.php
+++ b/classes/WebHookNock.php
@@ -34,7 +34,7 @@ class WebHookNock
         header('Content-Type: application/json');
         headers_list();
 
-        $bodyReturn = \Tools::jsonEncode($headerDatas);
+        $bodyReturn = json_encode($headerDatas);
         \PrestaShopLoggerCore::addLog('[PSPwebhook] ' . $bodyReturn, 3, null, null, null, true);
 
         echo $bodyReturn;

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -61,13 +61,13 @@ class OrderDispatcher implements Dispatcher
         }
 
         if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REFUNED
-        || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REVERSED) {
+            || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REVERSED) {
             return $this->dispatchPaymentAction($payload['eventType'], $payload['resource'], $psOrderId);
         }
 
         if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_COMPLETED
-        || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_DENIED
-        || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_AUTH_VOIDED) {
+            || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_DENIED
+            || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_AUTH_VOIDED) {
             return $this->dispatchPaymentStatus($payload['eventType'], $payload['resource'], $psOrderId);
         }
 

--- a/controllers/front/DispatchWebHook.php
+++ b/controllers/front/DispatchWebHook.php
@@ -88,7 +88,7 @@ class ps_checkoutDispatchWebHookModuleFrontController extends ModuleFrontControl
                 throw new UnauthorizedException(WebHookValidation::BODY_DATA_ERROR);
             }
 
-            $bodyValues = \Tools::jsonDecode($bodyContent, true);
+            $bodyValues = json_decode($bodyContent, true);
 
             if (empty($bodyValues)) {
                 throw new UnauthorizedException(WebHookValidation::BODY_DATA_ERROR);
@@ -179,7 +179,7 @@ class ps_checkoutDispatchWebHookModuleFrontController extends ModuleFrontControl
     private function setAtributesBodyValues(array $bodyValues)
     {
         $this->payload = [
-            'resource' => (array) \Tools::jsonDecode($bodyValues['resource']),
+            'resource' => (array) json_decode($bodyValues['resource'], true),
             'eventType' => (string) $bodyValues['eventType'],
             'category' => (string) $bodyValues['category'],
             'summary' => (string) $bodyValues['summary'],


### PR DESCRIPTION
Sometime we have a `stdClass` object instead of an `array` because `resource` is still json encoded in webhook payload

Cause an error fatal and HTTP 500 response