### PR TITLE
Fix refund webhook validation

### DIFF
--- a/classes/webHookValidation/WebHookValidation.php
+++ b/classes/webHookValidation/WebHookValidation.php
@@ -117,15 +117,15 @@ class WebHookValidation
             return $errors;
         }
 
-        if (empty($resource['amount']->value)) {
+        if (empty($resource['amount']['value'])) {
             $errors[] = self::RESOURCE_VALUE_EMPTY_ERROR;
         }
 
-        if (0 >= $resource['amount']->value) {
+        if (0 >= $resource['amount']['value']) {
             $errors[] = self::RESOURCE_VALUE_ZERO_ERROR;
         }
 
-        if (empty($resource['amount']->currency_code)) {
+        if (empty($resource['amount']['currency_code'])) {
             $errors[] = self::RESOURCE_CURRENCY_ERROR;
         }
 


### PR DESCRIPTION
Fix error on refund webbook `Amount value can't be empty,Amount value must be higher than 0,Amount currency can't be empty`