### PR TITLE
Fix troubles with Order split

### DIFF
--- a/classes/ObjectModel/OrderMatrice.php
+++ b/classes/ObjectModel/OrderMatrice.php
@@ -39,35 +39,41 @@ class OrderMatrice extends \ObjectModel
     ];
 
     /**
-     * Get the Prestashop Order Id from Paypal Order Id
+     * Get PrestaShop Orders associated to PayPal Order
      *
-     * @param string $orderPaypal
+     * @param string $orderPayPal
      *
-     * @return int
+     * @return array
      */
-    public function getOrderPrestashopFromPaypal($orderPaypal)
+    public function getPrestaShopOrdersByPayPalOrder($orderPayPal)
     {
-        $query = 'SELECT id_order_prestashop
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE pom.id_order_paypal = "' . pSQL($orderPaypal) . '"';
+        $orderIds = \Db::getInstance()->executeS('
+            SELECT `id_order_prestashop`
+            FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice`
+            WHERE `id_order_paypal` = "' . pSQL($orderPayPal) . '"'
+        );
 
-        return (int) \Db::getInstance()->getValue($query);
+        if (empty($orderIds)) {
+            return [];
+        }
+
+        return $orderIds;
     }
 
     /**
      * Get the Paypal Order Id from the Prestashop Order Id
      *
-     * @param int $orderPrestashop
+     * @param int $orderId
      *
      * @return string|false
      */
-    public function getOrderPaypalFromPrestashop($orderPrestashop)
+    public function getOrderPaypalFromPrestashop($orderId)
     {
-        $query = 'SELECT id_order_paypal
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE pom.id_order_prestashop = "' . (int) $orderPrestashop . '"';
-
-        return \Db::getInstance()->getValue($query);
+        return \Db::getInstance()->getValue('
+            SELECT `id_order_paypal`
+            FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice`
+            WHERE `id_order_prestashop` = ' . (int) $orderId
+        );
     }
 
     /**
@@ -85,9 +91,12 @@ class OrderMatrice extends \ObjectModel
         }
 
         // If more than one order found, there are inconsistencies for this order
-        return (bool) \Db::getInstance()->getValue('
+        $total = (int) \Db::getInstance()->getValue('
             SELECT COUNT(*)
             FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice`
-            WHERE id_order_prestashop = ' . (int) $orderId);
+            WHERE `id_order_prestashop` = ' . (int) $orderId
+        );
+
+        return $total > 1;
     }
 }

--- a/classes/ObjectModel/OrderMatrice.php
+++ b/classes/ObjectModel/OrderMatrice.php
@@ -39,48 +39,6 @@ class OrderMatrice extends \ObjectModel
     ];
 
     /**
-     * Save current object to database (add or update).
-     *
-     * @param bool $autoDate
-     * @param bool $nullValues
-     *
-     * @return bool
-     */
-    public function add($autoDate = true, $nullValues = false)
-    {
-        if (true === $this->alreadyExist()) {
-            return false;
-        }
-
-        return parent::add($autoDate, $nullValues);
-    }
-
-    /**
-     * Check if the Prestashop or Paypal Order Id already Exist to prevent duplicate ID entry
-     *
-     * @return bool
-     */
-    private function alreadyExist()
-    {
-        $wherePrestashopIdExist = '1';
-        $wherePaypalIdExist = '1';
-
-        if (null !== $this->id_order_prestashop) {
-            $wherePrestashopIdExist = 'pom.id_order_prestashop = "' . (int) $this->id_order_prestashop . '"';
-        }
-
-        if (null !== $this->id_order_paypal) {
-            $wherePaypalIdExist = 'pom.id_order_paypal = "' . pSQL($this->id_order_paypal) . '"';
-        }
-
-        $query = 'SELECT id_order_matrice
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE ' . $wherePrestashopIdExist . ' OR ' . $wherePaypalIdExist;
-
-        return (bool) \Db::getInstance()->getValue($query);
-    }
-
-    /**
      * Get the Prestashop Order Id from Paypal Order Id
      *
      * @param string $orderPaypal

--- a/classes/ObjectModel/OrderMatrice.php
+++ b/classes/ObjectModel/OrderMatrice.php
@@ -57,7 +57,7 @@ class OrderMatrice extends \ObjectModel
             return [];
         }
 
-        return $orderIds;
+        return array_column($orderIds, 'id_order_prestashop');
     }
 
     /**

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -61,6 +61,10 @@ class OrderDispatcher implements Dispatcher
         $result = true;
         $orderIds = (new \OrderMatrice())->getPrestaShopOrdersByPayPalOrder($payload['orderId']);
 
+        if (empty($orderIds)) {
+            throw new UnprocessableException('order #' . $payload['orderId'] . ' does not exist');
+        }
+
         foreach ($orderIds as $orderId) {
             if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REFUNED
                 || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REVERSED) {


### PR DESCRIPTION
In PrestaShop Core, on PaymentModule::validateOrder() an Order can be split for example if a product is out of stock. So more than one Order can be created with same Order reference for the same Cart and same Payment but different Order Id.

⚠️ To be checked with Product Team for behavior before merge