### PR TITLE
Remove our admin controller from SEO & URLs page

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -58,6 +58,14 @@ class Ps_checkout extends PaymentModule
     ];
 
     /**
+     * Names of ModuleAdminController used
+     */
+    const MODULE_ADMIN_CONTROLLERS = [
+        'AdminAjaxPrestashopCheckout',
+        'AdminPaypalOnboardingPrestashopCheckout',
+    ];
+
+    /**
      * Hook to install for 1.6
      *
      * @var array
@@ -89,7 +97,6 @@ class Ps_checkout extends PaymentModule
 
     public $confirmUninstall;
     public $bootstrap;
-    public $controllers;
 
     // Needed in order to retrieve the module version easier (in api call headers) than instanciate
     // the module each time to get the version
@@ -122,10 +129,6 @@ class Ps_checkout extends PaymentModule
 
         $this->confirmUninstall = $this->l('Are you sure you want to uninstall this module?');
         $this->ps_versions_compliancy = ['min' => '1.6.1', 'max' => _PS_VERSION_];
-        $this->controllers = [
-            'AdminAjaxPrestashopCheckout',
-            'AdminPaypalOnboardingPrestashopCheckout',
-        ];
     }
 
     /**
@@ -193,19 +196,19 @@ class Ps_checkout extends PaymentModule
     public function installTabs()
     {
         $installTabCompleted = true;
-        $tab = new Tab();
 
-        foreach ($this->controllers as $controllerName) {
+        foreach (static::MODULE_ADMIN_CONTROLLERS as $controllerName) {
             if (Tab::getIdFromClassName($controllerName)) {
                 continue;
             }
 
+            $tab = new Tab();
             $tab->class_name = $controllerName;
             $tab->active = true;
-            $tab->name = [];
-            foreach (Language::getLanguages(true) as $lang) {
-                $tab->name[$lang['id_lang']] = $this->name;
-            }
+            $tab->name = array_fill_keys(
+                Language::getIDs(false),
+                $this->displayName
+            );
             $tab->id_parent = -1;
             $tab->module = $this->name;
             $installTabCompleted = $installTabCompleted && $tab->add();
@@ -239,7 +242,7 @@ class Ps_checkout extends PaymentModule
     {
         $uninstallTabCompleted = true;
 
-        foreach ($this->controllers as $controllerName) {
+        foreach (static::MODULE_ADMIN_CONTROLLERS as $controllerName) {
             $id_tab = (int) Tab::getIdFromClassName($controllerName);
             $tab = new Tab($id_tab);
             if (Validate::isLoadedObject($tab)) {

--- a/upgrade/upgrade-1.4.0.php
+++ b/upgrade/upgrade-1.4.0.php
@@ -30,5 +30,25 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_1_4_0($module)
 {
+    // Remove our ModuleAdminControllers from SEO & URLs page
+    foreach (Ps_checkout::MODULE_ADMIN_CONTROLLERS as $controller) {
+        $metaId = Db::getInstance()->getValue('
+            SELECT id_meta
+            FROM `' . _DB_PREFIX_ . 'meta`
+            WHERE page="' . pSQL('module-' . $module->name . '-' . $controller) . '"'
+        );
+
+        if ($metaId) {
+            Db::getInstance()->delete(
+                'meta_lang',
+                'id_meta = ' . (int) $metaId
+            );
+            Db::getInstance()->delete(
+                'meta',
+                'id_meta = ' . (int) $metaId
+            );
+        }
+    }
+
     return $module->registerHook('displayAdminOrderLeft');
 }


### PR DESCRIPTION
`Module::$controllers` is an undocumented reserved var used to register ModuleFrontController in SEO & URLs page on BO in order to allow merchant to customize rewrite link and page title, meta keyword, meta description...
It should never be used for a ModuleAdminController

![ps_checkout-admincontrollers](https://user-images.githubusercontent.com/5262628/78535522-9a200b80-77ec-11ea-9bea-bb5511277ae7.png)
![ps_checkout-admincontroller](https://user-images.githubusercontent.com/5262628/78535771-0438b080-77ed-11ea-9b65-ab457e307c0c.png)

This PR fix this at module installation and module upgrade.