### PR TITLE
Fix javascript conflict with test()

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -388,7 +388,7 @@ class Ps_checkout extends PaymentModule
     }
 
     /**
-     * Add payment option at the checkout in the front office (prestashop 1.7)
+     * Add payment option at the checkout in the front office (prestashop 1.6)
      */
     public function hookPayment()
     {

--- a/views/js/initPaypalAndCard.js
+++ b/views/js/initPaypalAndCard.js
@@ -237,7 +237,7 @@ function hideDefaultPaymentButtonIfPaypalIsChecked() {
   }
 }
 
-function test(event) {
+function testPsPayPalCard(event) {
   event.preventDefault();
   document.querySelector('#hosted-fields-form button').click();
 }

--- a/views/templates/front/paymentOptions/hosted-fields.tpl
+++ b/views/templates/front/paymentOptions/hosted-fields.tpl
@@ -21,7 +21,7 @@
 
     <div id="payments-sdk__contingency-lightbox"></div>
 
-    <form id="hosted-fields-form" onsubmit="test(event)">
+    <form id="hosted-fields-form" onsubmit="testPsPayPalCard(event)">
 
         <div class="form-group row">
             <div class="col-md-8">


### PR DESCRIPTION
If a merchant use a javascript function or var named `test`, it cause an error.

```
Uncaught TypeError: test is not a function
at HTMLFormElement.onsubmit (order?token=EC-77A68400BR191334K:844)
at Object.trigger (core.js:39)
at HTMLFormElement.<anonymous> (core.js:39)
at Function.each (core.js:28)
at m.fn.init.each (core.js:28)
at m.fn.init.trigger (core.js:39)
at m.fn.init.m.fn.<computed> [as submit] (core.js:39)
at e.value (core.js:161)
at HTMLButtonElement.i (core.js:28)
at HTMLBodyElement.dispatch (core.js:39)
```