### PR TITLE
Improve PayPal Refund

### DIFF
--- a/classes/Handler/CreatePaypalOrderHandler.php
+++ b/classes/Handler/CreatePaypalOrderHandler.php
@@ -43,6 +43,13 @@ class CreatePaypalOrderHandler
         $this->context = $context;
     }
 
+    /**
+     * @param bool $expressCheckout
+     * @param bool $updateOrder
+     * @param string|null $paypalOrderId
+     *
+     * @return array
+     */
     public function handle($expressCheckout = false, $updateOrder = false, $paypalOrderId = null)
     {
         // Present an improved cart in order to create the payload

--- a/classes/PaypalOrder.php
+++ b/classes/PaypalOrder.php
@@ -95,6 +95,8 @@ class PaypalOrder
     /**
      * Returns PayPal Order Id
      *
+     * @todo To be moved in PayPalOrderPresenter
+     *
      * @return string|null
      */
     public function getId()
@@ -104,6 +106,8 @@ class PaypalOrder
 
     /**
      * Returns PayPal Order intent
+     *
+     * @todo To be moved in PayPalOrderPresenter
      *
      * @return string|null
      */
@@ -115,6 +119,8 @@ class PaypalOrder
     /**
      * Returns PayPal Order status
      *
+     * @todo To be moved in PayPalOrderPresenter
+     *
      * @return string|null
      */
     public function getStatus()
@@ -123,6 +129,8 @@ class PaypalOrder
     }
 
     /**
+     * @todo To be moved in PayPalTransactionPresenter
+     *
      * @return array
      */
     public function getTransactions()
@@ -171,6 +179,12 @@ class PaypalOrder
                     ];
                 }
             }
+        }
+
+        if (!empty($transactions)) {
+            uasort($transactions, function (array $transactionA, array $transactionB) {
+                return strtotime($transactionB['date']) - strtotime($transactionA['date']);
+            });
         }
 
         return $transactions;

--- a/classes/PaypalOrder.php
+++ b/classes/PaypalOrder.php
@@ -83,4 +83,96 @@ class PaypalOrder
     {
         $this->order = $order;
     }
+
+    /**
+     * @return bool
+     */
+    public function isLoaded()
+    {
+        return false === empty($this->order);
+    }
+
+    /**
+     * Returns PayPal Order Id
+     *
+     * @return string|null
+     */
+    public function getId()
+    {
+        return isset($this->order['id']) ? $this->order['id'] : null;
+    }
+
+    /**
+     * Returns PayPal Order intent
+     *
+     * @return string|null
+     */
+    public function getIntent()
+    {
+        return isset($this->order['intent']) ? $this->order['intent'] : null;
+    }
+
+    /**
+     * Returns PayPal Order status
+     *
+     * @return string|null
+     */
+    public function getStatus()
+    {
+        return isset($this->order['status']) ? $this->order['status'] : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTransactions()
+    {
+        if (empty($this->order['purchase_units'])) {
+            return [];
+        }
+
+        $transactions = [];
+
+        foreach ($this->order['purchase_units'] as $purchase) {
+            if (empty($purchase['payments'])) {
+                continue;
+            }
+
+            $totalRefunded = 0;
+
+            if (!empty($purchase['payments']['refunds'])) {
+                foreach ($purchase['payments']['refunds'] as $refund) {
+                    $totalRefunded += $refund['amount']['value'];
+                    $transactions[] = [
+                        'type' => 'refund',
+                        'id' => $refund['id'],
+                        'status' => $refund['status'],
+                        'amount' => $refund['amount']['value'],
+                        'currency' => $refund['amount']['currency_code'],
+                        'date' => (new \DateTime($refund['create_time']))->format('Y-m-d H:i:s'),
+                        'isRefundable' => false,
+                        'maxAmountRefundable' => 0,
+                    ];
+                }
+            }
+
+            if (!empty($purchase['payments']['captures'])) {
+                foreach ($purchase['payments']['captures'] as $payment) {
+                    $maxAmountRefundable = $payment['amount']['value'] - $totalRefunded;
+                    $transactions[] = [
+                        'type' => 'capture',
+                        'id' => $payment['id'],
+                        'status' => $payment['status'],
+                        'amount' => $payment['amount']['value'],
+                        'currency' => $payment['amount']['currency_code'],
+                        'date' => (new \DateTime($payment['create_time']))->format('Y-m-d H:i:s'),
+                        'isRefundable' => in_array($payment['status'], ['COMPLETED', 'PARTIALLY_REFUNDED']),
+                        'maxAmountRefundable' => $maxAmountRefundable > 0 ? $maxAmountRefundable : 0,
+                    ];
+                }
+            }
+        }
+
+        return $transactions;
+    }
 }

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -60,10 +60,10 @@ class OrderDispatcher implements Dispatcher
             return false;
         }
 
-        if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REFUNED
-            || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REVERSED) {
-            return $this->dispatchPaymentAction($payload['eventType'], $payload['resource'], $psOrderId);
-        }
+//        if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REFUNED
+//            || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REVERSED) {
+//            return $this->dispatchPaymentAction($payload['eventType'], $payload['resource'], $psOrderId);
+//        }
 
         if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_COMPLETED
             || $payload['eventType'] === self::PS_CHECKOUT_PAYMENT_DENIED

--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -19,7 +19,6 @@
  */
 use PrestaShop\Module\PrestashopCheckout\Handler\CreatePaypalOrderHandler;
 use PrestaShop\Module\PrestashopCheckout\PaypalCountryCodeMatrice;
-use PrestaShop\Module\PrestashopCheckout\PaypalOrder;
 
 class ps_checkoutExpressCheckoutModuleFrontController extends ModuleFrontController
 {

--- a/upgrade/upgrade-1.4.0.php
+++ b/upgrade/upgrade-1.4.0.php
@@ -50,5 +50,7 @@ function upgrade_module_1_4_0($module)
         }
     }
 
-    return $module->registerHook('displayAdminOrderLeft');
+    return $module->registerHook('displayAdminOrderLeft')
+        && $module->unregisterHook('actionOrderSlipAdd')
+        && $module->unregisterHook('actionOrderStatusUpdate');
 }

--- a/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/views/templates/hook/displayAdminOrderLeft.tpl
@@ -97,7 +97,7 @@
 <script>
   $(document).ready(function() {
     $(document).on('submit', '.orderPayPalRefundForm', function () {
-      let isApproved = confirm("{l s='Refund request will be sent to PayPal, you have to change PrestaShop order status yourself.' mod='ps_checkout'}");
+      let isApproved = confirm("{l s='Refund request will be sent to PayPal, you have to apply refund on PrestaShop yourself.' mod='ps_checkout'}");
 
       if (isApproved) {
         $('button[name="orderPayPalRefundSubmit"]').html('<i class="process-icon-loading"></i>').prop('disabled', true);

--- a/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/views/templates/hook/displayAdminOrderLeft.tpl
@@ -22,8 +22,88 @@
     <img src="{$moduleLogoUri|escape:'html':'UTF-8'}" alt="{$moduleName|escape:'html':'UTF-8'}" width="15" height="15">
     {$moduleName|escape:'html':'UTF-8'}
   </div>
-  <dl class="list-detail">
-    <dt>{l s='PayPal Order Id' mod='ps_checkout'}</dt>
-    <dd>{$paypalOrderId|escape:'html':'UTF-8'}</dd>
-  </dl>
+  {if $orderPayPalRefundSuccess}
+    <div class="alert alert-success">{$orderPayPalRefundSuccess|escape:'html':'UTF-8'}</div>
+  {/if}
+  {if $orderPayPalRefundErrors}
+    <div class="alert alert-danger">
+      <ul>
+        {foreach $orderPayPalRefundErrors as $orderPayPalRefundError}
+          <li>{$orderPayPalRefundError|escape:'html':'UTF-8'}</li>
+        {/foreach}
+      </ul>
+      {$orderPayPalRefundSuccess|escape:'html':'UTF-8'}
+    </div>
+  {/if}
+  <div class="row">
+    <div class="col-xs-6">
+      <strong>{l s='PayPal Order Id' mod='ps_checkout'}</strong> {$orderPayPalId|escape:'html':'UTF-8'}
+    </div>
+    <div class="col-xs-6">
+      <strong>{l s='PayPal Order Status' mod='ps_checkout'}</strong> {$orderPayPalStatus|escape:'html':'UTF-8'}
+    </div>
+  </div>
+  {if !empty($orderPayPalTransactions)}
+    <hr>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+        <tr>
+          <th><span class="title_box">{l s='Type' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Transaction ID' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Date' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Status' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Amount' mod='ps_checkout'}</span></th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {foreach $orderPayPalTransactions as $orderPayPalTransaction}
+          <tr>
+            <td>{$orderPayPalTransaction.type|escape:'html':'UTF-8'}</td>
+            <td>{$orderPayPalTransaction.id|escape:'html':'UTF-8'}</td>
+            <td>{dateFormat date=$orderPayPalTransaction.date full=true}</td>
+            <td>{$orderPayPalTransaction.status|escape:'html':'UTF-8'}</td>
+            <td>{$orderPayPalTransaction.amount|escape:'html':'UTF-8'} {$orderPayPalTransaction.currency|escape:'html':'UTF-8'}</td>
+            <td class="actions">
+              <a class="btn btn-default" target="_blank" href="https://www.paypal.com/activity/payment/{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">
+                <i class="icon-search"></i>
+                {l s='Details' mod='ps_checkout'}
+              </a>
+              {if $orderPayPalTransaction.isRefundable}
+                <hr>
+              <form class="form-horizontal form-inline orderPayPalRefundForm" method="post" action="{$orderPayPalRefundUrl|escape:'html':'UTF-8'}">
+                <input type="hidden" name="orderPayPalRefundTransaction" value="{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">
+                <input type="hidden" name="orderPayPalRefundCurrency" value="{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}">
+                <div class="input-group">
+                  <input name="orderPayPalRefundAmount" type="number" step=".01" min="0" max="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" value="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" class="form-control">
+                  <div id="orderPayPalRefundCurrencyContainer" class="input-group-addon">{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}</div>
+                </div>
+                <button type="submit" name="orderPayPalRefundSubmit" class="btn btn-default">
+                  <i class="icon-exchange"></i>
+                  {l s='Refund' mod='ps_checkout'}
+                </button>
+              </form>
+              {/if}
+            </td>
+          </tr>
+        {/foreach}
+        </tbody>
+      </table>
+    </div>
+  {/if}
 </div>
+
+<script>
+  $(document).ready(function() {
+    $(document).on('submit', '.orderPayPalRefundForm', function () {
+      let isApproved = confirm("{l s='Refund request will be sent to PayPal, you have to change PrestaShop order status yourself.' mod='ps_checkout'}");
+
+      if (isApproved) {
+        $('button[name="orderPayPalRefundSubmit"]').html('<i class="process-icon-loading"></i>').prop('disabled', true);
+      }
+
+      return isApproved;
+    });
+  });
+</script>

--- a/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/views/templates/hook/displayAdminOrderLeft.tpl
@@ -40,53 +40,99 @@
       <strong>{l s='PayPal Order Id' mod='ps_checkout'}</strong> {$orderPayPalId|escape:'html':'UTF-8'}
     </div>
     <div class="col-xs-6">
-      <strong>{l s='PayPal Order Status' mod='ps_checkout'}</strong> {$orderPayPalStatus|escape:'html':'UTF-8'}
+      <strong>{l s='PayPal Order Status' mod='ps_checkout'}</strong>
+      {* @todo To be moved in PayPalOrderPresenter *}
+      {if $orderPayPalStatus == 'CREATED'}
+        {l s='Created' mod='ps_checkout'}
+      {elseif $orderPayPalStatus == 'SAVED'}
+        {l s='Saved' mod='ps_checkout'}
+      {elseif $orderPayPalStatus == 'APPROVED'}
+        {l s='Approved' mod='ps_checkout'}
+      {elseif $orderPayPalStatus == 'VOIDED'}
+        {l s='Voided' mod='ps_checkout'}
+      {elseif $orderPayPalStatus == 'COMPLETED'}
+        {l s='Completed' mod='ps_checkout'}
+      {/if}
     </div>
   </div>
   {if !empty($orderPayPalTransactions)}
     <hr>
+    <p>{l s='See here all transactions linked to that order. If needed, send a refund request by entering the corresponding amount in the form just below.' mod='ps_checkout'}</p>
     <div class="table-responsive">
       <table class="table">
         <thead>
         <tr>
-          <th><span class="title_box">{l s='Type' mod='ps_checkout'}</span></th>
-          <th><span class="title_box">{l s='Transaction ID' mod='ps_checkout'}</span></th>
           <th><span class="title_box">{l s='Date' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Transaction ID' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Type' mod='ps_checkout'}</span></th>
           <th><span class="title_box">{l s='Status' mod='ps_checkout'}</span></th>
-          <th><span class="title_box">{l s='Amount' mod='ps_checkout'}</span></th>
+          <th><span class="title_box">{l s='Amount (Tax included)' mod='ps_checkout'}</span></th>
           <th></th>
         </tr>
         </thead>
         <tbody>
         {foreach $orderPayPalTransactions as $orderPayPalTransaction}
           <tr>
-            <td>{$orderPayPalTransaction.type|escape:'html':'UTF-8'}</td>
-            <td>{$orderPayPalTransaction.id|escape:'html':'UTF-8'}</td>
             <td>{dateFormat date=$orderPayPalTransaction.date full=true}</td>
-            <td>{$orderPayPalTransaction.status|escape:'html':'UTF-8'}</td>
+            <td>{$orderPayPalTransaction.id|escape:'html':'UTF-8'}</td>
+            <td>
+              {* @todo To be moved in PayPalTransactionPresenter *}
+              {if $orderPayPalTransaction.type == 'capture'}
+                <span class="span label label-inactive" style="background-color: #00B887">
+                  {l s='Payment' mod='ps_checkout'}
+                </span>
+              {elseif $orderPayPalTransaction.type == 'refund'}
+                <span class="span label label-inactive" style="background-color: #34219E">
+                  {l s='Refund' mod='ps_checkout'}
+                </span>
+              {/if}
+            </td>
+            <td>
+              {* @todo To be moved in PayPalTransactionPresenter *}
+              {if $orderPayPalTransaction.status == 'COMPLETED'}
+                  {l s='Completed' mod='ps_checkout'}
+              {elseif $orderPayPalTransaction.status == 'PENDING'}
+                  {l s='Pending' mod='ps_checkout'}
+              {elseif $orderPayPalTransaction.status == 'DECLINED'}
+                  {l s='Declined' mod='ps_checkout'}
+              {elseif $orderPayPalTransaction.status == 'PARTIALLY_REFUNDED'}
+                  {l s='Partially refunded' mod='ps_checkout'}
+              {elseif $orderPayPalTransaction.status == 'REFUNDED'}
+                  {l s='Refunded' mod='ps_checkout'}
+              {/if}
+            </td>
             <td>{$orderPayPalTransaction.amount|escape:'html':'UTF-8'} {$orderPayPalTransaction.currency|escape:'html':'UTF-8'}</td>
             <td class="actions">
               <a class="btn btn-default" target="_blank" href="https://www.paypal.com/activity/payment/{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">
                 <i class="icon-search"></i>
                 {l s='Details' mod='ps_checkout'}
               </a>
-              {if $orderPayPalTransaction.isRefundable}
-                <hr>
-              <form class="form-horizontal form-inline orderPayPalRefundForm" method="post" action="{$orderPayPalRefundUrl|escape:'html':'UTF-8'}">
-                <input type="hidden" name="orderPayPalRefundTransaction" value="{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">
-                <input type="hidden" name="orderPayPalRefundCurrency" value="{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}">
-                <div class="input-group">
-                  <input name="orderPayPalRefundAmount" type="number" step=".01" min="0" max="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" value="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" class="form-control">
-                  <div id="orderPayPalRefundCurrencyContainer" class="input-group-addon">{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}</div>
-                </div>
-                <button type="submit" name="orderPayPalRefundSubmit" class="btn btn-default">
-                  <i class="icon-exchange"></i>
-                  {l s='Refund' mod='ps_checkout'}
-                </button>
-              </form>
-              {/if}
             </td>
           </tr>
+          {if $orderPayPalTransaction.isRefundable}
+            <tr>
+              <td colspan="6" class="text-right">
+                <form class="form-horizontal form-inline orderPayPalRefundForm" method="post" action="{$orderPayPalRefundUrl|escape:'html':'UTF-8'}">
+                  <input type="hidden" name="orderPayPalRefundTransaction" value="{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">
+                  <input type="hidden" name="orderPayPalRefundCurrency" value="{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}">
+                  <div class="form-group">
+                    <label for="orderPayPalRefundAmount{$orderPayPalTransaction.id|escape:'html':'UTF-8'}">{l s='Choose amount to refund (tax included)' mod='ps_checkout'}</label>
+                    <div class="input-group">
+                      <input name="orderPayPalRefundAmount" id="orderPayPalRefundAmount{$orderPayPalTransaction.id|escape:'html':'UTF-8'}" type="number" step=".01" min="0" max="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" value="{$orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f"}" class="form-control">
+                      <div id="orderPayPalRefundCurrencyContainer" class="input-group-addon">{$orderPayPalTransaction.currency|escape:'html':'UTF-8'}</div>
+                    </div>
+                  </div>
+                  <button type="submit" name="orderPayPalRefundSubmit" class="btn btn-primary">
+                    <i class="icon-exchange"></i>
+                    {l s='Refund' mod='ps_checkout'}
+                  </button>
+                </form>
+                <span class="help-block">
+                  {l s='Maximum [AMOUNT_MAX] [CURRENCY] (tax included)' sprintf=['[AMOUNT_MAX]' => $orderPayPalTransaction.maxAmountRefundable|escape:'html':'UTF-8'|string_format:"%.2f", '[CURRENCY]' => $orderPayPalTransaction.currency|escape:'html':'UTF-8'] mod='ps_checkout'}
+                </span>
+              </td>
+            </tr>
+          {/if}
         {/foreach}
         </tbody>
       </table>
@@ -97,7 +143,7 @@
 <script>
   $(document).ready(function() {
     $(document).on('submit', '.orderPayPalRefundForm', function () {
-      let isApproved = confirm("{l s='Refund request will be sent to PayPal, you have to apply refund on PrestaShop yourself.' mod='ps_checkout'}");
+      let isApproved = confirm("{l s='Your transaction refund request will be sent to PayPal. After that, you\'ll still need to manually apply the refund registration in the PrestaShop order, to choose the type of refund and generate invoice.' mod='ps_checkout'}");
 
       if (isApproved) {
         $('button[name="orderPayPalRefundSubmit"]').html('<i class="process-icon-loading"></i>').prop('disabled', true);

--- a/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/views/templates/hook/displayAdminOrderLeft.tpl
@@ -32,7 +32,6 @@
           <li>{$orderPayPalRefundError|escape:'html':'UTF-8'}</li>
         {/foreach}
       </ul>
-      {$orderPayPalRefundSuccess|escape:'html':'UTF-8'}
     </div>
   {/if}
   <div class="row">


### PR DESCRIPTION
Improve PayPal Refund
- Remove hooks `actionOrderSlipAdd` & `actionOrderStatusUpdate`
- Disable PrestaShop refund by webhook
- Display PayPal Transactions in BO > Order > View with form to make a refund
- (Quickwin to be refactored with Service Container in another Pull Request)
- (I will add an PayPalOrderPresenter and PayPalOrderTransactionPresenter later)

I remove hooks because it cause too much malfunctions, in case of processing is too long due to some others modules hooked in it too. It's too hazardous for processing money.
Follow PayPal recommendations.

Now merchant have to make refund on PrestaShop himself, paypal refund request can be made on paypal account or with paypal refund form bellow

![displayAdminOrderLeft-initial](https://user-images.githubusercontent.com/5262628/78982890-5f3b1200-7b23-11ea-9d51-b2cc8a1b6b05.png)
![displayAdminOrderLeft-confirm](https://user-images.githubusercontent.com/5262628/78982904-6530f300-7b23-11ea-9edf-08b8dd9d791e.png)
![displayAdminOrderLeft-loading](https://user-images.githubusercontent.com/5262628/78982912-682be380-7b23-11ea-9f2e-dc75ba48f6d0.png)
![displayAdminOrderLeft-partial](https://user-images.githubusercontent.com/5262628/78982919-6b26d400-7b23-11ea-8005-b01d7e514632.png)
![displayAdminOrderLeft-final](https://user-images.githubusercontent.com/5262628/78982925-6e21c480-7b23-11ea-987b-b27176875ff6.png)
