### PR TITLE
Fix unsaved PayPal Order will cause fail of webhook

### DIFF
--- a/classes/ObjectModel/OrderMatrice.php
+++ b/classes/ObjectModel/OrderMatrice.php
@@ -39,48 +39,6 @@ class OrderMatrice extends \ObjectModel
     ];
 
     /**
-     * Save current object to database (add or update).
-     *
-     * @param bool $autoDate
-     * @param bool $nullValues
-     *
-     * @return bool
-     */
-    public function add($autoDate = true, $nullValues = false)
-    {
-        if (true === $this->alreadyExist()) {
-            return false;
-        }
-
-        return parent::add($autoDate, $nullValues);
-    }
-
-    /**
-     * Check if the Prestashop or Paypal Order Id already Exist to prevent duplicate ID entry
-     *
-     * @return bool
-     */
-    private function alreadyExist()
-    {
-        $wherePrestashopIdExist = '1';
-        $wherePaypalIdExist = '1';
-
-        if (null !== $this->id_order_prestashop) {
-            $wherePrestashopIdExist = 'pom.id_order_prestashop = "' . (int) $this->id_order_prestashop . '"';
-        }
-
-        if (null !== $this->id_order_paypal) {
-            $wherePaypalIdExist = 'pom.id_order_paypal = "' . pSQL($this->id_order_paypal) . '"';
-        }
-
-        $query = 'SELECT id_order_matrice
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE ' . $wherePrestashopIdExist . ' OR ' . $wherePaypalIdExist;
-
-        return (bool) \Db::getInstance()->getValue($query);
-    }
-
-    /**
      * Get the Prestashop Order Id from Paypal Order Id
      *
      * @param string $orderPaypal
@@ -89,9 +47,11 @@ class OrderMatrice extends \ObjectModel
      */
     public function getOrderPrestashopFromPaypal($orderPaypal)
     {
-        $query = 'SELECT id_order_prestashop
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE pom.id_order_paypal = "' . pSQL($orderPaypal) . '"';
+        $query = new \DbQuery();
+        $query->select('id_order_prestashop');
+        $query->from('pscheckout_order_matrice');
+        $query->where('id_order_paypal = "' . pSQL($orderPaypal) . '"');
+        $query->orderBy('id_order_matrice DESC');
 
         return (int) \Db::getInstance()->getValue($query);
     }
@@ -105,9 +65,11 @@ class OrderMatrice extends \ObjectModel
      */
     public function getOrderPaypalFromPrestashop($orderPrestashop)
     {
-        $query = 'SELECT id_order_paypal
-                FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice` pom
-                WHERE pom.id_order_prestashop = "' . (int) $orderPrestashop . '"';
+        $query = new \DbQuery();
+        $query->select('id_order_paypal');
+        $query->from('pscheckout_order_matrice');
+        $query->where('id_order_prestashop = ' . (int) $orderPrestashop);
+        $query->orderBy('id_order_matrice DESC');
 
         return \Db::getInstance()->getValue($query);
     }
@@ -127,9 +89,11 @@ class OrderMatrice extends \ObjectModel
         }
 
         // If more than one order found, there are inconsistencies for this order
-        return (bool) \Db::getInstance()->getValue('
-            SELECT COUNT(*)
-            FROM `' . _DB_PREFIX_ . 'pscheckout_order_matrice`
-            WHERE id_order_prestashop = ' . (int) $orderId);
+        $query = new \DbQuery();
+        $query->select('COUNT(*)');
+        $query->from('pscheckout_order_matrice');
+        $query->where('id_order_prestashop = ' . (int) $orderId);
+
+        return (bool) \Db::getInstance()->getValue($query);
     }
 }


### PR DESCRIPTION
Always save PayPal Order after a PrestaShop Order is created to avoid a webhook fail due to not found order.
`Error: order [PAYPAL ORDER] does not exist`

Due to PrestaShop Core split sometime a Cart in multiple Orders : https://github.com/PrestaShop/docs/issues/508