### PR TITLE
Fix date timezone received from PayPal

### DIFF
--- a/classes/Presenter/Date/DatePresenter.php
+++ b/classes/Presenter/Date/DatePresenter.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\PrestashopCheckout\Presenter\Date;
+
+class DatePresenter
+{
+    /**
+     * @var \DateTime
+     */
+    private $date;
+
+    /**
+     * @var string
+     */
+    private $format;
+
+    /**
+     * @param string $timestamp
+     * @param string $format
+     */
+    public function __construct($timestamp, $format)
+    {
+        $this->date = new \DateTime(
+            $timestamp,
+            $this->getTimeZone()
+        );
+        $this->format = $format;
+    }
+
+    /**
+     * @return string
+     */
+    public function present()
+    {
+        return $this->date->format($this->format);
+    }
+
+    /**
+     * @return \DateTimeZone
+     */
+    private function getTimeZone()
+    {
+        return new \DateTimeZone(\Configuration::get(
+            'PS_TIMEZONE',
+            null,
+            null,
+            null,
+            date_default_timezone_get()
+        ));
+    }
+}

--- a/classes/Presenter/Order/OrderPresenter.php
+++ b/classes/Presenter/Order/OrderPresenter.php
@@ -122,7 +122,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($refund['status']),
                         'amount' => $refund['amount']['value'],
                         'currency' => $refund['amount']['currency_code'],
-                        'date' => (new \DateTime($refund['create_time']))->format('Y-m-d H:i:s'),
+                        'date' => (new \DateTime($refund['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s'),
                         'isRefundable' => false,
                         'maxAmountRefundable' => 0,
                     ];
@@ -138,7 +138,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($payment['status']),
                         'amount' => $payment['amount']['value'],
                         'currency' => $payment['amount']['currency_code'],
-                        'date' => (new \DateTime($payment['create_time']))->format('Y-m-d H:i:s'),
+                        'date' => (new \DateTime($payment['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s'),
                         'isRefundable' => in_array($payment['status'], ['COMPLETED', 'PARTIALLY_REFUNDED']),
                         'maxAmountRefundable' => $maxAmountRefundable > 0 ? $maxAmountRefundable : 0,
                     ];

--- a/classes/Presenter/Order/OrderPresenter.php
+++ b/classes/Presenter/Order/OrderPresenter.php
@@ -20,6 +20,8 @@
 
 namespace PrestaShop\Module\PrestashopCheckout\Presenter\Order;
 
+use PrestaShop\Module\PrestashopCheckout\Presenter\Date\DatePresenter;
+
 class OrderPresenter
 {
     /**
@@ -122,7 +124,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($refund['status']),
                         'amount' => $refund['amount']['value'],
                         'currency' => $refund['amount']['currency_code'],
-                        'date' => (new \DateTime($refund['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s'),
+                        'date' => (new DatePresenter($refund['create_time'], 'Y-m-d H:i:s'))->present(),
                         'isRefundable' => false,
                         'maxAmountRefundable' => 0,
                     ];
@@ -138,7 +140,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($payment['status']),
                         'amount' => $payment['amount']['value'],
                         'currency' => $payment['amount']['currency_code'],
-                        'date' => (new \DateTime($payment['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s'),
+                        'date' => (new DatePresenter($payment['create_time'], 'Y-m-d H:i:s'))->present(),
                         'isRefundable' => in_array($payment['status'], ['COMPLETED', 'PARTIALLY_REFUNDED']),
                         'maxAmountRefundable' => $maxAmountRefundable > 0 ? $maxAmountRefundable : 0,
                     ];

--- a/classes/Presenter/Order/OrderPresenter.php
+++ b/classes/Presenter/Order/OrderPresenter.php
@@ -122,7 +122,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($refund['status']),
                         'amount' => $refund['amount']['value'],
                         'currency' => $refund['amount']['currency_code'],
-                        'date' => (new \DateTime($refund['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s'),
+                        'date' => (new \DateTime($refund['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s'),
                         'isRefundable' => false,
                         'maxAmountRefundable' => 0,
                     ];
@@ -138,7 +138,7 @@ class OrderPresenter
                         'status' => $this->getTransactionStatus($payment['status']),
                         'amount' => $payment['amount']['value'],
                         'currency' => $payment['amount']['currency_code'],
-                        'date' => (new \DateTime($payment['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s'),
+                        'date' => (new \DateTime($payment['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s'),
                         'isRefundable' => in_array($payment['status'], ['COMPLETED', 'PARTIALLY_REFUNDED']),
                         'maxAmountRefundable' => $maxAmountRefundable > 0 ? $maxAmountRefundable : 0,
                     ];

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -147,7 +147,7 @@ class OrderDispatcher implements Dispatcher
                 $order->payment,
                 $resource['id'],
                 \Currency::getCurrencyInstance(\Currency::getIdByIsoCode($resource['amount']['currency_code'])),
-                (new \DateTime($resource['create_time']))->format('Y-m-d H:i:s')
+                (new \DateTime($resource['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s')
             );
         }
 

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -147,7 +147,7 @@ class OrderDispatcher implements Dispatcher
                 $order->payment,
                 $resource['id'],
                 \Currency::getCurrencyInstance(\Currency::getIdByIsoCode($resource['amount']['currency_code'])),
-                (new \DateTime($resource['create_time'], new \DateTimeZone(date_default_timezone_get())))->format('Y-m-d H:i:s')
+                (new \DateTime($resource['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s')
             );
         }
 

--- a/classes/webHookDispatcher/OrderDispatcher.php
+++ b/classes/webHookDispatcher/OrderDispatcher.php
@@ -20,6 +20,8 @@
 
 namespace PrestaShop\Module\PrestashopCheckout;
 
+use PrestaShop\Module\PrestashopCheckout\Presenter\Date\DatePresenter;
+
 class OrderDispatcher implements Dispatcher
 {
     const PS_CHECKOUT_PAYMENT_REVERSED = 'PaymentCaptureReversed';
@@ -147,7 +149,7 @@ class OrderDispatcher implements Dispatcher
                 $order->payment,
                 $resource['id'],
                 \Currency::getCurrencyInstance(\Currency::getIdByIsoCode($resource['amount']['currency_code'])),
-                (new \DateTime($resource['create_time'], new \DateTimeZone(\Configuration::get('PS_TIMEZONE'))))->format('Y-m-d H:i:s')
+                (new DatePresenter($resource['create_time'], 'Y-m-d H:i:s'))->present()
             );
         }
 


### PR DESCRIPTION
PayPal send us `2020-05-06T08:11:59.692Z` we have to set timezone to have right date according to PrestaShop settings.

BO > International > Localization > Time zone