### PR TITLE
Fix notice on others modules configuration page

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -735,9 +735,7 @@ class Ps_checkout extends PaymentModule
      */
     public function hookDisplayAdminAfterHeader()
     {
-        $currentController = $this->context->controller->controller_name;
-
-        if ('AdminPayment' !== $currentController) {
+        if ('AdminPayment' !== Tools::getValue('controller')) {
             return false;
         }
 
@@ -763,11 +761,11 @@ class Ps_checkout extends PaymentModule
      */
     public function hookActionAdminControllerSetMedia()
     {
-        if ('AdminPayment' === $this->context->controller->controller_name) {
+        if ('AdminPayment' === Tools::getValue('controller')) {
             $this->context->controller->addCss($this->_path . 'views/css/adminAfterHeader.css');
         }
 
-        if ('AdminOrders' === $this->context->controller->controller_name) {
+        if ('AdminOrders' === Tools::getValue('controller')) {
             $this->context->controller->addJS($this->getPathUri() . 'views/js/adminOrderView.js?version=' . $this->version);
         }
     }


### PR DESCRIPTION
Weird case

![notice](https://user-images.githubusercontent.com/5262628/81161056-3d4e7700-8f8b-11ea-9f8f-4173815ac2cd.png)

`Tools::getValue('controller')` still work in migrated page