### PR TITLE
Fix default value for isPaymentMethodEnabled on PrestaShop 1.6

### DIFF
--- a/classes/Repository/PaypalAccountRepository.php
+++ b/classes/Repository/PaypalAccountRepository.php
@@ -279,12 +279,15 @@ class PaypalAccountRepository
      */
     private function isPaymentMethodEnabled($paymentMethod)
     {
+        if (false === \Configuration::hasKey($paymentMethod)) {
+            return true;
+        }
+
         return (bool) \Configuration::get(
             $paymentMethod,
             null,
             null,
-            (int) \Context::getContext()->shop->id,
-            true
+            (int) \Context::getContext()->shop->id
         );
     }
 }


### PR DESCRIPTION
On PrestaShop 1.6, no default value can be given to `Configuration::get()`