### PR TITLE
Improve logger

### DIFF
--- a/classes/Factory/CheckoutLogger.php
+++ b/classes/Factory/CheckoutLogger.php
@@ -37,9 +37,17 @@ class CheckoutLogger
             $path = _PS_ROOT_DIR_ . '/app/logs/ps_checkout';
         }
 
+        $isDebug = (bool) \Configuration::get(
+            'PS_CHECKOUT_DEBUG_LOGS_ENABLED',
+            null,
+            null,
+            (int) \Context::getContext()->shop->id
+        );
+
         $rotatingFileHandler = new RotatingFileHandler(
             $path,
-            static::MAX_FILES
+            static::MAX_FILES,
+            $isDebug ? Logger::DEBUG : Logger::ERROR
         );
         $logger = new Logger('ps_checkout');
         $logger->pushHandler($rotatingFileHandler);

--- a/classes/Faq/Faq.php
+++ b/classes/Faq/Faq.php
@@ -73,7 +73,9 @@ class Faq
         try {
             $response = $this->client->post($this->generateRoute());
         } catch (RequestException $e) {
-            \PrestaShopLogger::addLog($e->getMessage(), 1, null, null, null, true);
+            /** @var \Ps_checkout $module */
+            $module = \Module::getInstanceByName('ps_checkout');
+            $module->getLogger()->error($e->getMessage());
 
             if (!$e->hasResponse()) {
                 return false;

--- a/classes/Handler/CreatePaypalOrderHandler.php
+++ b/classes/Handler/CreatePaypalOrderHandler.php
@@ -96,6 +96,14 @@ class CreatePaypalOrderHandler
             }
         }
 
+        /** @var \Ps_checkout $module */
+        $module = \Module::getInstanceByName('ps_checkout');
+        $module->getLogger()->info(sprintf(
+            'Create PayPal Order %s from cart %s',
+            $paypalOrder['body']['id'],
+            $this->context->cart->id
+        ));
+
         return $paypalOrder;
     }
 }

--- a/classes/OrderStates.php
+++ b/classes/OrderStates.php
@@ -178,12 +178,14 @@ class OrderStates
      */
     private function setStateIcons($state, $orderStateId)
     {
+        /** @var \Ps_checkout $module */
+        $module = \Module::getInstanceByName('ps_checkout');
         $iconExtension = '.gif';
         $iconToPaste = _PS_ORDER_STATE_IMG_DIR_ . $orderStateId . $iconExtension;
 
         if (true === file_exists($iconToPaste)) {
             if (true !== is_writable($iconToPaste)) {
-                \PrestaShopLogger::addLog('[PSPInstall] ' . $iconToPaste . ' is not writable', 2, null, null, null, true);
+                $module->getLogger()->error('[PSPInstall] ' . $iconToPaste . ' is not writable');
 
                 return false;
             }
@@ -199,7 +201,7 @@ class OrderStates
         $iconToCopy = $iconsFolderOrigin . $iconName . $iconExtension;
 
         if (false === copy($iconToCopy, $iconToPaste)) {
-            \PrestaShopLogger::addLog('[PSPInstall] not able to copy ' . $iconName . ' for ID ' . $orderStateId, 2, null, null, null, true);
+            $module->getLogger()->error('[PSPInstall] not able to copy ' . $iconName . ' for ID ' . $orderStateId);
         }
     }
 }

--- a/classes/Refund.php
+++ b/classes/Refund.php
@@ -246,6 +246,8 @@ class Refund
      * @param string $transactionId
      *
      * @return bool
+     *
+     * @throws PsCheckoutException
      */
     private function refundPrestashopOrder(\Order $order, $orderProductList, $orderStateId, $transactionId)
     {
@@ -297,6 +299,8 @@ class Refund
      * @param string $paypalTransactionId
      *
      * @return bool
+     *
+     * @throws PsCheckoutException
      */
     public function addOrderPayment(\Order $order, $paypalTransactionId)
     {
@@ -305,9 +309,7 @@ class Refund
         $orderPayments = $order->getOrderPaymentCollection();
         foreach ($orderPayments as $orderPayment) {
             if ($orderPayment->transaction_id === $paypalTransactionId) {
-                $message = sprintf('This PayPal transaction is already saved : %s', $orderPayment->transaction_id);
-                \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-                throw new PsCheckoutException($message);
+                throw new PsCheckoutException(sprintf('This PayPal transaction is already saved : %s', $orderPayment->transaction_id));
             }
         }
 

--- a/classes/WebHookNock.php
+++ b/classes/WebHookNock.php
@@ -35,7 +35,10 @@ class WebHookNock
         headers_list();
 
         $bodyReturn = json_encode($headerDatas);
-        \PrestaShopLoggerCore::addLog('[PSPwebhook] ' . $bodyReturn, 3, null, null, null, true);
+
+        /** @var \Ps_checkout $module */
+        $module = \Module::getInstanceByName('ps_checkout');
+        $module->getLogger()->error($bodyReturn);
 
         echo $bodyReturn;
     }

--- a/classes/WebHookOrder.php
+++ b/classes/WebHookOrder.php
@@ -76,6 +76,8 @@ class WebHookOrder
      * refund the order and update the resource status
      *
      * @return bool
+     *
+     * @throws PsCheckoutException
      */
     public function updateOrder()
     {
@@ -86,9 +88,7 @@ class WebHookOrder
         $orderPayments = $order->getOrderPaymentCollection();
         foreach ($orderPayments as $orderPayment) {
             if ($orderPayment->transaction_id === $this->paypalTransactionId) {
-                $message = sprintf('This PayPal transaction is already saved : %s', $this->paypalTransactionId);
-                \PrestaShopLogger::addLog($message, 1, null, null, null, true);
-                throw new PsCheckoutException($message);
+                throw new PsCheckoutException(sprintf('This PayPal transaction is already saved : %s', $this->paypalTransactionId));
             }
         }
 

--- a/controllers/front/ValidateOrder.php
+++ b/controllers/front/ValidateOrder.php
@@ -17,13 +17,15 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-use PrestaShop\Module\PrestashopCheckout\Api\Payment\Order;
 use PrestaShop\Module\PrestashopCheckout\Handler\CreatePaypalOrderHandler;
 use PrestaShop\Module\PrestashopCheckout\Repository\PaypalAccountRepository;
 use PrestaShop\Module\PrestashopCheckout\ValidateOrder;
 
 class ps_checkoutValidateOrderModuleFrontController extends ModuleFrontController
 {
+    /** @var Ps_checkout */
+    public $module;
+
     public function initContent()
     {
         if ($this->checkIfContextIsValid()) {
@@ -51,6 +53,14 @@ class ps_checkoutValidateOrderModuleFrontController extends ModuleFrontControlle
         }
 
         $isExpressCheckout = (bool) Tools::getValue('isExpressCheckout');
+
+        $this->module->getLogger()->info(sprintf(
+            'ValidateOrder PayPal Order Id : %s Payment Method : %s Express Checkout : %s Cart : %s',
+            $paypalOrderId,
+            $paymentMethod,
+            $isExpressCheckout ? 'true' : 'false',
+            Validate::isLoadedObject($this->context->cart) ? (int) $this->context->cart->id : 0
+        ));
 
         if ($isExpressCheckout) {
             // API call here

--- a/upgrade/upgrade-1.2.9.php
+++ b/upgrade/upgrade-1.2.9.php
@@ -49,7 +49,7 @@ function removeFromFsDuringUpgrade(array $files)
 /**
  * Update main function for module Version 1.2.9
  *
- * @param Module $module
+ * @param Ps_checkout $module
  *
  * @return bool
  */
@@ -63,7 +63,7 @@ function upgrade_module_1_2_9($module)
     if (file_exists($path)) {
         $result = removeFromFsDuringUpgrade([$path]);
         if ($result !== true) {
-            PrestaShopLogger::addLog('Could not delete PHPUnit from module. ' . $result, 3);
+            $module->getLogger()->error('Could not delete PHPUnit from module.');
 
             return false;
         }


### PR DESCRIPTION
Quickwin for QA Team

If debug option is enabled in module configuration, logger level is set to `DEBUG` else `ERROR`

Remove all usage of `PrestaShopLogger` to use our `CheckoutLogger` based on `Monolog\Logger`.

Please note, Logger Service is totally refactored in v2.0.0
