### PR TITLE
Fix fatal error on API Client

### DIFF
--- a/classes/Api/GenericClient.php
+++ b/classes/Api/GenericClient.php
@@ -204,16 +204,18 @@ class GenericClient
         $httpCode = 500;
         $hasResponse = method_exists($exception, 'hasResponse') ? $exception->hasResponse() : false;
 
-        if (method_exists($exception, 'getResponse')) {
+        if (true === $hasResponse && method_exists($exception, 'getResponse')) {
             $body = $exception->getResponse()->getBody();
             $httpCode = $exception->getResponse()->getStatusCode();
         }
 
         $module->getLogger()->error('route ' . $this->getRoute());
         $module->getLogger()->error('options ' . var_export($options, true));
+
         if ($hasResponse) {
             $module->getLogger()->error('body ' . $body);
         }
+
         $module->getLogger()->error('exception ' . $exception->getMessage());
 
         return [


### PR DESCRIPTION
Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getBody() on null in /modules/ps_checkout/classes/Api/GenericClient.php:208