### PR TITLE
Fix Cart Presenter - Customer not found in some case

### DIFF
--- a/classes/Builder/Payload/OrderPayloadBuilder.php
+++ b/classes/Builder/Payload/OrderPayloadBuilder.php
@@ -225,7 +225,7 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
                 'given_name' => $this->cart['addresses']['invoice']->firstname,
                 'surname' => $this->cart['addresses']['invoice']->lastname,
             ],
-            'email_address' => $this->cart['customer']->email,
+            'email_address' => (string) $this->cart['customer']->email,
             'address' => [
                 'address_line_1' => $this->cart['addresses']['invoice']->address1,
                 'address_line_2' => (string) $this->cart['addresses']['invoice']->address2,

--- a/classes/Handler/CreatePaypalOrderHandler.php
+++ b/classes/Handler/CreatePaypalOrderHandler.php
@@ -53,7 +53,7 @@ class CreatePaypalOrderHandler
     public function handle($expressCheckout = false, $updateOrder = false, $paypalOrderId = null)
     {
         // Present an improved cart in order to create the payload
-        $cartPresenter = (new CartPresenter($this->context))->present();
+        $cartPresenter = (new CartPresenter())->present();
 
         $builder = new OrderPayloadBuilder($cartPresenter);
 


### PR DESCRIPTION
If guest checkout is enabled in BO > Shop Parameters > Order settings, sometimes we need to find guest created in `Customer` with `id_customer` of `Cart` instead of `Context` to retrieve email.
```
Invalid request payload input. child "Payer" fails because
[child "email_address" fails because ["email_address" must be a string]].
{"value":null,"key":"email_address","label":"email_address"}
````