### PR TITLE
Fix missing checkboxes for currency restrictions

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -117,6 +117,8 @@ class Ps_checkout extends PaymentModule
         $this->version = '1.5.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
+        $this->currencies = true;
+        $this->currencies_mode = 'checkbox';
 
         $this->module_key = '82bc76354cfef947e06f1cc78f5efe2e';
 


### PR DESCRIPTION
### PrestaShop 1.6

BO > Modules > Payment

#### Before
![before](https://user-images.githubusercontent.com/5262628/83261290-62fe2300-a1bb-11ea-9208-12bade5d55b8.png)


#### After
![after](https://user-images.githubusercontent.com/5262628/83261300-68f40400-a1bb-11ea-8a2d-8c8ec4b597bf.png)
