### PR TITLE
Fix display of PayPal buttons on PrestaShop 1.6

### DIFF
--- a/views/templates/front/paymentPaypalConfirmation.tpl
+++ b/views/templates/front/paymentPaypalConfirmation.tpl
@@ -61,7 +61,7 @@
     <p>
       - {l s='Please confirm your order by clicking on the method you want to pay with.' mod='ps_checkout'}
     </p>
-
+    <div id="paypal-button-container" style="width: 300px; margin-top: 20px;"></div>
   </div>
 
   <div class="cart_navigation clearfix" id="cart_navigation">
@@ -69,8 +69,6 @@
       <a class="button-exclusive btn btn-default" href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}">
         <i class="icon-chevron-left"></i>{l s='Other payment methods' mod='ps_checkout'}
       </a>
-    </div>
-    <div id="paypal-button-container">
     </div>
   </div>
 </form>


### PR DESCRIPTION
### Fix display of PayPal buttons on PrestaShop 1.6

#### Before
![before](https://user-images.githubusercontent.com/5262628/83264148-f76a8480-a1bf-11ea-8a6d-01cbea7c64ce.png)

#### After
![after](https://user-images.githubusercontent.com/5262628/83264157-fb96a200-a1bf-11ea-8f39-8fc3b84e25ed.png)
