### PR TITLE
Fix currency restrictions

### DIFF
--- a/upgrade/upgrade-1.5.0.php
+++ b/upgrade/upgrade-1.5.0.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Update main function for module Version 1.5.0
+ *
+ * @param Ps_checkout $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_5_0($module)
+{
+    if (empty(Currency::checkPaymentCurrencies($module->id))) {
+        return 'checkbox' === $module->currencies_mode ? $module->addCheckboxCurrencyRestrictionsForModule() : $module->addRadioCurrencyRestrictionsForModule();
+    }
+
+    return true;
+}


### PR DESCRIPTION
If no data are found in ps_module_currency table, PrestaShop Core will adds currencies linked to ps_checkout.

This is already done on module install and when new shop is created (multistore)