### PR TITLE
Adds exception when PrestaShop fail to returns Order identifier

### DIFF
--- a/classes/Exception/PsCheckoutException.php
+++ b/classes/Exception/PsCheckoutException.php
@@ -52,4 +52,5 @@ class PsCheckoutException extends \PrestaShopExceptionCore
     const PAYPAL_PAYMENT_METHOD_MISSING = 28;
     const PAYPAL_PAYMENT_CARD_ERROR = 29;
     const PAYPAL_PAYMENT_CAPTURE_DECLINED = 30;
+    const PRESTASHOP_ORDER_ID_MISSING = 31;
 }

--- a/classes/ValidateOrder.php
+++ b/classes/ValidateOrder.php
@@ -139,6 +139,10 @@ class ValidateOrder
             $payload['secureKey']
         );
 
+        if (empty($module->currentOrder)) {
+            throw new PsCheckoutException(sprintf('PrestaShop was unable to returns Prestashop Order ID for Prestashop Cart ID : %s  - Paypal Order ID : %s. This happens when PrestaShop take too long time to create an Order due to heavy processes in hooks actionValidateOrder and/or actionOrderStatusUpdate and/or actionOrderStatusPostUpdate', $payload['cartId'], $this->paypalOrderId), PsCheckoutException::PRESTASHOP_ORDER_ID_MISSING);
+        }
+
         if (false === $this->setOrdersMatrice($module->currentOrder, $this->paypalOrderId)) {
             throw new PsCheckoutException(sprintf('Set Order Matrice error for Prestashop Order ID : %s and Paypal Order ID : %s', $module->currentOrder, $this->paypalOrderId), PsCheckoutException::PSCHECKOUT_ORDER_MATRICE_ERROR);
         }


### PR DESCRIPTION
Sometimes `PaymentModule::validateOrder` fail due to timeout caused by heavy processes in hooks `actionValidateOrder` and/or `actionOrderStatusUpdate` and/or `actionOrderStatusPostUpdate` 

In this case, `PaymentModule::$currentOrder` is empty and will cause fail of PrestaShop Checkout end processing...

Merchant should go to BO > Design > Positions, check option `Display non-positionable hooks` and search modules hooked on :
1. actionValidateOrder
2. actionOrderStatusUpdate
3. actionOrderStatusPostUpdate

Then disable modules use bad practices like API Calls without timeout setted