### PR TITLE
Handle NO_EXTERNAL_FUNDING_DETAILS_FOUND

### DIFF
--- a/controllers/front/ValidateOrder.php
+++ b/controllers/front/ValidateOrder.php
@@ -237,6 +237,7 @@ class ps_checkoutValidateOrderModuleFrontController extends ModuleFrontControlle
             case PayPalException::REDIRECT_PAYER_FOR_ALTERNATE_FUNDING:
             case PayPalException::TRANSACTION_BLOCKED_BY_PAYEE:
             case PayPalException::TRANSACTION_REFUSED:
+            case PayPalException::NO_EXTERNAL_FUNDING_DETAILS_FOUND:
                 $this->redirectToCheckout(['step' => 'payment', 'paymentError' => $exception->getCode()]);
                 break;
             case PayPalException::ORDER_ALREADY_CAPTURED:


### PR DESCRIPTION
Allow customer to use another payment method when Alternative payment method is not available