### PR TITLE
Fix ampersand escape on first versions 1.7

### DIFF
--- a/views/templates/front/expressCheckout.tpl
+++ b/views/templates/front/expressCheckout.tpl
@@ -17,9 +17,9 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<script type="text/javascript" src="{$jsExpressCheckoutPath|escape:'javascript':'UTF-8'}"></script>
+<script type="text/javascript" src="{$jsExpressCheckoutPath|escape:'javascript':'UTF-8'|replace:'&amp;':'&'}"></script>
 
-<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'}" as="script">
+<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&'}" as="script">
 
 <div id="pscheckout-express-checkout" style="display:none;">
   {if $displayMode eq 'cart'}
@@ -53,10 +53,10 @@
 </style>
 
 <script>
-  const checkoutLink = "{$checkoutLink|escape:'javascript':'UTF-8' nofilter}";
+  const checkoutLink = "{$checkoutLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
   const displayMode = "{$displayMode|escape:'javascript':'UTF-8'}";
   const isPs176 = "{$isPs176|escape:'javascript':'UTF-8'}";
-  const expressCheckoutController = "{$expressCheckoutController|escape:'javascript':'UTF-8' nofilter}";
+  const expressCheckoutController = "{$expressCheckoutController|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
   const paypalIsActive = "{$paypalIsActive|escape:'javascript':'UTF-8'}";
   /**
    * Load paypal script
@@ -73,7 +73,7 @@
     }
 
     const paypalScript = document.createElement('script');
-    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8' nofilter}");
+    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}");
     paypalScript.setAttribute('id', 'psCheckoutPaypalSdk');
     paypalScript.setAttribute('data-namespace', 'paypalSdkPsCheckoutEC');
     paypalScript.setAttribute('data-enable-3ds', '');

--- a/views/templates/front/paymentCardConfirmation.tpl
+++ b/views/templates/front/paymentCardConfirmation.tpl
@@ -17,7 +17,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'}" as="script">
+<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&'}" as="script">
 
 {capture name=path}
 <a href="{$link->getPageLink('order', true, NULL, 'step=3')|escape:'html':'UTF-8'}" title="{l s='Go back to the Checkout' mod='ps_checkout'}">
@@ -133,8 +133,8 @@
   const expDatePlaceholder = "{l s='MM/YY' mod='ps_checkout'}";
   const cvvPlaceholder = "{l s='XXX' mod='ps_checkout'}";
   const paypalOrderId = "{$paypalOrderId|escape:'javascript':'UTF-8'}";
-  const validateOrderLinkByCard = "{$validateOrderLinkByCard|escape:'javascript':'UTF-8' nofilter}";
-  const hostedFieldsErrors = {$hostedFieldsErrors|escape:'javascript':'UTF-8'|stripslashes nofilter};
+  const validateOrderLinkByCard = "{$validateOrderLinkByCard|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
+  const hostedFieldsErrors = {$hostedFieldsErrors|escape:'javascript':'UTF-8'|stripslashes|replace:'&amp;':'&' nofilter};
 
   /**
    * Create paypal script
@@ -151,7 +151,7 @@
     }
 
     const paypalScript = document.createElement('script');
-    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8' nofilter}");
+    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}");
     paypalScript.setAttribute('data-client-token', "{$clientToken|escape:'javascript':'UTF-8'}");
     paypalScript.setAttribute('id', 'psCheckoutPaypalSdk');
     paypalScript.setAttribute('data-namespace', 'paypalSdkPsCheckout');

--- a/views/templates/front/paymentOptions/paypal.tpl
+++ b/views/templates/front/paymentOptions/paypal.tpl
@@ -17,7 +17,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<link rel="preload" href="{$paypalSdkLink|escape:'htmlall':'UTF-8'}" as="script">
+<link rel="preload" href="{$paypalSdkLink|escape:'htmlall':'UTF-8'|replace:'&amp;':'&'}" as="script">
 
 <div class="paypal-tips">{l s='You will be redirected to the related gateway to complete payment' mod='ps_checkout'}</div>
 
@@ -40,19 +40,19 @@
   </article>
 </div>
 
-<script type="text/javascript" src="{$jsPathInitPaypalSdk|escape:'javascript':'UTF-8' nofilter}"></script>
+<script type="text/javascript" src="{$jsPathInitPaypalSdk|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}"></script>
 
 <script>
   const cardNumberPlaceholder = "{l s='Card number' mod='ps_checkout'}";
   const expDatePlaceholder = "{l s='MM/YY' mod='ps_checkout'}";
   const cvvPlaceholder = "{l s='XXX' mod='ps_checkout'}";
   const paypalOrderId = "{$paypalOrderId|escape:'javascript':'UTF-8'}";
-  const validateOrderLinkByCard = "{$validateOrderLinkByCard|escape:'javascript':'UTF-8' nofilter}";
-  const validateOrderLinkByPaypal = "{$validateOrderLinkByPaypal|escape:'javascript':'UTF-8' nofilter}";
+  const validateOrderLinkByCard = "{$validateOrderLinkByCard|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
+  const validateOrderLinkByPaypal = "{$validateOrderLinkByPaypal|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
   const cardIsActive = "{$cardIsActive|escape:'javascript':'UTF-8'}";
   const paypalIsActive = "{$paypalIsActive|escape:'javascript':'UTF-8'}";
   const paypalPaymentOption = "{$paypalPaymentOption|escape:'javascript':'UTF-8'}";
-  const hostedFieldsErrors = {$hostedFieldsErrors|escape:'javascript':'UTF-8'|stripslashes nofilter};
+  const hostedFieldsErrors = {$hostedFieldsErrors|escape:'javascript':'UTF-8'|stripslashes|replace:'&amp;':'&' nofilter};
 /**
  * Create paypal script
  */
@@ -68,7 +68,7 @@ function initPaypalScript() {
   }
 
   const paypalScript = document.createElement('script');
-  paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8' nofilter}");
+  paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}");
   paypalScript.setAttribute('data-client-token', "{$clientToken|escape:'javascript':'UTF-8'}");
   paypalScript.setAttribute('id', 'psCheckoutPaypalSdk');
   paypalScript.setAttribute('data-namespace', 'paypalSdkPsCheckout');

--- a/views/templates/front/paymentPaypalConfirmation.tpl
+++ b/views/templates/front/paymentPaypalConfirmation.tpl
@@ -17,7 +17,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'}" as="script">
+<link rel="preload" href="{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&'}" as="script">
 
 {capture name=path}
 <a href="{$link->getPageLink('order', true, NULL, 'step=3')|escape:'html':'UTF-8'}" title="{l s='Go back to the Checkout' mod='ps_checkout'}">

--- a/views/templates/front/paymentPaypalConfirmation.tpl
+++ b/views/templates/front/paymentPaypalConfirmation.tpl
@@ -76,7 +76,7 @@
 
 <script>
   const paypalOrderId = "{$paypalOrderId|escape:'javascript':'UTF-8'}";
-  const validateOrderLinkByPaypal = "{$validateOrderLinkByPaypal|escape:'javascript':'UTF-8' nofilter}";
+  const validateOrderLinkByPaypal = "{$validateOrderLinkByPaypal|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}";
   /**
    * Create paypal script
    */
@@ -92,7 +92,7 @@
     }
 
     const paypalScript = document.createElement('script');
-    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8' nofilter}");
+    paypalScript.setAttribute('src', "{$paypalSdkLink|escape:'javascript':'UTF-8'|replace:'&amp;':'&' nofilter}");
     paypalScript.setAttribute('data-client-token', "{$clientToken|escape:'javascript':'UTF-8'}");
     paypalScript.setAttribute('id', 'psCheckoutPaypalSdk');
     paypalScript.setAttribute('data-namespace', 'paypalSdkPsCheckout');


### PR DESCRIPTION
Some feedbacks about ampersand escape cause broken links on first PrestaShop versions 1.7
No problem with 1.6 and 1.7 latest