### PR TITLE
MultiShop: init configuration with default value

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -975,6 +975,7 @@ class Ps_checkout extends PaymentModule
         $shop = $params['object'];
 
         (new PrestaShop\Module\PrestashopCheckout\ShopUuidManager())->generateForShop((int) $shop->id);
+        $this->installConfiguration();
         $this->addCheckboxCarrierRestrictionsForModule([(int) $shop->id]);
         $this->addCheckboxCountryRestrictionsForModule([(int) $shop->id]);
         if ($this->currencies_mode === 'checkbox') {

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -176,7 +176,7 @@ class Ps_checkout extends PaymentModule
         foreach (\Shop::getShops(false, null, true) as $shopId) {
             foreach ($this->configurationList as $name => $value) {
                 if (false === Configuration::hasKey($name, null, null, (int) $shopId)) {
-                    $result = $result && Configuration::updateValue(
+                    $result = $result && (bool) Configuration::updateValue(
                         $name,
                         $value,
                         false,


### PR DESCRIPTION
After new Shop creation, init configuration for new Shop with default value.
Existing Configuration will not be overridden, missing will be generated.