### PR TITLE
Update event condition for building artifact

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,10 +1,6 @@
 name: Build & Release draft
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   deploy:
@@ -30,7 +26,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     needs: [deploy]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
This PR allows artifact to be build on all branches, not only master.

It still takes care to NOT upload it on the release draft until we push to the `branch` master.