### PR TITLE
Remove 'disabled' attribute from payment confirmation button at check…

### DIFF
--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -43,6 +43,8 @@
 
       if ('ps_checkout_expressCheckout' === paymentOptionName) {
         paymentOption.click();
+        const paymentConfirmationButton = document.querySelector('#payment-confirmation button');
+        paymentConfirmationButton.removeAttribute('disabled');
       } else {
         paymentOption.disabled = true;
         paymentOptionContainer.style.display = 'none';


### PR DESCRIPTION
This PR aims to fix an issue where the payment approval button stays greyed out when using paypal express checkout.
Not sure if this is the right way to go about it, but it fixed my problems.