### PR TITLE
Add workflow to publish on the marketplace (with debug)

### DIFF
--- a/.github/mktp-metadata.json
+++ b/.github/mktp-metadata.json
@@ -1,0 +1,9 @@
+{
+    "id_product" : "46347",
+    "technical_name" : "ps_checkout",
+    "display_name" : "PrestaShop Checkout",
+    "channel" : "stable",
+    "type_upgrade" : "updatemin",
+    "product_type" : "module",
+    "compatible_from" : "1.6.1.0"
+}

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -1,0 +1,31 @@
+name: Publish to the Marketplace
+
+on:
+  release:
+    action: [released]
+
+jobs:
+  publish_to_marketplace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Download release asset
+        uses: dsaltares/fetch-gh-release-asset@0.0.4
+        with:
+          repo: ${{ github.event.repository.full_name }}
+          version: ${{ github.event.release.id }}
+          file: ${{ github.event.repository.name }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare publishing tool
+        run: |
+          composer global require prestashop/publish-on-marketplace
+
+      - name: Release zip
+        run: |
+          ~/.composer/vendor/bin/publish-on-marketplace --archive=$PWD/${{ github.event.repository.name }}.zip --metadata-json=$PWD/.github/mktp-metadata.json --changelog="${{ github.event.release.body }}" --debug
+        env:
+          MARKETPLACE_API_KEY: ${{ secrets.MARKETPLACE_API_KEY }}


### PR DESCRIPTION
This PR adds a workflow allowing maintainers to push  new release directly on the marketplace as soon as the release has been created on GitHub