### PR TITLE
New lib version (PS Accounts integration)

### DIFF
--- a/_dev/package.json
+++ b/_dev/package.json
@@ -14,7 +14,7 @@
     "core-js": "^3.4.3",
     "lodash": "^4.17.15",
     "prestakit": "^1.1.0",
-    "prestashop_accounts_vue_components": "^1.1.0",
+    "prestashop_accounts_vue_components": "^1.1.1",
     "vue": "^2.6.10",
     "vue-i18n": "^8.15.3",
     "vue-router": "^3.1.3",


### PR DESCRIPTION
Use lib v1.1.1 for VueJS components.
Feel free to implement this update into your most recent branch that contains the PS Accounts integration.