### PR TITLE
Fix cURL Error 60 : Provide cacert used by PrestaShop

### DIFF
--- a/src/Api/Firebase/Client/FirebaseClient.php
+++ b/src/Api/Firebase/Client/FirebaseClient.php
@@ -46,6 +46,7 @@ class FirebaseClient extends GenericClient
 
         $client = new Client([
             'defaults' => [
+                'verify' => $this->getVerify(),
                 'timeout' => $this->timeout,
                 'exceptions' => $this->catchExceptions,
                 'allow_redirects' => false,

--- a/src/Api/GenericClient.php
+++ b/src/Api/GenericClient.php
@@ -282,4 +282,18 @@ class GenericClient
             'exceptionMessage' => $exception->getMessage(),
         ];
     }
+
+    /**
+     * @see https://docs.guzzlephp.org/en/5.3/clients.html#verify
+     *
+     * @return true|string
+     */
+    protected function getVerify()
+    {
+        if (defined('_PS_CACHE_CA_CERT_FILE_')) {
+            return constant('_PS_CACHE_CA_CERT_FILE_');
+        }
+
+        return true;
+    }
 }

--- a/src/Api/Payment/Client/PaymentClient.php
+++ b/src/Api/Payment/Client/PaymentClient.php
@@ -41,6 +41,7 @@ class PaymentClient extends GenericClient
             $client = new Client([
                 'base_url' => (new PaymentEnv())->getPaymentApiUrl(),
                 'defaults' => [
+                    'verify' => $this->getVerify(),
                     'timeout' => $this->timeout,
                     'exceptions' => $this->catchExceptions,
                     'headers' => [

--- a/src/Api/Psx/Client/PsxClient.php
+++ b/src/Api/Psx/Client/PsxClient.php
@@ -33,6 +33,7 @@ class PsxClient extends GenericClient
         $client = new Client([
             'base_url' => (new PsxEnv())->getPsxApiUrl(),
             'defaults' => [
+                'verify' => $this->getVerify(),
                 'timeout' => $this->getTimeout(),
                 'exceptions' => $this->getExceptionsMode(),
                 'headers' => [


### PR DESCRIPTION
Fix `cURL error 60: SSL certificate problem: unable to get local issuer certificate`
See https://docs.guzzlephp.org/en/5.3/clients.html#verify
Use cacert used by PrestaShop since 1.6.1.21 for previous fallback on server configuration