### PR TITLE
Fix get value of environment vars

### DIFF
--- a/src/Environment/Env.php
+++ b/src/Environment/Env.php
@@ -110,4 +110,22 @@ class Env
     {
         $this->mode = $mode;
     }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getEnv($name)
+    {
+        if (isset($_ENV[$name])) {
+            return $_ENV[$name];
+        }
+
+        if (isset($_SERVER[$name])) {
+            return $_SERVER[$name];
+        }
+
+        return getenv($name);
+    }
 }

--- a/src/Environment/FirebaseEnv.php
+++ b/src/Environment/FirebaseEnv.php
@@ -36,7 +36,7 @@ class FirebaseEnv extends Env
     {
         parent::__construct();
 
-        $this->setFirebaseApiKey($_ENV['FIREBASE_API_KEY']);
+        $this->setFirebaseApiKey($this->getEnv('FIREBASE_API_KEY'));
     }
 
     /**

--- a/src/Environment/PaymentEnv.php
+++ b/src/Environment/PaymentEnv.php
@@ -43,10 +43,10 @@ class PaymentEnv extends Env
 
     private function setEnvDependingOnMode()
     {
-        $this->setPaymentApiUrl($_ENV['PAYMENT_API_URL_LIVE']);
+        $this->setPaymentApiUrl($this->getEnv('PAYMENT_API_URL_LIVE'));
 
         if (Mode::SANDBOX === $this->mode) {
-            $this->setPaymentApiUrl($_ENV['PAYMENT_API_URL_SANDBOX']);
+            $this->setPaymentApiUrl($this->getEnv('PAYMENT_API_URL_SANDBOX'));
         }
     }
 

--- a/src/Environment/PaypalEnv.php
+++ b/src/Environment/PaypalEnv.php
@@ -43,10 +43,10 @@ class PaypalEnv extends Env
 
     private function setEnvDependingOnMode()
     {
-        $this->setPaypalClientId($_ENV['PAYPAL_CLIENT_ID_LIVE']);
+        $this->setPaypalClientId($this->getEnv('PAYPAL_CLIENT_ID_LIVE'));
 
         if (Mode::SANDBOX === $this->mode) {
-            $this->setPaypalClientId($_ENV['PAYPAL_CLIENT_ID_SANDBOX']);
+            $this->setPaypalClientId($this->getEnv('PAYPAL_CLIENT_ID_SANDBOX'));
         }
     }
 

--- a/src/Environment/PsxEnv.php
+++ b/src/Environment/PsxEnv.php
@@ -36,7 +36,7 @@ class PsxEnv extends Env
     {
         parent::__construct();
 
-        $this->setPsxApiUrl($_ENV['PSX_API_URL']);
+        $this->setPsxApiUrl($this->getEnv('PSX_API_URL'));
     }
 
     /**

--- a/src/Environment/SegmentEnv.php
+++ b/src/Environment/SegmentEnv.php
@@ -33,7 +33,7 @@ class SegmentEnv extends Env
     {
         parent::__construct();
 
-        $this->setSegmentApiKey($_ENV['SEGMENT_API_KEY']);
+        $this->setSegmentApiKey($this->getEnv('SEGMENT_API_KEY'));
     }
 
     /**

--- a/src/Environment/SentryEnv.php
+++ b/src/Environment/SentryEnv.php
@@ -47,9 +47,9 @@ class SentryEnv extends Env
     {
         parent::__construct();
 
-        $this->setKey($_ENV['VUE_APP_SENTRY_KEY']);
-        $this->setOrganisation($_ENV['VUE_APP_SENTRY_ORGANIZATION']);
-        $this->setProject($_ENV['VUE_APP_SENTRY_PROJECT']);
+        $this->setKey($this->getEnv('VUE_APP_SENTRY_KEY'));
+        $this->setOrganisation($this->getEnv('VUE_APP_SENTRY_ORGANIZATION'));
+        $this->setProject($this->getEnv('VUE_APP_SENTRY_PROJECT'));
     }
 
     /**

--- a/src/Environment/SsoEnv.php
+++ b/src/Environment/SsoEnv.php
@@ -36,7 +36,7 @@ class SsoEnv extends Env
     {
         parent::__construct();
 
-        $this->setSsoUrl($_ENV['SSO_URL']);
+        $this->setSsoUrl($this->getEnv('SSO_URL'));
     }
 
     /**


### PR DESCRIPTION
Depending of server configuration, DotEnv can load values from .env into `$_ENV`, `$_SERVER` or `getenv()`
Some merchants on Windows Server doesn't have values in `$_ENV`, we have to retrieve it from `$_SERVER`
See https://github.com/vlucas/phpdotenv#usage