### PR TITLE
Do not reuse PayPal Order if client token is expired

### DIFF
--- a/controllers/front/token.php
+++ b/controllers/front/token.php
@@ -63,6 +63,7 @@ class Ps_CheckoutTokenModuleFrontController extends ModuleFrontController
             if (empty($psCheckoutCart->paypal_token_expire)
                 || strtotime($psCheckoutCart->paypal_token_expire) <= time()
             ) {
+                $psCheckoutCart->paypal_order = '';
                 $psCheckoutCart->paypal_token = $this->getToken();
                 $psCheckoutCart->paypal_token_expire = (new DateTime())->modify('+3550 seconds')->format('Y-m-d H:i:s');
                 $psCheckoutCartRepository->save($psCheckoutCart);

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -623,14 +623,6 @@ class Ps_checkout extends PaymentModule
             && strtotime($psCheckoutCart->paypal_token_expire) > time()
         ) {
             $payPalOrderId = $psCheckoutCart->paypal_order;
-        }
-
-        // If we have no PayPal Order Id but a not expired PayPal Client Token, we can use it
-        // If paypal_token_expire is in future, token is not expired
-        if (false !== $psCheckoutCart
-            && false === empty($psCheckoutCart->paypal_token_expire)
-            && strtotime($psCheckoutCart->paypal_token_expire) > time()
-        ) {
             $payPalClientToken = $psCheckoutCart->paypal_token;
         }
         // END To be refactored in services


### PR DESCRIPTION
Fix INVALID_RESOURCE_ID on try to use an expired PayPal Order Id, we check if associated Client Token is expired to know if we can reuse PayPal Order Id or not