### PR TITLE
Fix displayOrderConfirmaton PS1.6

### DIFF
--- a/views/templates/hook/displayOrderConfirmation.tpl
+++ b/views/templates/hook/displayOrderConfirmation.tpl
@@ -20,12 +20,18 @@
   <div class="alert alert-warning">
     {l s='Your order hasn\'t been validated yet, only created. There can be an issue with your payment or it can be captured later, please contact our customer service to have more details about it.' mod='ps_checkout'}
   </div>
-{elseif $isAuthorized }
-  <div class="alert alert-success">
-      {l s='Your order is confirmed.' mod='ps_checkout'}<br>
-      {if $isShop17}
-        <i class="material-icons">info</i>
-      {/if}
-      {l s="Important : you won't be charged until the order is shipping is effective." mod="ps_checkout"}
+{elseif $isShop17 && $isAuthorized }
+  {* PrestaShop 1.7 show a confirmation message itself, so we display only a message in case of isAuthorized *}
+  <div class="alert alert-info">
+    <i class="material-icons">info</i>
+    {l s="Important : you won't be charged until the order is shipping is effective." mod="ps_checkout"}
   </div>
+{elseif !$isShop17 }
+  {* PrestaShop 1.6 doesn't show a confirmation message itself, so have to display it *}
+  <div class="alert alert-success">
+    {l s='Your order is confirmed.' mod='ps_checkout'}
+  </div>
+  {if $isAuthorized }
+    <p>{l s="Important : you won't be charged until the order is shipping is effective." mod="ps_checkout"}</p>
+  {/if}
 {/if}

--- a/views/templates/hook/displayOrderConfirmation.tpl
+++ b/views/templates/hook/displayOrderConfirmation.tpl
@@ -16,22 +16,26 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-{if $status === 'pending' }
-  <div class="alert alert-warning">
-    {l s='Your order hasn\'t been validated yet, only created. There can be an issue with your payment or it can be captured later, please contact our customer service to have more details about it.' mod='ps_checkout'}
-  </div>
-{elseif $isShop17 && $isAuthorized }
-  {* PrestaShop 1.7 show a confirmation message itself, so we display only a message in case of isAuthorized *}
-  <div class="alert alert-info">
-    <i class="material-icons">info</i>
-    {l s="Important : you won't be charged until the order is shipping is effective." mod="ps_checkout"}
-  </div>
-{elseif !$isShop17 }
-  {* PrestaShop 1.6 doesn't show a confirmation message itself, so have to display it *}
-  <div class="alert alert-success">
-    {l s='Your order is confirmed.' mod='ps_checkout'}
-  </div>
-  {if $isAuthorized }
-    <p>{l s="Important : you won't be charged until the order is shipping is effective." mod="ps_checkout"}</p>
+<section id="ps_checkout-displayOrderConfirmation">
+  {if $status === 'pending' }
+    <div class="alert alert-warning">
+      {l s='Your order hasn\'t been validated yet, only created. There can be an issue with your payment or it can be captured later, please contact our customer service to have more details about it.' mod='ps_checkout'}
+    </div>
+  {elseif $isShop17 && $isAuthorized }
+    {* PrestaShop 1.7 show a confirmation message itself, so we display only a message in case of isAuthorized *}
+    <div class="alert alert-info">
+      <i class="material-icons">info</i>
+      {l s="Important : you won't be charged until the order's shipping is effective." mod="ps_checkout"}
+    </div>
+  {elseif !$isShop17 }
+    {* PrestaShop 1.6 doesn't show a confirmation message itself, so have to display it *}
+    <div class="alert alert-success">
+      {l s='Your order is confirmed.' mod='ps_checkout'}
+    </div>
+    {if $isAuthorized }
+      <div class="box">
+        <p>{l s="Important : you won't be charged until the order's shipping is effective." mod="ps_checkout"}</p>
+      </div>
+    {/if}
   {/if}
-{/if}
+</section>


### PR DESCRIPTION
# Order pending

### 1.7
![Capture d’écran 2020-10-21 à 19 12 05](https://user-images.githubusercontent.com/5262628/96754390-86777380-13d1-11eb-9c78-58ba75931919.png)

### 1.6
![Capture d’écran 2020-10-21 à 19 11 48](https://user-images.githubusercontent.com/5262628/96754415-8e371800-13d1-11eb-8c99-3f3ebd91cd05.png)

# Order confirmed (CAPTURE)

### 1.7
![Capture d’écran 2020-10-21 à 19 11 01](https://user-images.githubusercontent.com/5262628/96754494-a7d85f80-13d1-11eb-8b64-8b8c0531b93c.png)

### 1.6
![Capture d’écran 2020-10-21 à 19 12 21](https://user-images.githubusercontent.com/5262628/96754507-adce4080-13d1-11eb-9222-9c91b23df1a7.png)

# Order confirmed (AUTHORIZE)

### 1.7
![Capture d’écran 2020-10-21 à 19 12 37](https://user-images.githubusercontent.com/5262628/96754609-d2c2b380-13d1-11eb-9573-feab14f175c0.png)

### 1.6
![Capture d’écran 2020-10-21 à 19 12 51](https://user-images.githubusercontent.com/5262628/96754626-d6eed100-13d1-11eb-9f9f-892ed7327eda.png)
