### PR TITLE
Change compliancy for 1.7.0 to 1.7.3.4

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -190,6 +190,21 @@ class Ps_checkout extends PaymentModule
             $this->updatePosition(\Hook::getIdByName('payment'), false, 1);
     }
 
+    public function checkCompliancy()
+    {
+        $isCompliant = parent::checkCompliancy();
+
+        if ($isCompliant
+            && Tools::version_compare(_PS_VERSION_, '1.7.0', '>=')
+            && Tools::version_compare(_PS_VERSION_, '1.7.4', '<')
+        ) {
+            // We are aware about dependencies are not compliant for PrestaShop >= 1.7.0 and < 1.7.4 due to Symfony version mismatch
+            return false;
+        }
+
+        return $isCompliant;
+    }
+
     /**
      * Install configuration for each shop
      *


### PR DESCRIPTION
PrestaShop 1.7.0.0 to 1.7.3.4 use Symfony 2 and currently our dependencies are not working with this version.
So we currently don't allow installation of ps_checkout for affected PrestaShop version until we fix this issue.

Note this work for install action but not for upgrade action...