### PR TITLE
Adds module version in service container name

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1077,7 +1077,10 @@ class Ps_checkout extends PaymentModule
     public function getService($serviceName)
     {
         if ($this->serviceContainer === null) {
-            $this->serviceContainer = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer($this->name, $this->getLocalPath());
+            $this->serviceContainer = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer(
+                $this->name . str_replace('.', '', $this->version),
+                $this->getLocalPath()
+            );
         }
 
         return $this->serviceContainer->getService($serviceName);


### PR DESCRIPTION
On PrestaShop 1.6 Core doesn't clear all cache directory so our cache is not cleared and our service container cache is not updated. To avoid issues when we add new services, we add module version in container name.
We will implement cache clear in another PR