### PR TITLE
Fix hook displayPayment on PS 1.6 - use real name

### DIFF
--- a/_dev/js/front/components/1_6/payment-option.component.js
+++ b/_dev/js/front/components/1_6/payment-option.component.js
@@ -51,38 +51,38 @@ export class PaymentOptionComponent {
 
       // TODO: Move to CSS
       STYLE.innerHTML = `
-      #ps_checkout-payment a span {
+      #ps_checkout-displayPayment a span {
         color: white;
       }
 
-      #ps_checkout-payment .form-group {
+      #ps_checkout-displayPayment .form-group {
         margin-left: 0;
         margin-right: 0;
 
         margin-bottom: 15px;
       }
 
-      #ps_checkout-payment .form-group .form-control {
+      #ps_checkout-displayPayment .form-group .form-control {
         max-width: initial;
       }
 
-      #ps_checkout-payment .payment_module a {
+      #ps_checkout-displayPayment .payment_module a {
         padding: 33px 99px 34px 99px;
       }
 
-      #ps_checkout-payment .payment_module .pscheckout-paypal, #ps_checkout-payment .payment_module .pscheckout-card {
+      #ps_checkout-displayPayment .payment_module .pscheckout-paypal, #ps_checkout-displayPayment .payment_module .pscheckout-card {
         background: #fbfbfb;
         padding: 25px 99px 25px 10px;
       }
-      #ps_checkout-payment .payment_module.closed:first-child {}
-      #ps_checkout-payment .payment_module.closed:last-child { display: none }
+      #ps_checkout-displayPayment .payment_module.closed:first-child {}
+      #ps_checkout-displayPayment .payment_module.closed:last-child { display: none }
 
-      #ps_checkout-payment .payment_module.open:first-child { margin: 0 }
-      #ps_checkout-payment .payment_module.open:first-child .pscheckout-paypal, #ps_checkout-payment .payment_module.open:first-child .pscheckout-card {
+      #ps_checkout-displayPayment .payment_module.open:first-child { margin: 0 }
+      #ps_checkout-displayPayment .payment_module.open:first-child .pscheckout-paypal, #ps_checkout-displayPayment .payment_module.open:first-child .pscheckout-card {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
       }
-      #ps_checkout-payment .payment_module.open:last-child a {
+      #ps_checkout-displayPayment .payment_module.open:last-child a {
         border-top: none;
         border-top-left-radius: 0;
         border-top-right-radius: 0;

--- a/_dev/js/front/constants/html-selectors-ps1_6.constants.js
+++ b/_dev/js/front/constants/html-selectors-ps1_6.constants.js
@@ -17,9 +17,9 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 export const HtmlSelectorsPs1_6Constants = {
-  ANY_PAYMENT_OPTION: '#ps_checkout-payment .payment-option.row',
+  ANY_PAYMENT_OPTION: '#ps_checkout-displayPayment .payment-option.row',
 
-  CHECKOUT_PAYMENT_OPTIONS_CONTAINER: '#ps_checkout-payment .payment-options',
+  CHECKOUT_PAYMENT_OPTIONS_CONTAINER: '#ps_checkout-displayPayment .payment-options',
 
   NOTIFICATION_TARGET_ID: 'HOOK_PAYMENT',
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -74,7 +74,7 @@ class Ps_checkout extends PaymentModule
      * @var array
      */
     const HOOK_LIST_16 = [
-        'payment',
+        'displayPayment',
     ];
 
     public $configurationList = [
@@ -403,7 +403,7 @@ class Ps_checkout extends PaymentModule
     /**
      * Add payment option at the checkout in the front office (prestashop 1.6)
      */
-    public function hookPayment()
+    public function hookDisplayPayment()
     {
         if (false === Validate::isLoadedObject($this->context->cart)
             || false === $this->checkCurrency($this->context->cart)
@@ -416,7 +416,7 @@ class Ps_checkout extends PaymentModule
             'modulePath' => $this->getPathUri(),
         ]);
 
-        return $this->display(__FILE__, '/views/templates/hook/payment.tpl');
+        return $this->display(__FILE__, '/views/templates/hook/displayPayment.tpl');
     }
 
     /**

--- a/views/templates/hook/displayPayment.tpl
+++ b/views/templates/hook/displayPayment.tpl
@@ -17,7 +17,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-<section id="ps_checkout-payment">
+<section id="ps_checkout-displayPayment">
   <div class="payment-options">
     <div class="payment-option row" style="display: none;">
       <div class="col-xs-12">


### PR DESCRIPTION
We must use real hook name for hook `displayPayment`, not alias `payment`
It help us to retrieve content for 2.0 in case of merchant has an override of this template for previous version inside his theme