### PR TITLE
Fix missing symfony finder PS 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,16 @@
     "guzzlehttp/log-subscriber": "~1.0",
     "monolog/monolog": "1.25.3",
     "prestashop/decimal": "^1.3",
+    "prestashop/module-lib-service-container": "^1.0",
     "ramsey/uuid": "^3.8",
     "segmentio/analytics-php": "^1.5",
     "sentry/sentry": "^1.0",
     "symfony/config": "^3.4",
     "symfony/dependency-injection": "^3.4",
+    "symfony/finder": "^3.4",
     "symfony/options-resolver": "^3.4",
     "vlucas/phpdotenv": "^3.4",
-    "webmozart/assert": "^1.0",
-    "prestashop/module-lib-service-container": "^1.0"
+    "webmozart/assert": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9970cf4877cf6e30039e64732753d0cb",
+    "content-hash": "cc97dbfdc05d270b4066156df0664532",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1284,6 +1284,55 @@
                 }
             ],
             "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-09-02T16:06:40+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/52140652ed31cee3dabd0c481b5577201fa769b4",
+                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2020-09-02T16:06:40+00:00"
         },
@@ -3664,55 +3713,6 @@
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
             "time": "2020-09-18T12:06:50+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v3.4.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/52140652ed31cee3dabd0c481b5577201fa769b4",
-                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "time": "2020-09-02T16:06:40+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",


### PR DESCRIPTION
Logger cannot works without Symfony Finder used to find logs files. On PrestaShop 1.6, this component is not available