### PR TITLE
Do not display CB Inline by PayPal if Hosted Fields are enabled

### DIFF
--- a/_dev/js/front/components/1_7/payment-option.component.js
+++ b/_dev/js/front/components/1_7/payment-option.component.js
@@ -169,18 +169,21 @@ export class PaymentOptionComponent {
   renderNewPaymentOptionChildren() {
     if (
       this.fundingSource.name === 'card' &&
-      this.payPalService.isHostedFieldsEligible() &&
       this.config.expressCheckoutHostedFieldsEnabled
     ) {
-      this.paymentOptionAdditionalInformation = BASE_PAYMENT_OPTION_ADDITIONAL_INFORMATION.cloneNode(
-        true
-      );
+      if (this.payPalService.isHostedFieldsEligible()) {
+        this.paymentOptionAdditionalInformation = BASE_PAYMENT_OPTION_ADDITIONAL_INFORMATION.cloneNode(
+          true
+        );
 
-      this.children.hostedFields = new HostedFieldsComponent(
-        this.checkout,
-        this,
-        this.fundingSource
-      ).render();
+        this.children.hostedFields = new HostedFieldsComponent(
+          this.checkout,
+          this,
+          this.fundingSource
+        ).render();
+      } else {
+        console.error('Hosted Fields eligibility is declined');
+      }
     } else {
       this.children.smartButton = new SmartButtonComponent(
         this.checkout,


### PR DESCRIPTION
If Hosted Fields are available in BO and enabled but PayPal SDK Eligibility checker decline, do not display PayPal CB Inline.