### PR TITLE
Fix exception on enable

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1122,9 +1122,13 @@ class Ps_checkout extends PaymentModule
     {
         // We want to track only event appends on PrestaShop BO
         if (defined('_PS_ADMIN_DIR_')) {
-            /** @var \PrestaShop\Module\PrestashopCheckout\Segment\SegmentTracker $tracker */
-            $tracker = $this->getService('ps_checkout.segment.tracker');
-            $tracker->track($action);
+            try {
+                /** @var \PrestaShop\Module\PrestashopCheckout\Segment\SegmentTracker $tracker */
+                $tracker = $this->getService('ps_checkout.segment.tracker');
+                $tracker->track($action);
+            } catch (Exception $exception) {
+                // Sometime on module enable after an upgrade .env data are not loaded
+            }
         }
     }
 }


### PR DESCRIPTION
Exception thrown by module ps_checkout on enable. Error when enabling module ps_checkout. Segment::init() requires secret

On module upgrade, previous version of .env is already loaded without new secret of 2.0