### PR TITLE
Fix ignored phpstan error

### DIFF
--- a/tests/phpstan/phpstan-PS-1.7.neon
+++ b/tests/phpstan/phpstan-PS-1.7.neon
@@ -14,6 +14,7 @@ parameters:
 		- '#Strict comparison using === between false and string will always evaluate to false.#'
 		- '#Call to function is_array\(\) with Currency will always evaluate to false.#'
 		- '#Parameter \#1 \$id of class Customer constructor expects null, bool\|int<1, max>\|int<min, -1> given.#'
+		- '#Parameter \#1 \$id of class Customer constructor expects null, int<min, -1>\|int<1, max> given.#'
 		- '#Parameter \#1 \$id of class Customer constructor expects null, int given.#'
 		- '#Parameter \#1 \$hook_name of method ModuleCore::registerHook\(\) expects string, array<int, string> given.#'
 		- '#Parameter \#6 \$idShop of method LinkCore::getModuleLink\(\) expects null, int given.#'


### PR DESCRIPTION
 ------ ----------------------------------------------------------------------- 
  Line   controllers/front/ExpressCheckout.php                                  
 ------ ----------------------------------------------------------------------- 
  170    Parameter #1 $id of class Customer constructor expects null, int<min,  
         -1>|int<1, max> given.                                                 
 ------ ----------------------------------------------------------------------- 

Error: ] Found 1 error                                                          

Error: Parameter #1 $id of class Customer constructor expects null, int<min, -1>|int<1, max> given.
Error: Process completed with exit code 1.