### PR TITLE
Adjust button alignement on payment page on mobile

### DIFF
--- a/views/templates/hook/adminAfterHeader/promotionBlock.tpl
+++ b/views/templates/hook/adminAfterHeader/promotionBlock.tpl
@@ -51,7 +51,7 @@
                                 </div>
                             </div>
                             <div class="col-12 col-sm-4 col-md-3 col-lg-2 mb-3 m-auto">
-                                <div class="text-center">
+                                <div class="text-xs-center">
                                     <a href="{$configureLink|escape:'htmlall':'UTF-8'}" class="btn btn-primary-reverse btn-outline-primary light-button">
                                         {l s='Configure' mod='ps_checkout'}
                                     </a>


### PR DESCRIPTION
This button is centered on mobile while everything else is aligned to the left

From https://github.com/PrestaShopCorp/ps_checkout/pull/661