### PR TITLE
Fix for OrderPayment cannot be saved

### DIFF
--- a/src/Dispatcher/OrderDispatcher.php
+++ b/src/Dispatcher/OrderDispatcher.php
@@ -166,13 +166,14 @@ class OrderDispatcher implements Dispatcher
         foreach ($orderPayments as $orderPayment) {
             if (\Validate::isLoadedObject($orderPayment)) {
                 if ($orderPayment->transaction_id !== $resource['id']) {
-                    $orderPayment->transaction_id = $resource['id'];
-                    $orderPayment->payment_method = $fundingSourceTranslationProvider->getPaymentMethodName($this->psCheckoutCart->paypal_funding);
-                    try {
-                        $orderPayment->save();
-                    } catch (\Exception $exception) {
-                        throw new PsCheckoutException('Cannot update OrderPayment', PsCheckoutException::PRESTASHOP_ORDER_PAYMENT, $exception);
-                    }
+                    \Db::getInstance()->update(
+                        'order_payment',
+                        [
+                            'payment_method' => pSQL($fundingSourceTranslationProvider->getPaymentMethodName($this->psCheckoutCart->paypal_funding)),
+                            'transaction_id' => pSQL($resource['id']),
+                        ],
+                        'id_order_payment = ' . (int) $orderPayment->id
+                    );
                 }
                 $shouldAddOrderPayment = false;
             }

--- a/src/ValidateOrder.php
+++ b/src/ValidateOrder.php
@@ -210,13 +210,14 @@ class ValidateOrder
                         $orderPayment = $orderPaymentCollection->getFirst();
 
                         if (false !== $orderPayment) {
-                            $orderPayment->transaction_id = $transactionIdentifier;
-                            $orderPayment->payment_method = $fundingSourceTranslationProvider->getPaymentMethodName($psCheckoutCart->paypal_funding);
-                            try {
-                                $orderPayment->save();
-                            } catch (\Exception $exception) {
-                                throw new PsCheckoutException('Unable to save PrestaShop OrderPayment', PsCheckoutException::PRESTASHOP_ORDER_PAYMENT, $exception);
-                            }
+                            \Db::getInstance()->update(
+                                'order_payment',
+                                [
+                                    'payment_method' => pSQL($fundingSourceTranslationProvider->getPaymentMethodName($psCheckoutCart->paypal_funding)),
+                                    'transaction_id' => pSQL($transactionIdentifier),
+                                ],
+                                'id_order_payment = ' . (int) $orderPayment->id
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
This error happens when we cannot save PayPal Transaction Id and Payment Method name used in PrestaShop Order Payment.

The OrderPayment->amount property is not valid

Value already stored in database 1.0000000000 is not compliant with native validation Validate::isPrice()
`/^[0-9]{1,10}(\.[0-9]{1,9})?$/`

So as the amount is not set by us but by PrestaShop Core, I think we should perform this in pure SQL without using OrderPayment to avoid the error.