### PR TITLE
[PAYSHIP-1071] Fix small devices display of HostedFields on PrestaShop 1.6

### DIFF
--- a/views/css/payments16.css
+++ b/views/css/payments16.css
@@ -45,6 +45,12 @@
   padding: 33px 99px 34px 99px;
 }
 
+@media (max-width: 767px) {
+  .ps_checkout-payment-option div.payment_module:last-child a {
+    padding: 10px;
+  }
+}
+
 .ps_checkout-payment-option div.payment_module:first-child a:after {
   display: block;
   content: "\f054";


### PR DESCRIPTION
Small devices
<img width="477" alt="mobile" src="https://user-images.githubusercontent.com/5262628/113185364-a485b180-9256-11eb-999a-b46aa2ac4b5d.png">
Large devices (desktop)
<img width="1176" alt="large" src="https://user-images.githubusercontent.com/5262628/113185376-a8193880-9256-11eb-84d3-77a387c7b036.png">
