### PR TITLE
Fix JS error on notification component on PS1.6

### DIFF
--- a/_dev/js/front/src/components/1_6/notification.component.js
+++ b/_dev/js/front/src/components/1_6/notification.component.js
@@ -43,6 +43,8 @@ export class NotificationComponent extends BaseComponent {
     return this;
   }
 
+  hideConditions() {}
+
   hideCancelled() {
     this.notificationPaymentCanceled.style.display = 'none';
   }
@@ -54,6 +56,8 @@ export class NotificationComponent extends BaseComponent {
   showCanceled() {
     this.notificationPaymentCanceled.style.display = 'block';
   }
+
+  showConditions() {}
 
   showError(message) {
     this.notificationPaymentError.style.display = 'block';


### PR DESCRIPTION
On PrestaShop 1.6 Uncaught TypeError: t.data.notification.hideConditions is not a function at onInit