### PR TITLE
[PAYSHIP-1152] Fix SSL CA Bundle not found

### DIFF
--- a/src/Api/GenericClient.php
+++ b/src/Api/GenericClient.php
@@ -296,10 +296,8 @@ class GenericClient
      */
     protected function getVerify()
     {
-        if (defined('_PS_CACHE_CA_CERT_FILE_')) {
-            \Tools::refreshCACertFile();
-
-            return file_exists(constant('_PS_CACHE_CA_CERT_FILE_')) ? constant('_PS_CACHE_CA_CERT_FILE_') : true;
+        if (defined('_PS_CACHE_CA_CERT_FILE_') && file_exists(constant('_PS_CACHE_CA_CERT_FILE_'))) {
+            return constant('_PS_CACHE_CA_CERT_FILE_');
         }
 
         return true;

--- a/src/Api/GenericClient.php
+++ b/src/Api/GenericClient.php
@@ -297,7 +297,9 @@ class GenericClient
     protected function getVerify()
     {
         if (defined('_PS_CACHE_CA_CERT_FILE_')) {
-            return constant('_PS_CACHE_CA_CERT_FILE_');
+            \Tools::refreshCACertFile();
+
+            return file_exists(constant('_PS_CACHE_CA_CERT_FILE_')) ? constant('_PS_CACHE_CA_CERT_FILE_') : true;
         }
 
         return true;


### PR DESCRIPTION
When using CURL, if PHP is misconfigured SSL certificat cannot be verify when calling API
Since PrestaShop 1.6.1.21, Core team introduced a way to retrieve a local certificat and save it in cache and use it on every CURL Call.
To avoid error `SSL CA bundle not found` we check if file exist before use it.
If not available let Guzzle try to do it with PHP configuration, if it fail a CURL Error 35 will be emitted and we should ask merchant to upgrade PrestaShop or fix his PHP configuration.