### PR TITLE
Make generic message for Exception order not found

### DIFF
--- a/src/Dispatcher/OrderDispatcher.php
+++ b/src/Dispatcher/OrderDispatcher.php
@@ -59,7 +59,7 @@ class OrderDispatcher implements Dispatcher
         $psOrderId = \Order::getOrderByCartId((int) $this->psCheckoutCart->id_cart);
 
         if (false === $psOrderId) {
-            throw new PsCheckoutException(sprintf('order #%s does not exist', $this->psCheckoutCart->paypal_order), PsCheckoutException::PRESTASHOP_ORDER_NOT_FOUND);
+            throw new PsCheckoutException('No PrestaShop Order associated to this PayPal Order at this time.', PsCheckoutException::PRESTASHOP_ORDER_NOT_FOUND);
         }
 
         if ($payload['eventType'] === self::PS_CHECKOUT_PAYMENT_REFUNED


### PR DESCRIPTION
In order to reduce amount of duplicated issues on Sentry for same error, we put a generic message for this exception.