### PR TITLE
Fix ErrorException on PayPalAccountUpdater

### DIFF
--- a/src/Updater/PaypalAccountUpdater.php
+++ b/src/Updater/PaypalAccountUpdater.php
@@ -80,11 +80,11 @@ class PaypalAccountUpdater
             return $this->persistentConfiguration->savePaypalAccount($account);
         }
 
-        $account->setEmail($merchantIntegration['primary_email']);
-        $account->setEmailIsVerified($merchantIntegration['primary_email_confirmed']);
-        $account->setPaypalPaymentStatus($merchantIntegration['payments_receivable']);
-        $account->setCardPaymentStatus($this->getCardStatus($merchantIntegration));
-        $account->setMerchantCountry($merchantIntegration['country']);
+        $account->setEmail(isset($merchantIntegration['primary_email']) ? $merchantIntegration['primary_email'] : '');
+        $account->setEmailIsVerified(isset($merchantIntegration['primary_email_confirmed']) ? $merchantIntegration['primary_email_confirmed'] : '');
+        $account->setPaypalPaymentStatus(isset($merchantIntegration['payments_receivable']) ? $merchantIntegration['payments_receivable'] : '');
+        $account->setCardPaymentStatus(isset($merchantIntegration['products']) ? $this->getCardStatus($merchantIntegration) : '');
+        $account->setMerchantCountry(isset($merchantIntegration['country']) ? $merchantIntegration['country'] : '');
 
         return $this->persistentConfiguration->savePaypalAccount($account);
     }


### PR DESCRIPTION
Sometime the API Response is incomplete depends on account specificity 
```
ErrorException: Undefined index: country
#7 /modules/ps_checkout/src/Updater/PaypalAccountUpdater.php(87): handleError
#6 /modules/ps_checkout/src/Updater/PaypalAccountUpdater.php(87): update
#5 /modules/ps_checkout/ps_checkout.php(595): getContent
#4 /controllers/admin/AdminModulesController.php(905): postProcessCallback
#3 /controllers/admin/AdminModulesController.php(1165): postProcess
#2 /controller/Controller.php(270): run
#1 /classes/Dispatcher.php(511): dispatch
#0 index.php(99): null
```

```
Symfony\Component\Debug\Exception\ContextErrorException: Notice: Undefined index: primary_email
#5 /modules/ps_checkout/src/Updater/PaypalAccountUpdater.php(83): update
#4 /modules/ps_checkout/controllers/admin/AdminAjaxPrestashopCheckoutController.php(240): ajaxProcessRefreshPaypalAccountStatus
#3 /classes/controller/AdminController.php(933): postProcess
#2 /classes/controller/Controller.php(270): run
#1 /classes/Dispatcher.php(511): dispatch
#0 index.php(99): null
```