### PR TITLE
Fix missing CSS on product page

### DIFF
--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -972,6 +972,25 @@ class Ps_checkout extends PaymentModule
         /** @var \PrestaShop\Module\PrestashopCheckout\Validator\FrontControllerValidator $frontControllerValidator */
         $frontControllerValidator = $this->getService('ps_checkout.validator.front_controller');
 
+        if ($frontControllerValidator->shouldLoadFrontCss($controller)) {
+            if (method_exists($this->context->controller, 'registerStylesheet')) {
+                $this->context->controller->registerStylesheet(
+                    'ps-checkout-css-paymentOptions',
+                    $this->getPathUri() . 'views/css/payments.css?version=' . $this->version,
+                    [
+                        'server' => 'remote',
+                    ]
+                );
+            } else {
+                $this->context->controller->addCss(
+                    $this->getPathUri() . 'views/css/payments16.css?version=' . $this->version,
+                    'all',
+                    null,
+                    false
+                );
+            }
+        }
+
         if (false === $frontControllerValidator->shouldLoadFrontJS($controller)) {
             return;
         }
@@ -1106,23 +1125,6 @@ class Ps_checkout extends PaymentModule
         } else {
             $this->context->controller->addJS(
                 $this->getPathUri() . 'views/js/front.js?version=' . $this->version,
-                false
-            );
-        }
-
-        if (method_exists($this->context->controller, 'registerStylesheet')) {
-            $this->context->controller->registerStylesheet(
-                'ps-checkout-css-paymentOptions',
-                $this->getPathUri() . 'views/css/payments.css?version=' . $this->version,
-                [
-                    'server' => 'remote',
-                ]
-            );
-        } else {
-            $this->context->controller->addCss(
-                $this->getPathUri() . 'views/css/payments16.css?version=' . $this->version,
-                'all',
-                null,
                 false
             );
         }

--- a/src/Validator/FrontControllerValidator.php
+++ b/src/Validator/FrontControllerValidator.php
@@ -55,4 +55,33 @@ class FrontControllerValidator
 
         return false;
     }
+
+    /**
+     * @param string $controller
+     *
+     * @return bool
+     */
+    public function shouldLoadFrontCss($controller)
+    {
+        if (false === $this->merchantValidator->merchantIsValid()) {
+            return false;
+        }
+
+        switch ($controller) {
+            // Payment step
+            case 'orderopc':
+            case 'order':
+            // Payment methods logos (always if merchant is valid), Payment4X banner, ExpressCheckout button
+            case 'product':
+                return true;
+            // Payment4X banner, ExpressCheckout button
+            case 'cart':
+                return $this->expressCheckoutConfiguration->isOrderPageEnabled() || $this->payIn4XConfiguration->isOrderPageEnabled();
+            // ExpressCheckout button
+            case 'authentication':
+                return $this->expressCheckoutConfiguration->isCheckoutPageEnabled();
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
If on module configuration, ExpressCheckout is disabled and Payment4X banner is disabled, payment methods logos are not well displayed due to missing CSS.

Before
![Capture d’écran 2021-05-25 à 15 41 51](https://user-images.githubusercontent.com/5262628/119508136-c63f7880-bd6f-11eb-9fe3-87bc27ffdf11.png)


After
![Capture d’écran 2021-05-25 à 15 42 03](https://user-images.githubusercontent.com/5262628/119508143-c8a1d280-bd6f-11eb-98ac-3a8e8cb78393.png)
