### PR TITLE
PAYSHIP-984 - Fix double OrderPayment

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_checkout</name>
 	<displayName><![CDATA[PrestaShop Checkout]]></displayName>
-	<version><![CDATA[2.15.3]]></version>
+	<version><![CDATA[2.15.4]]></version>
 	<description><![CDATA[Provide the most commonly used payment methods to your customers in this all-in-one module, and manage all your sales in a centralized interface.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/config/common.yml
+++ b/config/common.yml
@@ -335,3 +335,25 @@ services:
       - '@ps_checkout.validator.merchant'
       - '@ps_checkout.express_checkout.configuration'
       - '@ps_checkout.pay_in_4x.configuration'
+
+  ps_checkout.cache.directory:
+    class: 'PrestaShop\ModuleLibCacheDirectoryProvider\Cache\CacheDirectoryProvider'
+    public: true
+    arguments:
+      - !php/const _PS_VERSION_
+      - !php/const _PS_ROOT_DIR_
+      - !php/const _PS_MODE_DEV_
+
+  ps_checkout.cache.paypal.order:
+    class: 'Symfony\Component\Cache\Simple\FilesystemCache'
+    public: true
+    arguments:
+      - 'paypal-orders'
+      - 3600
+      - '@=service("ps_checkout.cache.directory").getPath()'
+
+  ps_checkout.paypal.provider.order:
+    class: 'PrestaShop\Module\PrestashopCheckout\PayPal\PayPalOrderProvider'
+    public: true
+    arguments:
+      - '@ps_checkout.cache.paypal.order'

--- a/src/PayPal/PayPalOrderProvider.php
+++ b/src/PayPal/PayPalOrderProvider.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\PrestashopCheckout\PayPal;
+
+use PrestaShop\Module\PrestashopCheckout\PaypalOrder;
+use Psr\SimpleCache\CacheInterface;
+
+class PayPalOrderProvider
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @param CacheInterface $cache
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return array|false
+     */
+    public function getById($id)
+    {
+        if ($this->cache->has($id)) {
+            return $this->cache->get($id);
+        }
+
+        $orderPayPal = new PaypalOrder($id);
+
+        if (!$orderPayPal->isLoaded()) {
+            return false;
+        }
+
+        $data = $orderPayPal->getOrder();
+
+        $this->cache->set($id, $data);
+
+        return $data;
+    }
+}

--- a/upgrade/upgrade-2.15.4.php
+++ b/upgrade/upgrade-2.15.4.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Update main function for module version 2.15.4
+ *
+ * @param Ps_checkout $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_15_4($module)
+{
+    return (bool) $module->registerHook('actionObjectOrderPaymentAddAfter')
+        && (bool) $module->registerHook('actionObjectOrderPaymentUpdateAfter');
+}


### PR DESCRIPTION
We should let PrestaShop manage OrderPayment to avoid duplication and side effects :

- We shouldn't create OrderPayment after Order creation
So code changes required in src/ValidateOrder.php and src/Dispatcher/OrderDispatcher.php
- We should store PayPal Order in cache for 1 hour to preserve performance for others modules would change OrderState like Shipping, ERP, etc...
- We should implement hook `actionObjectOrderPaymentAddAfter` and hook `actionObjectOrderPaymentUpdateAfter`
In this hook we should execute a DbQuery to update OrderPayment with data we previously stored in cache.
Prefer a SQL update query instead of using ObjectModel method to avoid side effects with modules who change Order's reference field with a value doesn't fit default validation rules.

OrderPayment fields should be updated :
- payment_method with FundingSource name
- transaction_id with PayPal transaction reference