### PR TITLE
PAYSHIP-1279 - Fix missing ExpressCheckout confirmation button on 1.6

### DIFF
--- a/_dev/js/back/src/components/panel/express-checkout.vue
+++ b/_dev/js/back/src/components/panel/express-checkout.vue
@@ -58,7 +58,7 @@
                   ({{ $t('panel.express-checkout.recommended') }})
                 </div>
               </b-col>
-              <b-col v-if="shopIs17">
+              <b-col>
                 <PSCheckbox
                   id="checkout-page"
                   v-model="checkoutPageIsActive"

--- a/_dev/js/front/src/components/1_6/express-button-checkout.component.js
+++ b/_dev/js/front/src/components/1_6/express-button-checkout.component.js
@@ -22,13 +22,21 @@ import { ExpressCheckoutButtonComponent } from '../common/express-checkout-butto
 export class ExpressButtonCheckoutComponent extends BaseComponent {
   static Inject = {
     htmlElementService: 'HTMLElementService',
-    PsCheckoutApi: 'PsCheckoutApi',
+    prestashopService: 'PrestashopService',
+    psCheckoutApi: 'PsCheckoutApi',
     $: '$'
   };
 
   getButtonContainer() {
-    const selector = '#opc_account_form';
-    return document.querySelector(selector);
+    if (this.prestashopService.isOrderPersonalInformationStepPage() && !this.prestashopService.isNativeOnePageCheckoutPage()) {
+      return document.querySelector('#create-account_form');
+    }
+
+    if (this.prestashopService.isNativeOnePageCheckoutPage()) {
+      return document.querySelector('#opc_account_choice .opc-button');
+    }
+
+    return document.querySelector('#opc_account_form');
   }
 
   created() {
@@ -65,6 +73,17 @@ export class ExpressButtonCheckoutComponent extends BaseComponent {
           })
       }
     ).render();
+
+    if (this.prestashopService.isNativeOnePageCheckoutPage()) {
+      const separatorText = document.createElement('div');
+      separatorText.classList.add('ps_checkout-express-separator');
+      separatorText.innerText = this.$('express-button.cart.separator');
+
+      this.buttonContainer.append(separatorText);
+      this.buttonContainer.append(this.checkoutExpressButton);
+
+      return this;
+    }
 
     this.buttonContainer.prepend(this.checkoutExpressButton);
 

--- a/_dev/js/front/src/components/1_6/notification.component.js
+++ b/_dev/js/front/src/components/1_6/notification.component.js
@@ -20,7 +20,8 @@ import { BaseComponent } from '../../core/dependency-injection/base.component';
 
 export class NotificationComponent extends BaseComponent {
   static Inject = {
-    htmlElementService: 'HTMLElementService'
+    htmlElementService: 'HTMLElementService',
+    prestashopService: 'PrestashopService',
   };
 
   constructor(app, props) {
@@ -36,9 +37,11 @@ export class NotificationComponent extends BaseComponent {
   }
 
   render() {
-    this.notificationPaymentContainerTarget.prepend(
-      this.notificationPaymentContainer
-    );
+    if (!this.prestashopService.isNativeOnePageCheckoutPage()) {
+      this.notificationPaymentContainerTarget.prepend(
+        this.notificationPaymentContainer
+      );
+    }
 
     return this;
   }

--- a/_dev/js/front/src/components/1_6/payment-options.component.js
+++ b/_dev/js/front/src/components/1_6/payment-options.component.js
@@ -30,7 +30,7 @@ export class PaymentOptionsComponent extends BaseComponent {
   created() {
     this.data.HTMLElement = this.querySelectorService.getPaymentOptions();
 
-    this.data.HTMLBasePaymentConfirmation = this.querySelectorService.getBasePaymentConfirmation();
+    this.data.HTMLExpressCheckoutPaymentConfirmation = this.querySelectorService.getBasePaymentConfirmation();
 
     this.data.HTMLElementHookPayment = document.querySelector('#HOOK_PAYMENT');
   }
@@ -95,10 +95,7 @@ export class PaymentOptionsComponent extends BaseComponent {
   }
 
   renderExpressCheckoutPaymentButton() {
-    const paymentButton = this.data.HTMLBasePaymentConfirmation.cloneNode(true);
-
-    paymentButton.id = 'ps_checkout-hosted-submit-button';
-    paymentButton.type = 'button';
+    const paymentButton = this.data.HTMLExpressCheckoutPaymentConfirmation;
 
     paymentButton.addEventListener('click', (event) => {
       event.preventDefault();
@@ -127,13 +124,6 @@ export class PaymentOptionsComponent extends BaseComponent {
         });
     });
 
-    this.children.expressCheckoutButton = document.createElement('div');
-
-    this.children.expressCheckoutButton.id = 'button-paypal';
-    this.children.expressCheckoutButton.classList.add(
-      'ps_checkout-express-checkout-button'
-    );
-
     paymentButton.disabled = !this.data.conditions.isChecked();
     this.data.conditions.onChange(() => {
       paymentButton.disabled = !this.data.conditions.isChecked();
@@ -144,12 +134,6 @@ export class PaymentOptionsComponent extends BaseComponent {
         element.style.display = 'none';
       }
     });
-
-    // document.querySelector('.cart_navigation').append(paymentButton);
-    this.children.expressCheckoutButton.append(paymentButton);
-    document
-      .querySelector('.express-checkout-block')
-      .append(this.children.expressCheckoutButton);
   }
 
   render() {

--- a/_dev/js/front/src/components/ps-checkout-express.component/ps-checkout-express-ps1_6.component.js
+++ b/_dev/js/front/src/components/ps-checkout-express.component/ps-checkout-express-ps1_6.component.js
@@ -58,7 +58,7 @@ export class PsCheckoutExpressPs1_6Component extends BaseComponent {
 
     if (this.prestashopService.isCartPage()) {
       if (!this.config.expressCheckout.enabled.cart) return this;
-      if (document.body.classList.contains('cart-empty')) return this;
+      if (!window.ps_checkoutCartProductCount) return this;
 
       this.children.expressButton = new ExpressButtonCartComponent(
         this.app
@@ -69,6 +69,7 @@ export class PsCheckoutExpressPs1_6Component extends BaseComponent {
 
     if (this.prestashopService.isOrderPersonalInformationStepPage()) {
       if (!this.config.expressCheckout.enabled.order) return this;
+      if (!window.ps_checkoutCartProductCount) return this;
       this.children.expressButton = new ExpressButtonCheckoutComponent(
         this.app
       ).render();

--- a/_dev/js/front/src/components/ps-checkout.component/ps-checkout-ps1_6.component.js
+++ b/_dev/js/front/src/components/ps-checkout.component/ps-checkout-ps1_6.component.js
@@ -41,19 +41,16 @@ export class PsCheckoutPs1_6Component extends BaseComponent {
       this.app
     ).render();
 
-    // TODO: Move this to PrestashopService
-    if (window.isLogged) {
-      // TODO: Move this to HTMLElementService
-      const cgv = document.getElementById('cgv');
-      if ((cgv && cgv.checked) || !cgv) {
-        this.children.notification = new NotificationComponent(
-          this.app
-        ).render();
-        this.children.loader = new LoaderComponent(this.app).render();
-        this.children.paymentOptions = new PaymentOptionsComponent(this.app, {
-          markPosition: 'before'
-        }).render();
-      }
+    // TODO: Move this to HTMLElementService
+    const cgv = document.getElementById('cgv');
+    if ((cgv && cgv.checked) || !cgv) {
+      this.children.notification = new NotificationComponent(
+        this.app
+      ).render();
+      this.children.loader = new LoaderComponent(this.app).render();
+      this.children.paymentOptions = new PaymentOptionsComponent(this.app, {
+        markPosition: 'before'
+      }).render();
     }
 
     this.children.paymentOptionsLoader.hide();

--- a/_dev/js/front/src/core/app.js
+++ b/_dev/js/front/src/core/app.js
@@ -108,6 +108,11 @@ export class App {
         this.prestashopService.isProductPage()
       ) {
         await this.renderExpressCheckout();
+
+        if (this.prestashopService.isOrderPersonalInformationStepPage()) {
+          await this.renderCheckout();
+        }
+
         return this;
       }
 

--- a/_dev/js/front/src/service/html-element.service/index.js
+++ b/_dev/js/front/src/service/html-element.service/index.js
@@ -47,8 +47,8 @@ export class HTMLElementService extends BaseClass {
     return this.instance.getButtonContainer();
   }
 
-  getCheckoutExpressCartButtonContainer() {
-    return this.instance.getCheckoutExpressCartButtonContainer();
+  getBasePaymentConfirmation() {
+    return this.instance.getBasePaymentConfirmation();
   }
 
   getCheckoutExpressCheckoutButtonContainer() {

--- a/_dev/js/front/src/service/prestashop.service/index.js
+++ b/_dev/js/front/src/service/prestashop.service/index.js
@@ -52,12 +52,20 @@ export class PrestashopService {
     return this.instance.isOrderPage();
   }
 
+  isNativeOnePageCheckoutPage() {
+    return this.instance.isNativeOnePageCheckoutPage();
+  }
+
   isIframeProductPage() {
     return !!this.instance.isIframeProductPage();
   }
 
   isProductPage() {
     return !!this.instance.isProductPage();
+  }
+
+  isLogged() {
+    return this.instance.isLogged();
   }
 
   getVersion() {

--- a/_dev/js/front/src/service/prestashop.service/prestashop-ps1_6.service.js
+++ b/_dev/js/front/src/service/prestashop.service/prestashop-ps1_6.service.js
@@ -51,10 +51,14 @@ export class PrestashopPs1_6Service {
     return document.body.id === 'order' || document.body.id === 'order-opc';
   }
 
+  static isNativeOnePageCheckoutPage() {
+    return document.body.id === 'order-opc';
+  }
+
   static isOrderPersonalInformationStepPage() {
     return (
       document.body.id === 'authentication' ||
-      (document.body.id === 'order-opc' && window.isLogged === false)
+      (document.body.id === 'order-opc' && !window.isLogged && !window.isGuest)
     );
   }
 
@@ -64,6 +68,10 @@ export class PrestashopPs1_6Service {
 
   static isProductPage() {
     return document.body.id === 'product';
+  }
+
+  static isLogged() {
+    return !!window.isLogged || !!window.isGuest;
   }
 
   static onUpdatedCart() {}

--- a/_dev/js/front/src/service/prestashop.service/prestashop-ps1_7.service.js
+++ b/_dev/js/front/src/service/prestashop.service/prestashop-ps1_7.service.js
@@ -36,6 +36,10 @@ export class PrestashopPs1_7Service {
     return document.body.id === 'checkout';
   }
 
+  static isNativeOnePageCheckoutPage() {
+    return false; // This doesn't exist in PrestaShop 1.7
+  }
+
   static isOrderPersonalInformationStepPage() {
     if (document.body.id !== 'checkout') return false;
     const step = document.querySelector('#checkout-personal-information-step');
@@ -49,6 +53,10 @@ export class PrestashopPs1_7Service {
 
   static isProductPage() {
     return document.body.id === 'product';
+  }
+
+  static isLogged() {
+    return window.prestashop.customer.is_logged;
   }
 
   static onUpdatedCart(listener) {

--- a/_dev/js/front/src/service/query-selector.service/default-selectors/default-selectors-ps1_6.js
+++ b/_dev/js/front/src/service/query-selector.service/default-selectors/default-selectors-ps1_6.js
@@ -17,9 +17,9 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 export const DefaultSelectors1_6 = {
-  BASE_PAYMENT_CONFIRMATION: '#payment-confirmation [type="submit"]',
+  BASE_PAYMENT_CONFIRMATION: '#ps_checkout-express-checkout-submit-button',
 
-  CONDITIONS_CHECKBOXES: '#conditions-to-approve input[type="checkbox"]',
+  CONDITIONS_CHECKBOXES: 'input[name="cgv"]',
 
   LOADER_PARENT: 'body',
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -674,7 +674,7 @@ class Ps_checkout extends PaymentModule
             return;
         }
 
-        if ($psCheckoutCart->isExpressCheckout) {
+        if ($psCheckoutCart->isExpressCheckout || !$this->context->cart->nbProducts()) {
             $psCheckoutCartRepository->remove($psCheckoutCart);
             $this->context->cookie->__unset('paypalEmail');
         }
@@ -1027,9 +1027,11 @@ class Ps_checkout extends PaymentModule
         $payPalClientToken = '';
         $payPalOrderId = '';
         $psCheckoutCart = false;
+        $cartProductCount = 0;
 
         // Sometimes we can be in Front Office without a cart...
         if (Validate::isLoadedObject($this->context->cart)) {
+            $cartProductCount = (int) $this->context->cart->nbProducts();
             /** @var \PrestaShop\Module\PrestashopCheckout\Repository\PsCheckoutCartRepository $psCheckoutCartRepository */
             $psCheckoutCartRepository = $this->getService('ps_checkout.repository.pscheckoutcart');
 
@@ -1075,6 +1077,7 @@ class Ps_checkout extends PaymentModule
             $this->name . 'ExpressCheckoutOrderEnabled' => $expressCheckoutConfiguration->isCheckoutPageEnabled(),
             $this->name . '3dsEnabled' => $payPalConfiguration->is3dSecureEnabled(),
             $this->name . 'CspNonce' => $payPalConfiguration->getCSPNonce(),
+            $this->name . 'CartProductCount' => $cartProductCount,
             $this->name . 'FundingSourcesSorted' => $fundingSourcesSorted,
             $this->name . 'PayWithTranslations' => $payWithTranslations,
             $this->name . 'CheckoutTranslations' => [

--- a/views/css/payments16.css
+++ b/views/css/payments16.css
@@ -283,6 +283,10 @@
   color: #333;
 }
 
+#order-opc .ps_checkout-express-separator {
+  padding: 10px 0;
+}
+
 .ps_checkout-express-separator:before, .ps_checkout-express-separator:after{
   content: "";
   flex: 1 1;
@@ -425,4 +429,24 @@
 @keyframes fadeIn {
   from {opacity: 0;}
   to {opacity:1 ;}
+}
+
+#ps_checkout-notification-container .alert {
+  color: #fff;
+}
+
+#ps_checkout-notification-container .alert-warning-custom{
+  background-color: #a3a3a3;
+}
+
+#ps_checkout-notification-container .alert-danger-custom{
+  background-color: #ef808d;
+}
+
+#ps_checkout-canceled, #ps_checkout-error{
+  display: flex;
+  align-items: center;
+}
+#ps_checkout-canceled img, #ps_checkout-error img{
+  margin-right: 10px;
 }

--- a/views/templates/hook/displayPayment.tpl
+++ b/views/templates/hook/displayPayment.tpl
@@ -17,7 +17,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-{if !$isOnePageCheckout16 && !$isExpressCheckout}
+{if !$isExpressCheckout}
   <div id="ps_checkout-loader" class="express-checkout-block mb-2">
     <div class="express-checkout-block-wrapper">
       <p class="express-checkout-spinner-text">
@@ -37,6 +37,11 @@
     <p class="express-checkout-label">
       {$translatedText|escape:'htmlall':'UTF-8'}
     </p>
+    <div id="button-paypal" class="ps_checkout-express-checkout-button">
+      <button id="ps_checkout-express-checkout-submit-button" class="button btn btn-default button-medium" type="button" disabled>
+        <span>{l s='I confirm my order' mod='ps_checkout'}<i class="icon-chevron-right right"></i></span>
+      </button>
+    </div>
   </div>
   {/if}
   <div class="payment-options">

--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -35,8 +35,7 @@
     {$translatedText|escape:'htmlall':'UTF-8'}
   </p>
 </div>
-{else}
-  {if $is17 || ($isOnePageCheckout16 && !$isExpressCheckout)}
+{elseif $is17}
   <div id="ps_checkout-loader" class="express-checkout-block mb-2">
     <div class="express-checkout-block-wrapper">
       <p class="express-checkout-spinner-text">
@@ -47,7 +46,6 @@
       </div>
     </div>
   </div>
-  {/if}
 {/if}
 
 {if $is17}


### PR DESCRIPTION
## PAYSHIP-1279

Enable ExpressCheckout feature and disable Card funding source in configuration page.

Go to a product page on shop, make an ExpressCheckout, when you are on Payment Step, the confirmation button missing in ExpressCheckout block.

This PR add the confirmation button on template on 1.6 because instead of PrestaShop 1.7, by default there no confirmation button.

## PAYSHIP-1191 & PAYSHIP-1028

On PrestaShop 1.6, enable Guest Checkout in Order settings of PrestaShop.
Go to a product page on shop, create a cart, don't use ExpressCheckout but Quick Order option of PrestaShop without create a customer account.
Payment methods never appears.

This PR fix this

## PAYSHIP-1120

On PrestaShop 1.6, Express Checkout button never appears with native OnePageCheckout
