### PR TITLE
Adds merchant integration cache

### DIFF
--- a/config/common.yml
+++ b/config/common.yml
@@ -187,6 +187,7 @@ services:
     public: true
     arguments:
       - '@ps_checkout.persistent.configuration'
+      - '@ps_checkout.paypal.provider.merchant_integration'
 
   ps_checkout.step.live:
     class: 'PrestaShop\Module\PrestashopCheckout\OnBoarding\Step\LiveStep'
@@ -357,3 +358,17 @@ services:
     public: true
     arguments:
       - '@ps_checkout.cache.paypal.order'
+
+  ps_checkout.cache.paypal.merchant_integration:
+    class: 'Symfony\Component\Cache\Simple\FilesystemCache'
+    public: true
+    arguments:
+      - 'merchant-integration'
+      - 86400
+      - '@=service("ps_checkout.cache.directory").getPath()'
+
+  ps_checkout.paypal.provider.merchant_integration:
+    class: 'PrestaShop\Module\PrestashopCheckout\PayPal\PayPalMerchantIntegrationProvider'
+    public: true
+    arguments:
+      - '@ps_checkout.cache.paypal.merchant_integration'

--- a/src/PayPal/PayPalMerchantIntegrationProvider.php
+++ b/src/PayPal/PayPalMerchantIntegrationProvider.php
@@ -20,10 +20,10 @@
 
 namespace PrestaShop\Module\PrestashopCheckout\PayPal;
 
-use PrestaShop\Module\PrestashopCheckout\PaypalOrder;
+use PrestaShop\Module\PrestashopCheckout\Api\Payment\Shop;
 use Psr\SimpleCache\CacheInterface;
 
-class PayPalOrderProvider
+class PayPalMerchantIntegrationProvider
 {
     /**
      * @var CacheInterface
@@ -39,7 +39,7 @@ class PayPalOrderProvider
     }
 
     /**
-     * @param string $id PayPal Order Id
+     * @param string $id PayPal Merchant Id
      *
      * @return array|false
      */
@@ -49,13 +49,13 @@ class PayPalOrderProvider
             return $this->cache->get($id);
         }
 
-        $orderPayPal = new PaypalOrder($id);
+        $response = (new Shop(\Context::getContext()->link))->getMerchantIntegration($id);
 
-        if (!$orderPayPal->isLoaded()) {
+        if (false === $response['status'] || empty($response['body']['merchant_integrations'])) {
             return false;
         }
 
-        $data = $orderPayPal->getOrder();
+        $data = $response['body']['merchant_integrations'];
 
         $this->cache->set($id, $data);
 

--- a/src/Updater/PaypalAccountUpdater.php
+++ b/src/Updater/PaypalAccountUpdater.php
@@ -20,9 +20,9 @@
 
 namespace PrestaShop\Module\PrestashopCheckout\Updater;
 
-use PrestaShop\Module\PrestashopCheckout\Api\Payment\Shop;
 use PrestaShop\Module\PrestashopCheckout\Entity\PaypalAccount;
 use PrestaShop\Module\PrestashopCheckout\Exception\PsCheckoutException;
+use PrestaShop\Module\PrestashopCheckout\PayPal\PayPalMerchantIntegrationProvider;
 use PrestaShop\Module\PrestashopCheckout\PersistentConfiguration;
 
 /**
@@ -46,9 +46,15 @@ class PaypalAccountUpdater
      */
     private $persistentConfiguration;
 
-    public function __construct(PersistentConfiguration $persistentConfiguration)
+    /**
+     * @var PayPalMerchantIntegrationProvider
+     */
+    private $merchantIntegrationProvider;
+
+    public function __construct(PersistentConfiguration $persistentConfiguration, PayPalMerchantIntegrationProvider $merchantIntegrationProvider)
     {
         $this->persistentConfiguration = $persistentConfiguration;
+        $this->merchantIntegrationProvider = $merchantIntegrationProvider;
     }
 
     /**
@@ -68,7 +74,7 @@ class PaypalAccountUpdater
             throw new PsCheckoutException('MerchantId cannot be empty', PsCheckoutException::PSCHECKOUT_MERCHANT_IDENTIFIER_MISSING);
         }
 
-        $merchantIntegration = $this->getMerchantIntegration($merchantId);
+        $merchantIntegration = $this->merchantIntegrationProvider->getById($merchantId);
 
         if (false === $merchantIntegration) {
             $account->setEmail('');
@@ -153,23 +159,5 @@ class PaypalAccountUpdater
         }
 
         return self::SUBSCRIBED;
-    }
-
-    /**
-     * Get the merchant integration
-     *
-     * @param string $merchantId
-     *
-     * @return false|mixed
-     */
-    private function getMerchantIntegration($merchantId)
-    {
-        $response = (new Shop(\Context::getContext()->link))->getMerchantIntegration($merchantId);
-
-        if (false === $response['status']) {
-            return false;
-        }
-
-        return $response['body']['merchant_integrations'];
     }
 }


### PR DESCRIPTION
Quickwin before refactoring of Onboarding
Avoid to make a call to PSL at every module configuration access.
Merchant integration will be stored in cache for 1 day unless a PSL webhook inform data needs to be refreshed