### PR TITLE
Fix express checkout button missing on cart page 1.7

### DIFF
--- a/_dev/js/front/src/service/html-element.service/index.js
+++ b/_dev/js/front/src/service/html-element.service/index.js
@@ -51,6 +51,10 @@ export class HTMLElementService extends BaseClass {
     return this.instance.getBasePaymentConfirmation();
   }
 
+  getCheckoutExpressCartButtonContainer() {
+    return this.instance.getCheckoutExpressCartButtonContainer();
+  }
+
   getCheckoutExpressCheckoutButtonContainer() {
     return this.instance.getCheckoutExpressCheckoutButtonContainer();
   }


### PR DESCRIPTION
`TypeError: this.htmlElementService.getCheckoutExpressCartButtonContainer is not a function`