### PR TITLE
Fix INVALID_RESOURCE_ID

### DIFF
--- a/src/PaypalOrder.php
+++ b/src/PaypalOrder.php
@@ -49,11 +49,13 @@ class PaypalOrder
     {
         $response = (new Order(\Context::getContext()->link))->fetch($id);
 
-        if (false === $response['status']) {
-            return;
+        if (false === $response['status'] && isset($response['body']['message']) && $response['body']['message'] === 'INVALID_RESOURCE_ID') {
+            \Db::getInstance()->delete(\PsCheckoutCart::$definition['table'], 'paypal_order = "' . pSQL($id) . '"');
         }
 
-        $this->setOrder($response['body']);
+        if (true === $response['status'] && !empty($response['body'])) {
+            $this->setOrder($response['body']);
+        }
     }
 
     /**


### PR DESCRIPTION
Quickfix in case of PayPal Order no longer exist