### PR TITLE
Logout from PrestaShop Checkout Account when token cannot be refreshed

### DIFF
--- a/src/Api/Firebase/Token.php
+++ b/src/Api/Firebase/Token.php
@@ -72,6 +72,28 @@ class Token extends FirebaseClient
                 null,
                 (int) \Context::getContext()->shop->id
             );
+        } elseif (isset($response['httpCode']) && 400 === $response['httpCode']) {
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_ID_TOKEN',
+                '',
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_REFRESH_TOKEN',
+                '',
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
+            \Configuration::updateValue(
+                'PS_PSX_FIREBASE_REFRESH_DATE',
+                '',
+                false,
+                null,
+                (int) \Context::getContext()->shop->id
+            );
         }
 
         return $response;


### PR DESCRIPTION

Request
```
{
    "grant_type": "refresh_token",
    "refresh_token": "MY_REFRESH_TOKEN"
}
```

Response 
```
{
    "error":
    {
        "code": 400,
        "message": "TOKEN_EXPIRED",
        "status": "INVALID_ARGUMENT"
    }
}
```

=> Should be disconnected from PrestaShop Checkout Account

https://firebase.google.com/docs/reference/rest/auth#section-refresh-token