### PR TITLE
Remove reference to $bodyValues

### DIFF
--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -98,7 +98,7 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
                 $this->payload['order']['shipping']['address']['postal_code'],
                 $this->payload['order']['shipping']['address']['admin_area_2'],
                 $this->payload['order']['shipping']['address']['country_code'],
-                false === empty($bodyValues['order']['payer']['phone']) ? $this->payload['order']['payer']['phone']['phone_number']['national_number'] : ''
+                false === empty($this->payload['order']['payer']['phone']) ? $this->payload['order']['payer']['phone']['phone_number']['national_number'] : ''
             );
         } catch (Exception $exception) {
             $this->handleExceptionSendingToSentry($exception);


### PR DESCRIPTION
The installation I have been working with (PS version 1.7.6.9) $bodyValues is always null, causing no phone number to be submitted which is tripping up address validation and causing the user to have to edit the created address.