### PR TITLE
Change CustomerMessageCore:: type to bool

### DIFF
--- a/controllers/front/validate.php
+++ b/controllers/front/validate.php
@@ -454,7 +454,7 @@ class Ps_CheckoutValidateModuleFrontController extends AbstractFrontController
         $customerMessage->message = $message;
         $customerMessage->ip_address = (int) ip2long(Tools::getRemoteAddr());
         $customerMessage->user_agent = $_SERVER['HTTP_USER_AGENT'];
-        $customerMessage->private = 1;
+        $customerMessage->private = true;
         $customerMessage->read = false;
         $customerMessage->add();
     }

--- a/tests/phpstan/phpstan-PS-1.7.neon
+++ b/tests/phpstan/phpstan-PS-1.7.neon
@@ -31,5 +31,6 @@ parameters:
 		- '#Left side of \&\& is always true.#'
 		- '#Parameter \#7 \$currency_special of method PaymentModuleCore::validateOrder\(\) expects null, int given.#'
 		- '#Parameter \#9 \$secure_key of method PaymentModuleCore::validateOrder\(\) expects bool, string given.#'
+		- '#Property CustomerMessageCore::\$private \(int\) does not accept true.#'
 
 	level: 5


### PR DESCRIPTION
Since PrestaShop 1.7.8.0 CustomerMessageCore::$type is now typed to bool, so we need to ignore error of PHPStan

https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/CustomerMessage.php#L51
https://github.com/PrestaShop/PrestaShop/blob/1.7.7.8/classes/CustomerMessage.php#L51