### PR TITLE
PAYSHIP-1806 - Catch Sentry exception to avoid fatal error

### DIFF
--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -42,40 +42,44 @@ class ExceptionHandler
      */
     public function __construct(Ps_checkout $module, SentryEnv $sentryEnv, PsAccountRepository $psAccountRepository)
     {
-        $this->client = $module->getSentryClient();
+        try {
+            $this->client = $module->getSentryClient();
 
-        if (empty($this->client)) {
-            $this->client = new ModuleFilteredRavenClient(
-                $sentryEnv->getDsn(),
-                [
-                    'level' => 'error',
-                    'error_types' => E_ERROR,
-                    'tags' => [
-                        'php_version' => phpversion(),
-                        'module_version' => $module->version,
-                        'prestashop_version' => _PS_VERSION_,
-                    ],
-                ]
-            );
+            if (empty($this->client)) {
+                $this->client = new ModuleFilteredRavenClient(
+                    $sentryEnv->getDsn(),
+                    [
+                        'level' => 'error',
+                        'error_types' => E_ERROR,
+                        'tags' => [
+                            'php_version' => phpversion(),
+                            'module_version' => $module->version,
+                            'prestashop_version' => _PS_VERSION_,
+                        ],
+                    ]
+                );
 
-            $this->client->setAppPath(realpath(_PS_MODULE_DIR_ . 'ps_checkout/'));
-            $this->client->setExcludedAppPaths([
-                realpath(_PS_MODULE_DIR_ . 'ps_checkout/vendor/'),
-            ]);
-            $this->client->setExcludedDomains(['127.0.0.1', 'localhost', '.local']);
+                $this->client->setAppPath(realpath(_PS_MODULE_DIR_ . 'ps_checkout/'));
+                $this->client->setExcludedAppPaths([
+                    realpath(_PS_MODULE_DIR_ . 'ps_checkout/vendor/'),
+                ]);
+                $this->client->setExcludedDomains(['127.0.0.1', 'localhost', '.local']);
 
-            if (version_compare(phpversion(), '7.4.0', '>=') && version_compare(_PS_VERSION_, '1.7.8.0', '<')) {
-                return;
+                if (version_compare(phpversion(), '7.4.0', '>=') && version_compare(_PS_VERSION_, '1.7.8.0', '<')) {
+                    return;
+                }
+
+                $this->client->install();
             }
 
-            $this->client->install();
-        }
-
-        if ($psAccountRepository->onBoardingIsCompleted()) {
-            $this->client->user_context([
-                'id' => $psAccountRepository->getLocalId(),
-                'email' => $psAccountRepository->getEmail(),
-            ]);
+            if ($psAccountRepository->onBoardingIsCompleted()) {
+                $this->client->user_context([
+                    'id' => $psAccountRepository->getLocalId(),
+                    'email' => $psAccountRepository->getEmail(),
+                ]);
+            }
+        } catch (Exception $exception) {
+            $module->getLogger()->debug('Sentry exception', ['exception' => $exception]);
         }
     }
 
@@ -90,7 +94,9 @@ class ExceptionHandler
      */
     public function handle(Exception $error, $throw = true, $data = null)
     {
-        $this->client->captureException($error, $data);
+        if (null !== $this->client) {
+            $this->client->captureException($error, $data);
+        }
 
         if ($throw) {
             throw $error;


### PR DESCRIPTION
If merchant has another module using Sentry in different version, it can cause a fatal error.
As Sentry is currently disabled on our side, it should fail silently and add a log entry instead.