### PR TITLE
PAYSHIP-1916 - Fix fatal error due to gift wrapping fees

### DIFF
--- a/src/Builder/Payload/OrderPayloadBuilder.php
+++ b/src/Builder/Payload/OrderPayloadBuilder.php
@@ -376,8 +376,8 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
         ];
 
         // set handling cost id needed -> principally used in case of gift_wrapping
-        if (!empty($this->cart['cart']['subtotals']['gift_wrapping'])) {
-            $breakdownHandling += $this->cart['cart']['subtotals']['gift_wrapping'];
+        if (!empty($this->cart['cart']['subtotals']['gift_wrapping']['amount'])) {
+            $breakdownHandling += $this->cart['cart']['subtotals']['gift_wrapping']['amount'];
         }
 
         $remainderValue = $amountTotal - $breakdownItemTotal - $breakdownTaxTotal - $breakdownShipping - $breakdownHandling;


### PR DESCRIPTION
Fatal error: Uncaught Error: Unsupported operand types in /modules/ps_checkout/src/Builder/Payload/OrderPayloadBuilder.php:380

Stack trace:

1. /modules/ps_checkout/src/Builder/Payload/OrderPayloadBuilder.php(91): PrestaShop\Module\PrestashopCheckout\Builder\Payload\OrderPayloadBuilder->buildAmountBreakdownNode()
2. /modules/ps_checkout/src/Handler/CreatePaypalOrderHandler.php(82): PrestaShop\Module\PrestashopCheckout\Builder\Payload\OrderPayloadBuilder->buildFullPayload()
3. /modules/ps_checkout/controllers/front/create.php(113): PrestaShop\Module\PrestashopCheckout\Handler\CreatePaypalOrderHandler->handle(false)
4. /classes/controller/Controller.php(281): Ps_CheckoutCreateModuleFrontController->postProcess()
5. /classes/Dispatcher.php(515): ControllerCore->run()
6. /index.php(28): Dispat in /modules/ps_checkout/src/Builder/Payload/OrderPayloadBuilder.php on line 380