### PR TITLE
Fix paymentOptions display

### DIFF
--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -58,7 +58,7 @@
         const paymentOptionContainer = document.getElementById(paymentOption.id + '-container');
         const paymentOptionName = paymentOption.getAttribute('data-module-name');
 
-        if (-1 !== paymentOptionName.search('ps_checkout')) {
+        if (!paymentOptionContainer.classList.contains('ps_checkout-payment-option') && -1 !== paymentOptionName.search('ps_checkout')) {
           paymentOptionContainer.style.display = 'none';
         }
       });


### PR DESCRIPTION
In some cases this script is executed after front.js and add a display none on payment optons already rendered.
We improve condition to check if front.js already processed (it adds  class `ps_checkout-payment-option` when eligible)