### PR TITLE
Release/2.21.0

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,12 @@
+<FilesMatch "^\.env">
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
+
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+</FilesMatch>

--- a/_dev/js/back/src/components/panel/help.vue
+++ b/_dev/js/back/src/components/panel/help.vue
@@ -120,7 +120,7 @@
             <div class="mt-2">
               <b-button
                 variant="link"
-                href="mailto:support-checkout-download@prestashop.com"
+                href="https://help-center.prestashop.com/contact"
                 target="_blank"
                 @click="onClickContactUs()"
               >

--- a/_dev/js/back/src/components/panel/payment-mode.vue
+++ b/_dev/js/back/src/components/panel/payment-mode.vue
@@ -23,27 +23,13 @@
       {{ $t('panel.payment-mode.title') }}
     </template>
     <b-card-body>
+      <b-alert class="d-inline-block w-100" variant="warning" show>
+        <p>
+          After switch environment, please logout from PayPal Account and login
+          again on the new environment.
+        </p>
+      </b-alert>
       <b-form>
-        <b-form-group
-          label-cols="4"
-          label-align="right"
-          :label="$t('panel.payment-mode.paymentAction')"
-          label-for="intent-mode"
-        >
-          <b-form-radio-group
-            id="intent-mode"
-            v-model="captureMode"
-            :options="intentOptions"
-            buttons
-            button-variant="outline-primary"
-            name="radio-btn-outline"
-          />
-        </b-form-group>
-
-        <b-alert class="d-inline-block w-100" variant="info" show>
-          <p>{{ $t('panel.payment-mode.infoAlertText') }}.</p>
-        </b-alert>
-
         <b-form-group
           v-if="paymentMode === 'LIVE'"
           label-cols="4"
@@ -96,14 +82,6 @@
 
 <script>
   export default {
-    data() {
-      return {
-        intentOptions: [
-          { text: this.$t('panel.payment-mode.capture'), value: 'CAPTURE' },
-          { text: this.$t('panel.payment-mode.authorize'), value: 'AUTHORIZE' }
-        ]
-      };
-    },
     methods: {
       updatePaymentMode() {
         let mode = 'LIVE';
@@ -117,17 +95,6 @@
       }
     },
     computed: {
-      captureMode: {
-        get() {
-          return this.$store.state.configuration.captureMode;
-        },
-        set(value) {
-          if (this.captureMode === value) {
-            return;
-          }
-          this.$store.dispatch('updateCaptureMode', value);
-        }
-      },
       paymentMode() {
         return this.$store.state.configuration.paymentMode;
       }

--- a/_dev/js/back/src/components/panel/paypal-account.vue
+++ b/_dev/js/back/src/components/panel/paypal-account.vue
@@ -46,7 +46,7 @@
             </template>
 
             <template v-else>
-              {{ $t('panel.accounts.paypal.isLinked') }}
+              {{ $t('panel.accounts.paypal.isLinked') }} <i v-if="paypalMerchantId">{{ $t('panel.accounts.paypal.merchantId', [paypalMerchantId]) }}</i>
 
               <br />
 
@@ -188,6 +188,9 @@
         }
 
         return emailMerchant;
+      },
+      paypalMerchantId() {
+        return this.$store.state.paypal.idMerchant;
       },
       checkoutAccountStatus() {
         return this.$store.state.firebase.onboardingCompleted;

--- a/_dev/js/front/src/api/ps-checkout.api.js
+++ b/_dev/js/front/src/api/ps-checkout.api.js
@@ -190,33 +190,30 @@ export class PsCheckoutApi extends BaseClass {
         throw new Error('Invalid response');
       })
       .then((response) => {
-        if (response.body && 'COMPLETED' === response.body.paypal_status) {
-          const {
-            id_cart,
-            id_module,
-            id_order,
-            secure_key,
-            paypal_order,
-            paypal_transaction
-          } = response.body;
+        const {
+          id_cart,
+          id_module,
+          id_order,
+          secure_key,
+          paypal_order,
+          paypal_status,
+          paypal_transaction
+        } = response.body || {};
 
-          const confirmationUrl = new URL(this.config.confirmationUrl);
-          confirmationUrl.searchParams.append('id_cart', id_cart);
-          confirmationUrl.searchParams.append('id_module', id_module);
-          confirmationUrl.searchParams.append('id_order', id_order);
-          confirmationUrl.searchParams.append('key', secure_key);
-          confirmationUrl.searchParams.append('paypal_order', paypal_order);
-          confirmationUrl.searchParams.append(
-            'paypal_transaction',
-            paypal_transaction
-          );
+        const confirmationUrl = new URL(this.config.confirmationUrl);
+        confirmationUrl.searchParams.append('id_cart', id_cart);
+        confirmationUrl.searchParams.append('id_module', id_module);
+        confirmationUrl.searchParams.append('id_order', id_order);
+        confirmationUrl.searchParams.append('key', secure_key);
+        confirmationUrl.searchParams.append('paypal_order', paypal_order);
+        confirmationUrl.searchParams.append('paypal_status', paypal_status);
+        confirmationUrl.searchParams.append('fundingSource', data.fundingSource);
+        confirmationUrl.searchParams.append(
+          'paypal_transaction',
+          paypal_transaction
+        );
 
-          window.location.href = confirmationUrl.toString();
-        }
-
-        if (response.error && 'INSTRUMENT_DECLINED' === response.error) {
-          return actions.restart();
-        }
+        window.location.href = confirmationUrl.toString();
       });
   }
 

--- a/_dev/js/front/src/api/ps-checkout.api.js
+++ b/_dev/js/front/src/api/ps-checkout.api.js
@@ -190,30 +190,33 @@ export class PsCheckoutApi extends BaseClass {
         throw new Error('Invalid response');
       })
       .then((response) => {
-        const {
-          id_cart,
-          id_module,
-          id_order,
-          secure_key,
-          paypal_order,
-          paypal_status,
-          paypal_transaction
-        } = response.body || {};
+        if (response.body && 'COMPLETED' === response.body.paypal_status) {
+          const {
+            id_cart,
+            id_module,
+            id_order,
+            secure_key,
+            paypal_order,
+            paypal_transaction
+          } = response.body;
 
-        const confirmationUrl = new URL(this.config.confirmationUrl);
-        confirmationUrl.searchParams.append('id_cart', id_cart);
-        confirmationUrl.searchParams.append('id_module', id_module);
-        confirmationUrl.searchParams.append('id_order', id_order);
-        confirmationUrl.searchParams.append('key', secure_key);
-        confirmationUrl.searchParams.append('paypal_order', paypal_order);
-        confirmationUrl.searchParams.append('paypal_status', paypal_status);
-        confirmationUrl.searchParams.append('fundingSource', data.fundingSource);
-        confirmationUrl.searchParams.append(
-          'paypal_transaction',
-          paypal_transaction
-        );
+          const confirmationUrl = new URL(this.config.confirmationUrl);
+          confirmationUrl.searchParams.append('id_cart', id_cart);
+          confirmationUrl.searchParams.append('id_module', id_module);
+          confirmationUrl.searchParams.append('id_order', id_order);
+          confirmationUrl.searchParams.append('key', secure_key);
+          confirmationUrl.searchParams.append('paypal_order', paypal_order);
+          confirmationUrl.searchParams.append(
+            'paypal_transaction',
+            paypal_transaction
+          );
 
-        window.location.href = confirmationUrl.toString();
+          window.location.href = confirmationUrl.toString();
+        }
+
+        if (response.error && 'INSTRUMENT_DECLINED' === response.error) {
+          return actions.restart();
+        }
       });
   }
 

--- a/_dev/js/front/src/components/1_6/express-button-cart.component.js
+++ b/_dev/js/front/src/components/1_6/express-button-cart.component.js
@@ -66,9 +66,11 @@ export class ExpressButtonCartComponent extends BaseComponent {
     if (!this.buttonReferenceContainer) return;
 
     this.renderComponent();
-    this.prestashopService.onUpdatedShoppingCartExtra(() =>
-      this.renderComponent()
-    );
+    this.prestashopService.onUpdatedShoppingCartExtra(() => {
+        if (null === document.querySelector('#ps_checkout-express-button-cart')) {
+          this.renderComponent();
+        }
+    });
 
     return this;
   }

--- a/_dev/js/front/src/components/1_6/pay-later-button-cart.component.js
+++ b/_dev/js/front/src/components/1_6/pay-later-button-cart.component.js
@@ -68,9 +68,11 @@ export class PayLaterButtonCartComponent extends BaseComponent {
     if (!this.buttonReferenceContainer) return;
 
     this.renderComponent();
-    this.prestashopService.onUpdatedShoppingCartExtra(() =>
-      this.renderComponent()
-    );
+    this.prestashopService.onUpdatedShoppingCartExtra(() => {
+      if (null === document.querySelector('#ps_checkout-express-button-cart')) {
+        this.renderComponent();
+      }
+    });
 
     return this;
   }

--- a/_dev/js/front/src/components/1_6/payment-options.component.js
+++ b/_dev/js/front/src/components/1_6/payment-options.component.js
@@ -136,6 +136,25 @@ export class PaymentOptionsComponent extends BaseComponent {
     });
   }
 
+  renderExpressCheckoutCancelButton() {
+    const cancelButton = document.querySelector('#ps_checkout-cancel');
+    cancelButton.addEventListener('click', (event) => {
+      this.psCheckoutApi.postCancelOrder(
+        {
+          orderID: this.payPalService.getOrderId(),
+          fundingSource: this.payPalService.getFundingSource(),
+          isExpressCheckout: true
+        })
+        .then(() => {
+          location.reload();
+        })
+        .catch((error) => {
+          console.log(error);
+          this.data.notification.showError(error.message);
+        });
+    });
+  }
+
   render() {
     this.data.conditions = this.app.root.children.conditionsCheckbox;
     this.data.notification = this.app.root.children.notification;
@@ -147,6 +166,7 @@ export class PaymentOptionsComponent extends BaseComponent {
     } else {
       this.data.HTMLElement.style.display = 'none';
       this.renderExpressCheckoutPaymentButton();
+      this.renderExpressCheckoutCancelButton();
     }
 
     return this;

--- a/_dev/js/front/src/components/1_6/payment-options.component.js
+++ b/_dev/js/front/src/components/1_6/payment-options.component.js
@@ -138,7 +138,13 @@ export class PaymentOptionsComponent extends BaseComponent {
 
   renderExpressCheckoutCancelButton() {
     const cancelButton = document.querySelector('#ps_checkout-cancel');
-    cancelButton.addEventListener('click', (event) => {
+
+    if (!cancelButton) {
+      console.error('HTMLElement selector #ps_checkout-cancel not found.');
+      return;
+    }
+
+    cancelButton.addEventListener('click', () => {
       this.psCheckoutApi.postCancelOrder(
         {
           orderID: this.payPalService.getOrderId(),
@@ -149,7 +155,7 @@ export class PaymentOptionsComponent extends BaseComponent {
           location.reload();
         })
         .catch((error) => {
-          console.log(error);
+          console.error(error);
           this.data.notification.showError(error.message);
         });
     });

--- a/_dev/js/front/src/components/1_6/payment-options.component.js
+++ b/_dev/js/front/src/components/1_6/payment-options.component.js
@@ -29,10 +29,6 @@ export class PaymentOptionsComponent extends BaseComponent {
 
   created() {
     this.data.HTMLElement = this.querySelectorService.getPaymentOptions();
-
-    this.data.HTMLExpressCheckoutPaymentConfirmation = this.querySelectorService.getBasePaymentConfirmation();
-
-    this.data.HTMLElementHookPayment = document.querySelector('#HOOK_PAYMENT');
   }
 
   renderPaymentOptionItems() {
@@ -48,7 +44,6 @@ export class PaymentOptionsComponent extends BaseComponent {
           new PaymentOptionComponent(this.app, {
             fundingSource: fundingSource,
             markPosition: this.props.markPosition,
-
             HTMLElement
           }).render()
         );
@@ -57,8 +52,7 @@ export class PaymentOptionsComponent extends BaseComponent {
   }
 
   renderPaymentOptionListener() {
-    const HTMLListenerElements = this.children.paymentOptions.map(
-      (paymentOption) => {
+    const HTMLListenerElements = this.children.paymentOptions.map((paymentOption) => {
         const HTMLElement = paymentOption.data.HTMLElementContainer;
         const [button, form] = Array.prototype.slice.call(
           HTMLElement.querySelectorAll('.payment_module')
@@ -80,85 +74,41 @@ export class PaymentOptionsComponent extends BaseComponent {
           this.data.notification.hideError();
         });
 
+        if (this.config.expressCheckout.active && (('ps_checkout-' + this.payPalService.getFundingSource()) !== HTMLListenerElements[index].button.dataset.moduleName)) {
+          this.psCheckoutApi.postCancelOrder(
+            {
+              orderID: this.payPalService.getOrderId(),
+              fundingSource: this.payPalService.getFundingSource(),
+              isExpressCheckout: true
+            }
+          ).then(() => {
+            this.config.expressCheckout.active = false;
+
+            const expressCheckoutContainer = document.querySelector('#ps_checkout-express-checkout-banner');
+            if (expressCheckoutContainer) {
+              expressCheckoutContainer.style.display = 'none';
+            }
+          });
+        }
+
         HTMLListenerElements[index].button.classList.add('open');
         HTMLListenerElements[index].button.classList.remove('closed');
         HTMLListenerElements[index].form.classList.add('open');
         HTMLListenerElements[index].form.classList.remove('closed');
       });
     });
-  }
 
-  getHookPaymentElements() {
-    return Array.prototype.slice.call(
-      document.querySelector('#HOOK_PAYMENT').children
-    );
-  }
-
-  renderExpressCheckoutPaymentButton() {
-    const paymentButton = this.data.HTMLExpressCheckoutPaymentConfirmation;
-
-    paymentButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      this.data.loader.show();
-
-      this.psCheckoutApi
-        .postCheckCartOrder(
-          {
-            orderID: this.payPalService.getOrderId(),
-            fundingSource: this.payPalService.getFundingSource(),
-            isExpressCheckout: true
-          },
-          { resolve: () => {}, reject: () => {} }
-        )
-        .then(() =>
-          this.psCheckoutApi.postValidateOrder({
-            orderID: this.payPalService.getOrderId(),
-            fundingSource: this.payPalService.getFundingSource(),
-            isExpressCheckout: true
-          })
-        )
-        .catch((error) => {
-          console.log(error);
-          this.data.loader.hide();
-          this.data.notification.showError(error.message);
-        });
-    });
-
-    paymentButton.disabled = !this.data.conditions.isChecked();
-    this.data.conditions.onChange(() => {
-      paymentButton.disabled = !this.data.conditions.isChecked();
-    });
-
-    this.getHookPaymentElements().forEach((element) => {
-      if (element.id !== 'ps_checkout-displayPayment' && element.id !== 'ps_checkout-notification-container') {
-        element.style.display = 'none';
-      }
-    });
-  }
-
-  renderExpressCheckoutCancelButton() {
-    const cancelButton = document.querySelector('#ps_checkout-cancel');
-
-    if (!cancelButton) {
-      console.error('HTMLElement selector #ps_checkout-cancel not found.');
-      return;
+    console.log(this.payPalService.getFundingSource());
+    if (this.config.expressCheckout.active) {
+      HTMLListenerElements.forEach(({ button, form }) => {
+        if (button.dataset.moduleName === ('ps_checkout-' + this.payPalService.getFundingSource())) {
+          button.classList.add('open');
+          button.classList.remove('closed');
+          form.classList.add('open');
+          form.classList.remove('closed');
+        }
+      });
     }
-
-    cancelButton.addEventListener('click', () => {
-      this.psCheckoutApi.postCancelOrder(
-        {
-          orderID: this.payPalService.getOrderId(),
-          fundingSource: this.payPalService.getFundingSource(),
-          isExpressCheckout: true
-        })
-        .then(() => {
-          location.reload();
-        })
-        .catch((error) => {
-          console.error(error);
-          this.data.notification.showError(error.message);
-        });
-    });
   }
 
   render() {
@@ -166,14 +116,8 @@ export class PaymentOptionsComponent extends BaseComponent {
     this.data.notification = this.app.root.children.notification;
     this.data.loader = this.app.root.children.loader;
 
-    if (!this.config.expressCheckout.active) {
-      this.renderPaymentOptionItems();
-      this.renderPaymentOptionListener();
-    } else {
-      this.data.HTMLElement.style.display = 'none';
-      this.renderExpressCheckoutPaymentButton();
-      this.renderExpressCheckoutCancelButton();
-    }
+    this.renderPaymentOptionItems();
+    this.renderPaymentOptionListener();
 
     return this;
   }

--- a/_dev/js/front/src/components/1_7/payment-options.component.js
+++ b/_dev/js/front/src/components/1_7/payment-options.component.js
@@ -40,12 +40,15 @@ export class PaymentOptionsComponent extends BaseComponent {
           `[data-module-name^="ps_checkout-${fundingSource.name}"]`
         );
 
+        if (this.payPalService.getFundingSource() === fundingSource.name) {
+          HTMLElement.click();
+        }
+
         return (
           HTMLElement &&
           new PaymentOptionComponent(this.app, {
             fundingSource: fundingSource,
             markPosition: this.props.markPosition,
-
             HTMLElement
           }).render()
         );
@@ -53,114 +56,30 @@ export class PaymentOptionsComponent extends BaseComponent {
       .filter((paymentOption) => paymentOption);
   }
 
-  renderPaymentOptionRadios() {
+  renderPaymentOptionListener() {
     const radios = this.querySelectorService.getPaymentOptionRadios();
     radios.forEach((radio) => {
       radio.addEventListener('change', () => {
         this.data.notification.hideCancelled();
         this.data.notification.hideError();
+
+        if (this.config.expressCheckout.active && (('ps_checkout-' + this.payPalService.getFundingSource()) !== radio.dataset.moduleName)) {
+          this.psCheckoutApi.postCancelOrder(
+            {
+              orderID: this.payPalService.getOrderId(),
+              fundingSource: this.payPalService.getFundingSource(),
+              isExpressCheckout: true
+            }
+          ).then(() => {
+            this.config.expressCheckout.active = false;
+
+            const expressCheckoutContainer = document.querySelector('#ps_checkout-express-checkout-banner');
+            if (expressCheckoutContainer) {
+              expressCheckoutContainer.style.display = 'none';
+            }
+          });
+        }
       });
-    });
-  }
-
-  renderExpressCheckoutPaymentButton() {
-    this.data.HTMLElementPaymentOptionsContainer.style.display = 'none';
-    const nativePaymentButton = this.data.HTMLBasePaymentConfirmation;
-    const paymentButton = nativePaymentButton.cloneNode(true);
-    const nativePaymentButtonContainer = nativePaymentButton.parentElement;
-
-    nativePaymentButton.style.display = 'none';
-
-    paymentButton.id = 'ps_checkout-express-checkout-button';
-    paymentButton.type = 'button';
-
-    paymentButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      this.data.loader.show();
-
-      this.psCheckoutApi
-        .postCheckCartOrder(
-          {
-            orderID: this.payPalService.getOrderId(),
-            fundingSource: this.payPalService.getFundingSource(),
-            isExpressCheckout: true
-          },
-          { resolve: () => {}, reject: () => {} }
-        )
-        .then(() =>
-          this.psCheckoutApi.postValidateOrder({
-            orderID: this.payPalService.getOrderId(),
-            fundingSource: this.payPalService.getFundingSource(),
-            isExpressCheckout: true
-          })
-        )
-        .catch((error) => {
-          console.log(error);
-          this.data.loader.hide();
-          this.data.notification.showError(error.message);
-        });
-    });
-
-    this.children.expressCheckoutButton = document.createElement('div');
-
-    this.children.expressCheckoutButton.id = 'button-paypal';
-    this.children.expressCheckoutButton.classList.add(
-      'ps_checkout-express-checkout-button'
-    );
-
-    paymentButton.disabled = !this.data.conditions.isChecked();
-    paymentButton.classList.toggle('disabled', paymentButton.disabled);
-
-    this.data.conditions.onChange(() => {
-      setTimeout(() => {
-        nativePaymentButton.style.display = 'none';
-        paymentButton.disabled = !this.data.conditions.isChecked();
-        paymentButton.classList.toggle('disabled', paymentButton.disabled);
-      }, 0);
-    });
-
-    this.children.expressCheckoutButton.append(paymentButton);
-    nativePaymentButtonContainer.append(
-      this.children.expressCheckoutButton
-    );
-  }
-
-  renderExpressCheckoutCancelButton() {
-    const cancelButton = document.querySelector('#ps_checkout-cancel');
-
-    if (!cancelButton) {
-      console.error('HTMLElement selector #ps_checkout-cancel not found.');
-      return;
-    }
-
-    cancelButton.addEventListener('click', () => {
-      this.psCheckoutApi.postCancelOrder(
-        {
-          orderID: this.payPalService.getOrderId(),
-          fundingSource: this.payPalService.getFundingSource(),
-          isExpressCheckout: true
-        })
-        .then(() => {
-          this.renderPaymentOptionItems();
-          this.renderPaymentOptionRadios();
-          const expressCheckoutContainer = document.querySelector('.express-checkout-block');
-          const expressCheckoutPaymentButton = document.querySelector('#ps_checkout-express-checkout-button');
-
-          if (expressCheckoutContainer) {
-            expressCheckoutContainer.style.display = 'none';
-          }
-
-          if (expressCheckoutPaymentButton) {
-            expressCheckoutPaymentButton.style.display = 'none';
-          }
-
-          this.data.HTMLElementPaymentOptionsContainer.style.display = 'block';
-          this.data.HTMLBasePaymentConfirmation.style.display = 'block';
-        })
-        .catch((error) => {
-          console.error(error);
-          this.data.notification.showError(error.message);
-        });
     });
   }
 
@@ -169,13 +88,8 @@ export class PaymentOptionsComponent extends BaseComponent {
     this.data.notification = this.app.root.children.notification;
     this.data.loader = this.app.root.children.loader;
 
-    if (!this.config.expressCheckout.active) {
-      this.renderPaymentOptionItems();
-      this.renderPaymentOptionRadios();
-    } else {
-      this.renderExpressCheckoutPaymentButton();
-      this.renderExpressCheckoutCancelButton();
-    }
+    this.renderPaymentOptionItems();
+    this.renderPaymentOptionListener();
 
     return this;
   }

--- a/_dev/js/front/src/components/1_7/payment-options.component.js
+++ b/_dev/js/front/src/components/1_7/payment-options.component.js
@@ -125,6 +125,28 @@ export class PaymentOptionsComponent extends BaseComponent {
     );
   }
 
+  renderExpressCheckoutCancelButton() {
+    const cancelButton = document.querySelector('#ps_checkout-cancel');
+    cancelButton.addEventListener('click', (event) => {
+      this.psCheckoutApi.postCancelOrder(
+        {
+          orderID: this.payPalService.getOrderId(),
+          fundingSource: this.payPalService.getFundingSource(),
+          isExpressCheckout: true
+        })
+        .then(() => {
+          this.renderPaymentOptionItems();
+          this.renderPaymentOptionRadios();
+          document.querySelector('#ps_checkout-block').style.display = 'none';
+          document.querySelector('.payment-options').style.display = 'block';
+        })
+        .catch((error) => {
+          console.log(error);
+          this.data.notification.showError(error.message);
+        });
+    });
+  }
+
   render() {
     this.data.conditions = this.app.root.children.conditionsCheckbox;
     this.data.notification = this.app.root.children.notification;
@@ -135,6 +157,7 @@ export class PaymentOptionsComponent extends BaseComponent {
       this.renderPaymentOptionRadios();
     } else {
       this.renderExpressCheckoutPaymentButton();
+      this.renderExpressCheckoutCancelButton();
     }
 
     return this;

--- a/_dev/js/front/src/components/1_7/payment-options.component.js
+++ b/_dev/js/front/src/components/1_7/payment-options.component.js
@@ -127,7 +127,13 @@ export class PaymentOptionsComponent extends BaseComponent {
 
   renderExpressCheckoutCancelButton() {
     const cancelButton = document.querySelector('#ps_checkout-cancel');
-    cancelButton.addEventListener('click', (event) => {
+
+    if (!cancelButton) {
+      console.error('HTMLElement selector #ps_checkout-cancel not found.');
+      return;
+    }
+
+    cancelButton.addEventListener('click', () => {
       this.psCheckoutApi.postCancelOrder(
         {
           orderID: this.payPalService.getOrderId(),
@@ -137,11 +143,16 @@ export class PaymentOptionsComponent extends BaseComponent {
         .then(() => {
           this.renderPaymentOptionItems();
           this.renderPaymentOptionRadios();
-          document.querySelector('#ps_checkout-block').style.display = 'none';
-          document.querySelector('.payment-options').style.display = 'block';
+          const expressCheckoutContainer = document.querySelector('.express-checkout-block');
+
+          if (expressCheckoutContainer) {
+            expressCheckoutContainer.style.display = 'none';
+          }
+
+          this.data.HTMLElementPaymentOptionsContainer.style.display = 'block';
         })
         .catch((error) => {
-          console.log(error);
+          console.error(error);
           this.data.notification.showError(error.message);
         });
     });

--- a/_dev/js/front/src/components/1_7/payment-options.component.js
+++ b/_dev/js/front/src/components/1_7/payment-options.component.js
@@ -144,12 +144,18 @@ export class PaymentOptionsComponent extends BaseComponent {
           this.renderPaymentOptionItems();
           this.renderPaymentOptionRadios();
           const expressCheckoutContainer = document.querySelector('.express-checkout-block');
+          const expressCheckoutPaymentButton = document.querySelector('#ps_checkout-express-checkout-button');
 
           if (expressCheckoutContainer) {
             expressCheckoutContainer.style.display = 'none';
           }
 
+          if (expressCheckoutPaymentButton) {
+            expressCheckoutPaymentButton.style.display = 'none';
+          }
+
           this.data.HTMLElementPaymentOptionsContainer.style.display = 'block';
+          this.data.HTMLBasePaymentConfirmation.style.display = 'block';
         })
         .catch((error) => {
           console.error(error);

--- a/_dev/js/front/src/components/common/express-checkout-button.component.js
+++ b/_dev/js/front/src/components/common/express-checkout-button.component.js
@@ -33,7 +33,12 @@ export class ExpressCheckoutButtonComponent extends BaseComponent {
     return (
       this.psCheckoutApi
         .postCheckCartOrder(
-          { ...data, fundingSource: this.props.fundingSource, isExpressCheckout: true },
+          {
+            ...data,
+            fundingSource: this.props.fundingSource,
+            isExpressCheckout: true,
+            orderID: this.payPalService.getOrderId(),
+          },
           actions
         )
         // TODO: Error notification

--- a/_dev/js/front/src/components/common/hosted-fields.component.js
+++ b/_dev/js/front/src/components/common/hosted-fields.component.js
@@ -183,6 +183,7 @@ export class HostedFieldsComponent extends BaseComponent {
 
     this.data.HTMLElementButtonWrapper.append(this.data.HTMLElementButton);
     this.data.HTMLElementButton.classList.remove('disabled');
+    this.data.HTMLElementButton.style.display = '';
     this.data.HTMLElementButton.disabled = !this.isSubmittable();
 
     this.data.conditions &&

--- a/_dev/js/front/src/components/common/payment-option.component.js
+++ b/_dev/js/front/src/components/common/payment-option.component.js
@@ -69,10 +69,15 @@ export class PaymentOptionComponent extends BaseComponent {
       this.$(translationKey) !== undefined
         ? this.$(translationKey)
         : this.$('funding-source.name.default');
-
-    return Array.prototype.slice
+    let element = Array.prototype.slice
       .call(this.data.HTMLElementContainer.querySelectorAll('*'))
       .find(item => item.innerHTML.trim() === label.trim());
+
+    if (!element) {
+      console.error('HTMLElement label "' + label.trim() + '" not found.');
+    }
+
+    return element;
   }
 
   getSmartButton() {
@@ -93,6 +98,10 @@ export class PaymentOptionComponent extends BaseComponent {
   }
 
   renderMark() {
+    if (!this.data.HTMLElementLabel) {
+      return;
+    }
+
     if (!this.data.HTMLElementMarker) {
       this.data.HTMLElementMarker = document.createElement('div');
       this.data.HTMLElementMarker.style.display = 'inline-block';
@@ -112,6 +121,11 @@ export class PaymentOptionComponent extends BaseComponent {
   }
 
   render() {
+    if (this.data.HTMLElementContainer.classList.contains('ps_checkout-payment-option')) {
+      // Render already done
+      return;
+    }
+
     this.renderWrapper();
     this.renderMark();
 

--- a/_dev/js/front/src/components/common/paypal-sdk.component.js
+++ b/_dev/js/front/src/components/common/paypal-sdk.component.js
@@ -48,6 +48,10 @@ export class PayPalSdkComponent extends BaseComponent {
       script.setAttribute('data-order-id', this.config.orderId);
     }
 
+    if (this.config.partnerAttributionId) {
+      script.setAttribute('data-partner-attribution-id', this.config.partnerAttributionId);
+    }
+
     script.setAttribute('data-client-token', this.props.token);
 
     document.head.appendChild(script);

--- a/_dev/js/front/src/components/common/smart-button.component.js
+++ b/_dev/js/front/src/components/common/smart-button.component.js
@@ -91,8 +91,12 @@ export class SmartButtonComponent extends BaseComponent {
           }
 
           return this.psCheckoutApi
-            .postCheckCartOrder(
-              { ...data, fundingSource: this.data.name },
+            .postCheckCartOrder({
+                ...data,
+                fundingSource: this.data.name,
+                isExpressCheckout: this.config.expressCheckout.active,
+                orderID: this.payPalService.getOrderId(),
+              },
               actions
             )
             .catch(error => {
@@ -111,8 +115,11 @@ export class SmartButtonComponent extends BaseComponent {
         onApprove: (data, actions) => {
           this.data.loader.show();
           return this.psCheckoutApi
-            .postValidateOrder(
-              { ...data, fundingSource: this.data.name },
+            .postValidateOrder({
+                ...data,
+                fundingSource: this.data.name,
+                isExpressCheckout: this.config.expressCheckout.active
+              },
               actions
             )
             .catch(error => {
@@ -127,7 +134,8 @@ export class SmartButtonComponent extends BaseComponent {
           return this.psCheckoutApi
             .postCancelOrder({
               ...data,
-              fundingSource: this.data.name
+              fundingSource: this.data.name,
+              isExpressCheckout: this.config.expressCheckout.active
             })
             .catch(error => {
               this.data.loader.hide();
@@ -138,7 +146,8 @@ export class SmartButtonComponent extends BaseComponent {
           return this.psCheckoutApi
             .postCreateOrder({
               ...data,
-              fundingSource: this.data.name
+              fundingSource: this.data.name,
+              isExpressCheckout: this.config.expressCheckout.active
             })
             .catch(error => {
               this.data.loader.hide();

--- a/_dev/js/front/src/config/paypal-sdk.config.js
+++ b/_dev/js/front/src/config/paypal-sdk.config.js
@@ -31,5 +31,6 @@ export const PayPalSdkConfig = {
   hostedFieldsCustomization:
     window.ps_checkoutHostedFieldsCustomizationConfiguration,
   payLaterOfferMessageCustomization: window.ps_checkoutPayLaterOfferMessageCustomization,
-  payLaterOfferBannerCustomization: window.ps_checkoutPayLaterOfferBannerCustomization
+  payLaterOfferBannerCustomization: window.ps_checkoutPayLaterOfferBannerCustomization,
+  partnerAttributionId: window.ps_checkoutPartnerAttributionId
 };

--- a/_dev/js/front/src/service/query-selector.service/query-selector-ps1_6.service.js
+++ b/_dev/js/front/src/service/query-selector.service/query-selector-ps1_6.service.js
@@ -25,63 +25,59 @@ const SELECTORS = {
 
 export class QuerySelectorPs1_6Service {
   static getBasePaymentConfirmation() {
-    return document.querySelector(SELECTORS.BASE_PAYMENT_CONFIRMATION);
+    return this.querySelector(SELECTORS.BASE_PAYMENT_CONFIRMATION);
   }
 
   static getConditionsCheckboxes() {
-    return Array.prototype.slice.call(
-      document.querySelectorAll(SELECTORS.CONDITIONS_CHECKBOXES)
-    );
+    return this.querySelectorAll(SELECTORS.CONDITIONS_CHECKBOXES);
   }
 
   static getLoaderParent() {
-    return document.querySelector(SELECTORS.LOADER_PARENT);
+    return this.querySelector(SELECTORS.LOADER_PARENT);
   }
 
   static getNotificationConditions() {
-    return document.querySelector(SELECTORS.NOTIFICATION_CONDITIONS);
+    return this.querySelector(SELECTORS.NOTIFICATION_CONDITIONS);
   }
 
   static getNotificationPaymentCanceled() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_CANCELLED);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_CANCELLED);
   }
 
   static getNotificationPaymentError() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR);
   }
 
   static getNotificationPaymentErrorText() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR_TEXT);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR_TEXT);
   }
 
   static getPaymentOptions() {
-    return document.querySelector(SELECTORS.PAYMENT_OPTIONS);
+    return this.querySelector(SELECTORS.PAYMENT_OPTIONS);
   }
 
   static getPaymentOptionsLoader() {
-    return document.querySelector(SELECTORS.PAYMENT_OPTIONS_LOADER);
+    return this.querySelector(SELECTORS.PAYMENT_OPTIONS_LOADER);
   }
 
   static getPaymentOptionRadios() {
-    return Array.prototype.slice.call(
-      document.querySelectorAll(SELECTORS.PAYMENT_OPTION_RADIOS)
-    );
+    return this.querySelectorAll(SELECTORS.PAYMENT_OPTION_RADIOS);
   }
 
   static getExpressCheckoutButtonContainerCart() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_CART_PAGE
     );
   }
 
   static getExpressCheckoutButtonContainerCheckout() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_CHECKOUT_PAGE
     );
   }
 
   static getExpressCheckoutButtonContainerProduct() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_PRODUCT_PAGE
     );
   }
@@ -89,10 +85,10 @@ export class QuerySelectorPs1_6Service {
   static getPayLaterOfferMessageContainerSelector(placement) {
     switch (placement) {
       case 'product':
-        return document.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_PRODUCT);
+        return this.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_PRODUCT);
       case 'cart':
       case 'payment':
-        return document.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_CART_SUMMARY);
+        return this.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_CART_SUMMARY);
       default:
         return;
     }
@@ -105,9 +101,31 @@ export class QuerySelectorPs1_6Service {
       case 'home':
       case 'payment':
       case 'category':
-        return document.querySelector(SELECTORS.PAY_LATER_BANNER_CONTAINER);
+        return this.querySelector(SELECTORS.PAY_LATER_BANNER_CONTAINER);
       default:
         return;
     }
+  }
+
+  static querySelector(selector) {
+    let element = document.querySelector(selector);
+
+    if (!element) {
+      console.error('HTMLElement selector ' + selector + ' not found.');
+    }
+
+    return element;
+  }
+
+  static querySelectorAll(selector) {
+    let elements = Array.prototype.slice.call(
+      document.querySelectorAll(selector)
+    );
+
+    if (!elements) {
+      console.error('HTMLElement selector ' + selector + ' not found.');
+    }
+
+    return elements;
   }
 }

--- a/_dev/js/front/src/service/query-selector.service/query-selector-ps1_7.service.js
+++ b/_dev/js/front/src/service/query-selector.service/query-selector-ps1_7.service.js
@@ -25,63 +25,59 @@ const SELECTORS = {
 
 export class QuerySelectorPs1_7Service {
   static getBasePaymentConfirmation() {
-    return document.querySelector(SELECTORS.BASE_PAYMENT_CONFIRMATION);
+    return this.querySelector(SELECTORS.BASE_PAYMENT_CONFIRMATION);
   }
 
   static getConditionsCheckboxes() {
-    return Array.prototype.slice.call(
-      document.querySelectorAll(SELECTORS.CONDITIONS_CHECKBOXES)
-    );
+    return this.querySelectorAll(SELECTORS.CONDITIONS_CHECKBOXES);
   }
 
   static getLoaderParent() {
-    return document.querySelector(SELECTORS.LOADER_PARENT);
+    return this.querySelector(SELECTORS.LOADER_PARENT);
   }
 
   static getNotificationConditions() {
-    return document.querySelector(SELECTORS.NOTIFICATION_CONDITIONS);
+    return this.querySelector(SELECTORS.NOTIFICATION_CONDITIONS);
   }
 
   static getNotificationPaymentCanceled() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_CANCELLED);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_CANCELLED);
   }
 
   static getNotificationPaymentError() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR);
   }
 
   static getNotificationPaymentErrorText() {
-    return document.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR_TEXT);
+    return this.querySelector(SELECTORS.NOTIFICATION_PAYMENT_ERROR_TEXT);
   }
 
   static getPaymentOptions() {
-    return document.querySelector(SELECTORS.PAYMENT_OPTIONS);
+    return this.querySelector(SELECTORS.PAYMENT_OPTIONS);
   }
 
   static getPaymentOptionsLoader() {
-    return document.querySelector(SELECTORS.PAYMENT_OPTIONS_LOADER);
+    return this.querySelector(SELECTORS.PAYMENT_OPTIONS_LOADER);
   }
 
   static getPaymentOptionRadios() {
-    return Array.prototype.slice.call(
-      document.querySelectorAll(SELECTORS.PAYMENT_OPTION_RADIOS)
-    );
+    return this.querySelectorAll(SELECTORS.PAYMENT_OPTION_RADIOS);
   }
 
   static getExpressCheckoutButtonContainerCart() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_CART_PAGE
     );
   }
 
   static getExpressCheckoutButtonContainerCheckout() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_CHECKOUT_PAGE
     );
   }
 
   static getExpressCheckoutButtonContainerProduct() {
-    return document.querySelector(
+    return this.querySelector(
       SELECTORS.EXPRESS_CHECKOUT_CONTAINER_PRODUCT_PAGE
     );
   }
@@ -89,10 +85,10 @@ export class QuerySelectorPs1_7Service {
   static getPayLaterOfferMessageContainerSelector(placement) {
     switch (placement) {
       case 'product':
-        return document.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_PRODUCT);
+        return this.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_PRODUCT);
       case 'cart':
       case 'order':
-        return document.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_CART_SUMMARY);
+        return this.querySelector(SELECTORS.PAY_LATER_OFFER_MESSAGE_CONTAINER_CART_SUMMARY);
       default:
         return;
     }
@@ -105,9 +101,31 @@ export class QuerySelectorPs1_7Service {
       case 'home':
       case 'order':
       case 'category':
-        return document.querySelector(SELECTORS.PAY_LATER_BANNER_CONTAINER);
+        return this.querySelector(SELECTORS.PAY_LATER_BANNER_CONTAINER);
       default:
         return;
     }
+  }
+
+  static querySelector(selector) {
+    let element = document.querySelector(selector);
+
+    if (!element) {
+      console.error('HTMLElement selector ' + selector + ' not found.');
+    }
+
+    return element;
+  }
+
+  static querySelectorAll(selector) {
+    let elements = Array.prototype.slice.call(
+      document.querySelectorAll(selector)
+    );
+
+    if (!elements) {
+      console.error('HTMLElement selector ' + selector + ' not found.');
+    }
+
+    return elements;
   }
 }

--- a/classes/.htaccess
+++ b/classes/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/classes/PsCheckoutCart.php
+++ b/classes/PsCheckoutCart.php
@@ -24,44 +24,45 @@ class PsCheckoutCart extends ObjectModel
     const STATUS_APPROVED = 'APPROVED';
     const STATUS_COMPLETED = 'COMPLETED';
     const STATUS_VOIDED = 'VOIDED';
+    const PAYER_ACTION_REQUIRED = 'PAYER_ACTION_REQUIRED';
 
     /**
-     * @var int Cart Identifier
+     * @var int|null Cart Identifier
      */
     public $id_cart;
 
     /**
-     * @var string PayPal Order Intent
+     * @var string|null PayPal Order Intent
      */
     public $paypal_intent;
 
     /**
-     * @var string PayPal Order Identifier
+     * @var string|null PayPal Order Identifier
      */
     public $paypal_order;
 
     /**
-     * @var string PayPal Order Status
+     * @var string|null PayPal Order Status
      */
     public $paypal_status;
 
     /**
-     * @var string PayPal Funding Source
+     * @var string|null PayPal Funding Source
      */
     public $paypal_funding;
 
     /**
-     * @var string PayPal Access Token for Hosted-Fields
+     * @var string|null PayPal Access Token for Hosted-Fields
      */
     public $paypal_token;
 
     /**
-     * @var string PayPal expiration date for Access Token
+     * @var string|null PayPal expiration date for Access Token
      */
     public $paypal_token_expire;
 
     /**
-     * @var string PayPal expiration date for Authorization
+     * @var string|null PayPal expiration date for Authorization
      */
     public $paypal_authorization_expire;
 
@@ -76,12 +77,12 @@ class PsCheckoutCart extends ObjectModel
     public $isHostedFields = false;
 
     /**
-     * @var string Creation date in mysql date format
+     * @var string|null Creation date in mysql date format
      */
     public $date_add;
 
     /**
-     * @var string Last modification date in mysql date format
+     * @var string|null Last modification date in mysql date format
      */
     public $date_upd;
 
@@ -164,4 +165,130 @@ class PsCheckoutCart extends ObjectModel
             ],
         ],
     ];
+
+    /**
+     * @return int
+     */
+    public function getIdCart()
+    {
+        return (int) $this->id_cart;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaypalIntent()
+    {
+        return $this->paypal_intent;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaypalOrderId()
+    {
+        return $this->paypal_order;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaypalStatus()
+    {
+        return $this->paypal_status;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaypalFundingSource()
+    {
+        return $this->paypal_funding;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPaypalClientToken()
+    {
+        if (empty($this->paypal_token) || $this->isPaypalClientTokenExpired()) {
+            return null;
+        }
+
+        return $this->paypal_token;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaypalClientTokenExpired()
+    {
+        return empty($this->paypal_token_expire) || strtotime($this->paypal_token_expire) > time();
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaypalAuthorizationExpireDate()
+    {
+        return $this->paypal_authorization_expire;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaypalAuthorizationExpired()
+    {
+        return empty($this->paypal_authorization_expire) || strtotime($this->paypal_authorization_expire) > time();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExpressCheckout()
+    {
+        return (bool) $this->isExpressCheckout;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHostedFields()
+    {
+        return (bool) $this->isHostedFields;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDateAdd()
+    {
+        return $this->date_add;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDateUpd()
+    {
+        return $this->date_upd;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPayPalOrderExpired()
+    {
+        return empty($this->date_add) || strtotime($this->date_add) + 3600 * 3 < time();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOrderAvailable()
+    {
+        return $this->getPaypalOrderId()
+            && in_array($this->paypal_status, [PsCheckoutCart::STATUS_CREATED, PsCheckoutCart::STATUS_APPROVED, PsCheckoutCart::PAYER_ACTION_REQUIRED], true)
+            && !$this->isPayPalOrderExpired();
+    }
 }

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_checkout</name>
 	<displayName><![CDATA[PrestaShop Checkout]]></displayName>
-	<version><![CDATA[2.20.2]]></version>
+	<version><![CDATA[2.21.0]]></version>
 	<description><![CDATA[Provide the most commonly used payment methods to your customers in this all-in-one module, and manage all your sales in a centralized interface.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/controllers/.htaccess
+++ b/controllers/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -87,6 +87,7 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
 
             $this->context->cookie->__set('paypalEmail', $this->payload['order']['payer']['email_address']);
 
+            $this->resetContextCartAddresses();
             // Always 0 index because we are not using the paypal marketplace system
             // This index is only used in a marketplace context
             // @todo Extract factory in a Service.
@@ -99,7 +100,8 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
                 false === empty($this->payload['order']['shipping']['address']['admin_area_1']) ? $this->payload['order']['shipping']['address']['admin_area_1'] : '',
                 $this->payload['order']['shipping']['address']['admin_area_2'],
                 $this->payload['order']['shipping']['address']['country_code'],
-                false === empty($this->payload['order']['payer']['phone']) ? $this->payload['order']['payer']['phone']['phone_number']['national_number'] : ''
+                false === empty($this->payload['order']['payer']['phone']) ? $this->payload['order']['payer']['phone']['phone_number']['national_number'] : '',
+                $this->payload['orderID']
             );
         } catch (Exception $exception) {
             $this->handleExceptionSendingToSentry($exception);
@@ -190,6 +192,11 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
         $customer->firstname = $firstName;
         $customer->lastname = $lastName;
 
+        if (Configuration::get('PS_CHECKOUT_EXPRESS_USE_GUEST')) {
+            $customer->is_guest = true;
+            $customer->id_default_group = (int) Configuration::get('PS_GUEST_GROUP');
+        }
+
         if (class_exists('PrestaShop\PrestaShop\Core\Crypto\Hashing')) {
             $crypto = new PrestaShop\PrestaShop\Core\Crypto\Hashing();
             $customer->passwd = $crypto->hash(
@@ -237,15 +244,20 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
         $state,
         $city,
         $countryIsoCode,
-        $phone
+        $phone,
+        $idPaypalOrder
     ) {
         // check if country is available for delivery
         $psIsoCode = (new PaypalCountryCodeMatrice())->getPrestashopIsoCode($countryIsoCode);
         $idCountry = Country::getByIso($psIsoCode);
         $idState = 0;
-        $country = new Country((int) $idCountry);
+        $country = new Country((int) $idCountry, null, (int) $this->context->shop->id);
 
-        if (!$country->active || Country::isNeedDniByCountryId($idCountry)) {
+        if (!Validate::isLoadedObject($country)
+            || !$country->active
+            || !$country->isAssociatedToShop((int) $this->context->shop->id)
+            || Country::isNeedDniByCountryId($idCountry)
+        ) {
             return false;
         }
 
@@ -256,16 +268,19 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
             $idState = $countryRepository->getStateId($state);
         }
 
-        // check if a paypal address already exist for the customer
-        $paypalAddress = $this->addressAlreadyExist('PayPal', $this->context->customer->id);
+        // check if a PayPal address already exist for the customer and not used
+        $paypalAddressAlias = 'Paypal ' . $idPaypalOrder;
+        $paypalAddressId = $this->addressAlreadyExist($paypalAddressAlias, $this->context->customer->id);
+        $paypalAddress = new Address($paypalAddressId);
+        $isPaypalValidAddressAndNotUsed = Validate::isLoadedObject($paypalAddress) && !$paypalAddress->isUsed();
 
-        if ($paypalAddress) {
-            $address = new Address($paypalAddress); // if yes, update it with the new address
+        if ($isPaypalValidAddressAndNotUsed) {
+            $address = $paypalAddress; // if yes, update it with the new address
         } else {
             $address = new Address(); // otherwise create a new address
         }
 
-        $address->alias = 'PayPal';
+        $address->alias = $paypalAddressAlias;
         $address->id_customer = $this->context->customer->id;
         $address->firstname = $firstName;
         $address->lastname = $lastName;
@@ -316,5 +331,15 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
         $query->where('deleted = 0');
 
         return (int) Db::getInstance()->getValue($query);
+    }
+
+    /**
+     * Reset current cart address
+     */
+    private function resetContextCartAddresses()
+    {
+        $this->context->cart->id_address_delivery = 0;
+        $this->context->cart->id_address_invoice = 0;
+        $this->context->cart->save();
     }
 }

--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -67,7 +67,7 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
             $psCheckoutCartRepository = $this->module->getService('ps_checkout.repository.pscheckoutcart');
 
             /** @var PsCheckoutCart|false $psCheckoutCart */
-            $psCheckoutCart = $psCheckoutCartRepository->findOneByCartId((int) $this->context->cart->id);
+            $psCheckoutCart = $psCheckoutCartRepository->findOneByPayPalOrderId($this->payload['orderID']);
 
             if (false !== $psCheckoutCart) {
                 $psCheckoutCart->paypal_funding = $this->payload['fundingSource'];

--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -242,17 +242,19 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
         // check if country is available for delivery
         $psIsoCode = (new PaypalCountryCodeMatrice())->getPrestashopIsoCode($countryIsoCode);
         $idCountry = Country::getByIso($psIsoCode);
-
+        $idState = 0;
         $country = new Country((int) $idCountry);
 
         if (!$country->active || Country::isNeedDniByCountryId($idCountry)) {
             return false;
         }
 
-        /** @var \PrestaShop\Module\PrestashopCheckout\Repository\CountryRepository $countryRepository */
-        $countryRepository = $this->module->getService('ps_checkout.repository.country');
+        if ($country->contains_states) {
+            /** @var \PrestaShop\Module\PrestashopCheckout\Repository\CountryRepository $countryRepository */
+            $countryRepository = $this->module->getService('ps_checkout.repository.country');
 
-        $idState = $countryRepository->getStateId($state);
+            $idState = $countryRepository->getStateId($state);
+        }
 
         // check if a paypal address already exist for the customer
         $paypalAddress = $this->addressAlreadyExist('PayPal', $this->context->customer->id);
@@ -273,10 +275,7 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
         $address->city = $city;
         $address->id_country = $idCountry;
         $address->phone = $phone;
-
-        if ($idState) {
-            $address->id_state = $idState;
-        }
+        $address->id_state = $idState;
 
         if (true !== $address->validateFields(false)) {
             return false;

--- a/controllers/front/cancel.php
+++ b/controllers/front/cancel.php
@@ -59,7 +59,7 @@ class Ps_CheckoutCancelModuleFrontController extends AbstractFrontController
             $psCheckoutCartRepository = $this->module->getService('ps_checkout.repository.pscheckoutcart');
 
             /** @var PsCheckoutCart|false $psCheckoutCart */
-            $psCheckoutCart = $psCheckoutCartRepository->findOneByCartId((int) $this->context->cart->id);
+            $psCheckoutCart = $psCheckoutCartRepository->findOneByPayPalOrderId($bodyValues['orderID']);
 
             if (false !== $psCheckoutCart) {
                 $psCheckoutCart->paypal_funding = $bodyValues['fundingSource'];
@@ -73,8 +73,8 @@ class Ps_CheckoutCancelModuleFrontController extends AbstractFrontController
                 [
                     'PayPalOrderId' => isset($bodyValues['orderID']) ? $bodyValues['orderID'] : null,
                     'FundingSource' => isset($bodyValues['fundingSource']) ? $bodyValues['fundingSource'] : null,
-                    'isExpressCheckout' => isset($bodyValues['isExpressCheckout']) ? (bool) $bodyValues['isExpressCheckout'] : false,
-                    'isHostedFields' => isset($bodyValues['isHostedFields']) ? (bool) $bodyValues['isHostedFields'] : false,
+                    'isExpressCheckout' => isset($bodyValues['isExpressCheckout']) && $bodyValues['isExpressCheckout'],
+                    'isHostedFields' => isset($bodyValues['isHostedFields']) && $bodyValues['isHostedFields'],
                 ]
             );
 

--- a/controllers/front/check.php
+++ b/controllers/front/check.php
@@ -60,7 +60,7 @@ class Ps_CheckoutCheckModuleFrontController extends AbstractFrontController
             $psCheckoutCartRepository = $this->module->getService('ps_checkout.repository.pscheckoutcart');
 
             /** @var PsCheckoutCart|false $psCheckoutCart */
-            $psCheckoutCart = $psCheckoutCartRepository->findOneByCartId((int) $this->context->cart->id);
+            $psCheckoutCart = $psCheckoutCartRepository->findOneByPayPalOrderId($bodyValues['orderID']);
 
             if (false === $psCheckoutCart) {
                 $psCheckoutCart = new PsCheckoutCart();
@@ -71,8 +71,8 @@ class Ps_CheckoutCheckModuleFrontController extends AbstractFrontController
                 $psCheckoutCart->paypal_funding = $bodyValues['fundingSource'];
             }
 
-            $psCheckoutCart->isExpressCheckout = isset($bodyValues['isExpressCheckout']) ? (bool) $bodyValues['isExpressCheckout'] : false;
-            $psCheckoutCart->isHostedFields = isset($bodyValues['isHostedFields']) ? (bool) $bodyValues['isHostedFields'] : false;
+            $psCheckoutCart->isExpressCheckout = isset($bodyValues['isExpressCheckout']) && (bool) $bodyValues['isExpressCheckout'];
+            $psCheckoutCart->isHostedFields = isset($bodyValues['isHostedFields']) && (bool) $bodyValues['isHostedFields'];
             $psCheckoutCartRepository->save($psCheckoutCart);
 
             if (false === empty($psCheckoutCart->paypal_order)) {
@@ -81,6 +81,7 @@ class Ps_CheckoutCheckModuleFrontController extends AbstractFrontController
                 $response = $paypalOrder->handle($isExpressCheckout, true, $psCheckoutCart->paypal_order);
 
                 if (false === $response['status']) {
+                    $psCheckoutCartRepository->remove($psCheckoutCart);
                     throw new PsCheckoutException(sprintf('Unable to patch PayPal Order - Exception %s : %s', $response['exceptionCode'], $response['exceptionMessage']), PsCheckoutException::PSCHECKOUT_UPDATE_ORDER_HANDLE_ERROR);
                 }
             }

--- a/controllers/front/token.php
+++ b/controllers/front/token.php
@@ -58,10 +58,7 @@ class Ps_CheckoutTokenModuleFrontController extends AbstractFrontController
                 $psCheckoutCart->id_cart = (int) $this->context->cart->id;
             }
 
-            // If paypal_token_expire is in future, token is not expired
-            if (empty($psCheckoutCart->paypal_token_expire)
-                || strtotime($psCheckoutCart->paypal_token_expire) <= time()
-            ) {
+            if ($psCheckoutCart->isPaypalClientTokenExpired()) {
                 $psCheckoutCart->paypal_order = '';
                 $psCheckoutCart->paypal_token = $clientTokenProvider->getPayPalClientToken();
                 $psCheckoutCart->paypal_token_expire = (new DateTime())->modify('+3550 seconds')->format('Y-m-d H:i:s');

--- a/controllers/front/validate.php
+++ b/controllers/front/validate.php
@@ -84,7 +84,7 @@ class Ps_CheckoutValidateModuleFrontController extends AbstractFrontController
             $psCheckoutCartRepository = $this->module->getService('ps_checkout.repository.pscheckoutcart');
 
             /** @var PsCheckoutCart|false $psCheckoutCart */
-            $psCheckoutCart = $psCheckoutCartRepository->findOneByCartId((int) $this->context->cart->id);
+            $psCheckoutCart = $psCheckoutCartRepository->findOneByPayPalOrderId($bodyValues['orderID']);
 
             if (false !== $psCheckoutCart) {
                 $psCheckoutCart->paypal_funding = $bodyValues['fundingSource'];

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -129,7 +129,7 @@ class Ps_checkout extends PaymentModule
 
     // Needed in order to retrieve the module version easier (in api call headers) than instanciate
     // the module each time to get the version
-    const VERSION = '2.20.2';
+    const VERSION = '2.21.0';
 
     const INTEGRATION_DATE = '2022-14-06';
 
@@ -155,7 +155,7 @@ class Ps_checkout extends PaymentModule
 
         // We cannot use the const VERSION because the const is not computed by addons marketplace
         // when the zip is uploaded
-        $this->version = '2.20.2';
+        $this->version = '2.21.0';
         $this->author = 'PrestaShop';
         $this->currencies = true;
         $this->currencies_mode = 'checkbox';

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1051,6 +1051,8 @@ class Ps_checkout extends PaymentModule
             && in_array($psCheckoutCart->paypal_status, [PsCheckoutCart::STATUS_CREATED, PsCheckoutCart::STATUS_APPROVED], true)
             && false === empty($psCheckoutCart->paypal_token_expire)
             && strtotime($psCheckoutCart->paypal_token_expire) > time()
+            && false === empty($psCheckoutCart->date_upd)
+            && strtotime($psCheckoutCart->date_upd) + 3600 > time()
         ) {
             $payPalOrderId = $psCheckoutCart->paypal_order;
             $cartFundingSource = $psCheckoutCart->paypal_funding;

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1044,18 +1044,9 @@ class Ps_checkout extends PaymentModule
             $psCheckoutCart = $psCheckoutCartRepository->findOneByCartId((int) $this->context->cart->id);
         }
 
-        // If we have a PayPal Order Id with a status CREATED or APPROVED and a not expired PayPal Client Token, we can use it
-        // If paypal_token_expire is in future, token is not expired
-        if (false !== $psCheckoutCart
-            && false === empty($psCheckoutCart->paypal_order)
-            && in_array($psCheckoutCart->paypal_status, [PsCheckoutCart::STATUS_CREATED, PsCheckoutCart::STATUS_APPROVED], true)
-            && false === empty($psCheckoutCart->paypal_token_expire)
-            && strtotime($psCheckoutCart->paypal_token_expire) > time()
-            && false === empty($psCheckoutCart->date_upd)
-            && strtotime($psCheckoutCart->date_upd) + 3600 > time()
-        ) {
-            $payPalOrderId = $psCheckoutCart->paypal_order;
-            $cartFundingSource = $psCheckoutCart->paypal_funding;
+        if (false !== $psCheckoutCart && $psCheckoutCart->isOrderAvailable()) {
+            $payPalOrderId = $psCheckoutCart->getPaypalOrderId();
+            $cartFundingSource = $psCheckoutCart->getPaypalFundingSource();
         }
         // END To be refactored in services
 
@@ -1091,9 +1082,9 @@ class Ps_checkout extends PaymentModule
             $this->name . 'PayPalOrderId' => $payPalOrderId,
             $this->name . 'FundingSource' => $cartFundingSource,
             $this->name . 'HostedFieldsEnabled' => $isCardAvailable && $payPalConfiguration->isCardPaymentEnabled() && $paypalAccountRepository->cardHostedFieldsIsAllowed(),
-            $this->name . 'HostedFieldsSelected' => false !== $psCheckoutCart ? (bool) $psCheckoutCart->isHostedFields : false,
+            $this->name . 'HostedFieldsSelected' => false !== $psCheckoutCart && $psCheckoutCart->isHostedFields(),
             $this->name . 'HostedFieldsContingencies' => $payPalConfiguration->getHostedFieldsContingencies(),
-            $this->name . 'ExpressCheckoutSelected' => false !== $psCheckoutCart ? (bool) $psCheckoutCart->isExpressCheckout : false,
+            $this->name . 'ExpressCheckoutSelected' => false !== $psCheckoutCart && $psCheckoutCart->isExpressCheckout(),
             $this->name . 'ExpressCheckoutProductEnabled' => $expressCheckoutConfiguration->isProductPageEnabled() && $paypalAccountRepository->paypalPaymentMethodIsValid(),
             $this->name . 'ExpressCheckoutCartEnabled' => $expressCheckoutConfiguration->isOrderPageEnabled() && $paypalAccountRepository->paypalPaymentMethodIsValid(),
             $this->name . 'ExpressCheckoutOrderEnabled' => $expressCheckoutConfiguration->isCheckoutPageEnabled() && $paypalAccountRepository->paypalPaymentMethodIsValid(),

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -711,6 +711,7 @@ class Ps_checkout extends PaymentModule
         $isExpressCheckout = false !== $psCheckoutCart && $psCheckoutCart->isExpressCheckout;
 
         $this->context->smarty->assign([
+            'cancelTranslatedText' => $this->l('Choose another payment method'),
             'is17' => $shopContext->isShop17(),
             'isExpressCheckout' => $isExpressCheckout,
             'modulePath' => $this->getPathUri(),
@@ -1432,6 +1433,7 @@ class Ps_checkout extends PaymentModule
         $isExpressCheckout = false !== $psCheckoutCart && $psCheckoutCart->isExpressCheckout;
 
         $this->context->smarty->assign([
+            'cancelTranslatedText' => $this->l('Choose another payment method'),
             'is17' => $shopContext->isShop17(),
             'isExpressCheckout' => $isExpressCheckout,
             'isOnePageCheckout16' => !$shopContext->isShop17() && (bool) Configuration::get('PS_ORDER_PROCESS_TYPE'),

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1644,7 +1644,17 @@ class Ps_checkout extends PaymentModule
 
     public function hookHeader()
     {
-        if (false === $this->merchantIsValid()) {
+        $controller = Tools::getValue('controller');
+
+        if (empty($controller) && isset($this->context->controller->php_self)) {
+            $controller = $this->context->controller->php_self;
+        }
+
+        /** @var \PrestaShop\Module\PrestashopCheckout\Validator\FrontControllerValidator $frontControllerValidator */
+        $frontControllerValidator = $this->getService('ps_checkout.validator.front_controller');
+
+        if ($frontControllerValidator->shouldLoadFrontJS($controller)) {
+            // No need to prefetch if script will be loaded
             return '';
         }
 

--- a/ps_checkout.php
+++ b/ps_checkout.php
@@ -1011,6 +1011,9 @@ class Ps_checkout extends PaymentModule
         /** @var \PrestaShop\Module\PrestashopCheckout\PayPal\PayPalPayLaterConfiguration $payLaterConfiguration */
         $payLaterConfiguration = $this->getService('ps_checkout.pay_later.configuration');
 
+        /** @var \PrestaShop\Module\PrestashopCheckout\ShopContext $shopContext */
+        $shopContext = $this->getService('ps_checkout.context.shop');
+
         $fundingSourcesSorted = [];
         $payWithTranslations = [];
         $isCardAvailable = false;
@@ -1103,6 +1106,7 @@ class Ps_checkout extends PaymentModule
             $this->name . 'PayLaterOrderPageButtonEnabled' => $payLaterConfiguration->isOrderPageButtonActive() && $paypalAccountRepository->paypalPaymentMethodIsValid(),
             $this->name . '3dsEnabled' => $payPalConfiguration->is3dSecureEnabled(),
             $this->name . 'CspNonce' => $payPalConfiguration->getCSPNonce(),
+            $this->name . 'PartnerAttributionId' => $shopContext->getBnCode(),
             $this->name . 'CartProductCount' => $cartProductCount,
             $this->name . 'FundingSourcesSorted' => $fundingSourcesSorted,
             $this->name . 'PayWithTranslations' => $payWithTranslations,

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/src/Builder/Payload/OrderPayloadBuilder.php
+++ b/src/Builder/Payload/OrderPayloadBuilder.php
@@ -376,8 +376,8 @@ class OrderPayloadBuilder extends Builder implements PayloadBuilderInterface
         ];
 
         // set handling cost id needed -> principally used in case of gift_wrapping
-        if (!empty($this->cart['cart']['subtotals']['gift_wrapping'])) {
-            $breakdownHandling += $this->cart['cart']['subtotals']['gift_wrapping'];
+        if (!empty($this->cart['cart']['subtotals']['gift_wrapping']['amount'])) {
+            $breakdownHandling += $this->cart['cart']['subtotals']['gift_wrapping']['amount'];
         }
 
         $remainderValue = $amountTotal - $breakdownItemTotal - $breakdownTaxTotal - $breakdownShipping - $breakdownHandling;

--- a/src/OrderStates.php
+++ b/src/OrderStates.php
@@ -157,8 +157,8 @@ class OrderStates
             'SELECT id_order_state
             FROM  `' . _DB_PREFIX_ . self::ORDER_STATE_LANG_TABLE . '`
             WHERE
-                id_order_state = ' . $orderStateId . '
-                AND id_lang = ' . $langId
+                id_order_state = ' . (int) $orderStateId . '
+                AND id_lang = ' . (int) $langId
         );
     }
 

--- a/src/Presenter/Date/DatePresenter.php
+++ b/src/Presenter/Date/DatePresenter.php
@@ -40,10 +40,7 @@ class DatePresenter
      */
     public function __construct($timestamp, $format)
     {
-        $this->date = new \DateTime(
-            $timestamp,
-            $this->getTimeZone()
-        );
+        $this->date = new \DateTime($timestamp);
         $this->format = $format;
     }
 
@@ -52,6 +49,8 @@ class DatePresenter
      */
     public function present()
     {
+        $this->date->setTimezone($this->getTimeZone());
+
         return $this->date->format($this->format);
     }
 

--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -43,7 +43,7 @@ class OrderRepository
             INNER JOIN `' . _DB_PREFIX_ . 'customer` c ON (o.id_customer = c.id_customer)
             WHERE o.module = "ps_checkout"
             AND o.id_shop = ' . (int) $shopId . '
-            AND o.current_state IN (' . implode(',', array_keys($idStates)) . ')
+            AND o.current_state IN (' . implode(', ', array_map('intval', $idStates)) . ')
             ORDER BY o.date_add DESC
             LIMIT 1000
         ');

--- a/src/Translations/Translations.php
+++ b/src/Translations/Translations.php
@@ -222,6 +222,7 @@ class Translations
                         'title' => $this->module->l('PayPal account', 'translations'),
                         'activate' => $this->module->l('Log in or sign up to PayPal', 'translations'),
                         'isLinked' => $this->module->l('Your PrestaShop account is linked to your PayPal account', 'translations'),
+                        'merchantId' => $this->module->l('(merchant ID {0})', 'translations'),
                         'useAnotherAccount' => $this->module->l('Use another account', 'translations'),
                         'linkToPaypal' => $this->module->l('Link to PayPal account', 'translations'),
                         'linkToPsCheckoutFirst' => $this->module->l('Link to PrestaShop Checkout first', 'translations'),

--- a/src/ValidateOrder.php
+++ b/src/ValidateOrder.php
@@ -199,7 +199,7 @@ class ValidateOrder
                 $module->validateOrder(
                     $payload['cartId'],
                     (int) $this->getOrderState($psCheckoutCart->paypal_funding),
-                    $payload['amount'],
+                    0,
                     $fundingSourceTranslationProvider->getPaymentMethodName($psCheckoutCart->paypal_funding),
                     null,
                     [

--- a/translations/de.php
+++ b/translations/de.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Hier ist eine kurze Zusammenfassung Ihrer Bestellung:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'PayPal-Transaktions-Id : ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'oder';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Andere Zahlungsmethode';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Bitte bestätigen Sie Ihre Bestellung, indem Sie auf „Ich bestätige meine Bestellung“ klicken.';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Bestellübersicht';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'PayPal-Bestellnummer : ';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Weiß';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Zu ändernde gerundete Parameter';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'PDF herunterladen';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Wählen Sie die Platzierung der Nachrichten auf der Seite';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Herzlichen Glückwunsch! Sie können jetzt mit dem Online-Verkauf beginnen.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Beschreibung einrichten';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Achtung, Ihre gerundeten Parameter sind nicht völlig kompatibel mit der Transaktionsverarbeitung von PrestaShop Checkout. Einige Transaktionen können möglicherweise fehlschlagen. Aber es ist ganz einfach, Ihre Einstellungen für &quot;Rundungsregel&quot; und &quot;Rundungstyp&quot; müssen auf &quot;Bei halbem Wert auf unendlich runden&quot; und &quot;Für jedes Element runden&quot; eingestellt werden, oder klicken Sie auf die Schaltfläche unten, um dies automatisch zu tun!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Konfigurieren Sie Ihre Kontoauszugsbeschreibung';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Pille';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Beachten Sie, dass im Testmodus keine Zahlungen eingezogen werden können';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'überprüfen Sie bitte unsere Liste der anpassbaren Einstellungen';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Art des Unternehmens';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Ein Modul, alle Zahlungsmethoden.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'Keine Bestätigungs-E-Mail erhalten?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Verfügbar';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Ich akzeptiere ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Details für Kontoauszüge';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'Ausstehend';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Zusätzliche Informationen';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Begrenzen Sie Ihre Betrugsrate';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Bankverbindung';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Frau';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Verfügbarkeit von Kreditkarten auf Eis gelegt';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Wählen Sie die Platzierung von Schaltflächen auf der Seite';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Sobald PayPal alle Dokumente erhalten hat, müssen Sie 48 Stunden auf die endgültige Genehmigung warten.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Alle Transaktionen';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Sie können Kartentransaktionen im Wert von';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'E-Mail-Validierung erforderlich';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Keine Umleitung bei Zahlung mit Kreditkarte';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'Wir können für Sie derzeit keine Kartenzahlungen abwickeln.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Möglicherweise sind nicht alle benutzerdefinierten Themen vollständig kompatibel. Um mögliche Integrationsprobleme auf der Zahlungsseite zu vermeiden,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Wir haben die Bestätigung von PayPal erhalten. Sie können nun alle Kartentransaktionen ohne Limits verarbeiten.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'Diese E-Mail-Adresse konnte nicht gefunden werden.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'Zahlungseinstellungen';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Passwort';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Adresse';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Währungen';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Wählen Sie die Platzierung von Bannern auf der Seite.';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Vorsicht : die Währungen, dass Sie haben aktivieren : {0} mit PrestaShop Checkout zur Zeit nicht funktionieren. Bitte deaktivieren Sie {0} für PrestaShop Checkout in Ihren';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Brauchen Sie Hilfe? Hier finden Sie das Benutzerhandbuch des Moduls';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'Konto';

--- a/translations/en.php
+++ b/translations/en.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Here is a short summary of your order:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'PayPal Transaction Id : ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'or';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Choose another payment method';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Please confirm your order by clicking "I confirm my order".';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Order summary';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'PayPal Order Id : ';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'White';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Roundings settings to change';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Download PDF';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Choose the location of the messages on the page';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Congrats ! You can start selling online now.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Set up description';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Be careful, your roundings settings are not fully compatible with PrestaShop Checkout transaction processing. Some of the transactions could fail. But it is easy, your setting Round mode and Round type should be set on « Round up away from zero, when it is half way there » and « Round on each item » or click on the button bellow to make it automatically !';
@@ -409,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Available';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'I agree to the ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Details for Bank statements';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'pending';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Additional Details';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Limit your fraud rate';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Bank account';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Mrs';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Credit Card availability suspended';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Choose the location of the buttons on the page';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'As soon as PayPal gets all your documents, you\'ll have to wait 48h for final approval.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'All transactions';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'You can process';
@@ -536,6 +540,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Password';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Address';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Currencies';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Choose the location of the banners on the page';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Warning : the currencies you have activated : {0} are not currently supported by PrestaShop Checkout. Please deactivate {0} for PrestaShop Checkout in your';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Need help? Find here the documentation of this module';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'account';

--- a/translations/es.php
+++ b/translations/es.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Este es un breve resumen de tu pedido:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'ID transacción PayPal: ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'o';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Otro método de pago';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Haz clic en &quot;Confirmar mi pedido&quot; para confirmar el pedido.';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Resumen del pedido';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'Referencia del pedido de PayPal:';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Blanco';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Se deben actualizar las opciones de redondeo';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Descargar el PDF';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Elije la ubicación de los mensajes en la página';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = '¡Felicidades! Puedes empezar a vender en línea ahora.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Establecer la descripción';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = '¡Cuidado! Tus opciones de redondeo no son totalmente compatibles con el proceso de transacciones de PrestaShop Checkout. Algunas transacciones podrían no realizarse correctamente. Pero es fácil, la &quot;Regla de redondeo&quot; y el &quot;Tipo de redondeo&quot; tienen que estar configurados en &quot;Redondear al infinito cuando el valor es la mitad&quot; y &quot;Redondear para cada artículo&quot; o haz clic en el botón de abajo para hacerlo automáticamente.';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Configura la descripción de tus extractos bancarios';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Píldora';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Ten en cuenta que en el modo de prueba no puedes cobrar ningún importe';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'consulta nuestra lista de ajustes personalizables';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Tipo de empresa';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Un solo módulo para todos los métodos de pago.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = '¿El email de confirmación no ha llegado?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Disponible';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Acepto las ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Detalles para los extractos bancarios';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'pendiente';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Detalles adicionales';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Limita tu tasa de fraude';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Cuenta bancaria';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Señora';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Disponibilidad de la tarjeta de crédito suspendida';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Elije la ubicación de los botones en la página';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Tan pronto como PayPal reciba todos tus documentos, tendrás que esperar 48 horas para la aprobación final.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Todas las transacciones';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Puedes hacer operaciones';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'Es necesario validar el correo electrónico';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'No hay redirección al pagar con tarjeta de crédito';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'No podemos procesar los pagos con tarjeta bancaria por el momento.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Es posible que no todos los temas personalizados sean totalmente compatibles. Para evitar posibles problemas de integración en la página de pago,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Hemos recibido la confirmación de PayPal. Ahora puedes aceptar todos los pagos con tarjeta sin límites.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'No se ha encontrado el correo electrónico.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'Preferencias de pago';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Contraseña';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Dirección';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Divisas';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Elije la ubicación de los banners en la página';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Cuidado : las monedas que ha activado : {0} de momento no funcionan con PrestaShop Checkout. Desactiva {0} para PrestaShop Checkout en sus';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = '¿Necesitas ayuda? Aquí encontrarás el manual de usuario del módulo';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'cuenta';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Voici un résumé de votre commande :';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'Référence de Transaction PayPal';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'ou';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Choisir un autre moyen de paiement';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Veuillez finaliser votre commande en cliquant sur &quot;Je valide ma commande&quot;';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Résumé de commande';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'Référence de commande PayPal';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Blanc';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Paramètres d\'arrondis à mettre à jour';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Télécharger le Guide utilisateur';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Choisissez l\'emplacement des messages sur la page';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Félicitations ! Vous pouvez désormais recevoir des paiements.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Choisir la description';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Attention, vos paramètres d\'arrondi ne sont pas totalement compatibles avec le traitement des transactions PrestaShop Checkout. Certaines des transactions pourraient échouer. Mais c’est facile, vos réglages «Règle d\'arrondi» et «Type d\'arrondi» doivent être réglés sur «Arrondir vers l\'infini quand valeur à mi-chemin» et «Arrondir pour chaque article» ou cliquer sur le bouton ci-dessous pour le faire automatiquement!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Configurer votre description de relevé bancaire';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Pilule';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Notez que vous ne pouvez pas encaisser d\'argent en mode test';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'veuillez consulter notre liste de paramètres personnalisables';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Type d\'entreprise';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Un module, tous les moyens de paiement.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'Pas d\'email de confirmation ?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Disponible';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'J\'accepte les ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Details pour relevés bancaires';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'En attente';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Informations additionnelles';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Limitez votre taux de fraude';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Compte en banque';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Mme';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Disponibilité de la carte de crédit mise en suspens';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Choisissez l\'emplacement des boutons sur la page';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Patientez environ 48h pour la validation de vos documents par PayPal.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Toutes les transactions';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Vous pouvez opérer';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'Validation de mail nécessaire';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Aucune redirection lors du paiement par carte de crédit';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'Nous ne pouvons pas accepter les paiements par carte pour vous pour le moment.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Tous les thèmes personnalisés peuvent ne pas être entièrement compatibles. Pour éviter tout problème d\'intégration sur la page de paiement,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Nous avons reçu la confirmation de PayPal. Vous pouvez maintenant accepter tous les paiements par cartes sans aucune limite.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'L\'email n\'a pas été trouvé.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'Préférences Paiement';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Mot de passe';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Adresse';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Devises';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Choisissez l\'emplacement des bannières sur la page';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Attention : les monnaies que vous avez activées :{0} ne sont pas actuellement supportées par PrestaShop Checkout. Veuillez désactiver {0} pour PrestaShop Checkout dans vos';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Besoin d\'aide ? Trouvez ici la documentation du module';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = '  ';

--- a/translations/it.php
+++ b/translations/it.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Ecco un riepilogo del tuo ordine:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'ID Transazione PayPal: ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'o';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Altro metodo di pagamento';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Confermare l’ordine facendo clic su “Confermo l’ordine”';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Riepilogo dell’ordine';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'Numero ordine PayPal';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Bianco';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Parametri di arrotondamento da modificare';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Scarica il PDF';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Scegli la posizione dei messaggi nella pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Congratulazioni! Puoi iniziare a vendere i tuoi articoli online ora.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Configura descrizione';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Attenzione, i tuoi parametri di arrotondamento non sono pienamente compatibili con l’elaborazione delle transazioni PrestaShop Checkout. Alcune transazioni potrebbero non andare a buon fine. Ma è facile, le impostazioni &quot;Regola di arrotondamento&quot; e &quot;Tipo di arrotondamento&quot; devono essere predisposte su &quot;Arrotonda all\'infinito quando il valore è a metà&quot; e &quot;Arrotonda per ogni elemento&quot; oppure cliccare sul pulsante qui sotto per farlo automaticamente!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Configura la descrizione degli estratti conto bancari';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Pillola';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Nota che non puoi incassare i pagamenti con la modalità di prova';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'controlla il nostro elenco delle impostazioni personalizzabili.';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Tipo di azienda';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Tutti i metodi di pagamento in un unico modulo.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'Nessuna e-mail di conferma?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Disponibile';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Accetto i ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Dettaglio degli estratti conto bancari';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'in sospeso';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Informazioni aggiuntive';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Riduci il tuo tasso di frodi';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Conto corrente';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Sig.ra';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Disponibilità della carta di credito in sospeso';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Scegli la posizione dei pulsanti nella pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Non appena PayPal avrà ricevuto tutti i tuoi documenti, dovrai aspettare 48 ore per l\'approvazione finale.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Tutte le transazioni';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Puoi effettuare delle transazioni';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'È necessario confermare l’indirizzo e-mail';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Nessun reindirizzamento verso una pagina esterna se effettui il pagamento con carta di credito';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'Non è possibile accettare i pagamenti tramite carta per te in questo momento.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Non tutti i temi personalizzabili sono del tutto compatibili. Per evitare eventuali problemi di integrazione nella pagina di pagamento,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Abbiamo ricevuto la conferma da PayPal. Ora è possibile elaborare tutte le transazioni con carta senza limiti.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'E-mail non trovata.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'Preferenze di pagamento';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Password';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Indirizzo';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Valute';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Scegli la posizione dei banner nella pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Attenzione : alcune delle valute che hai attivato : {0} al momento non funzionano con PrestaShop Checkout. Prego disattiva {0} per PrestaShop Checkout nelle tue';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Bisogno di aiuto? Qui troverai la guida utente per il modulo';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'account';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Hier vindt u een kort overzicht van uw bestelling:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'PayPal transactienr: ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'of';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Andere betaalmethode';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Klik op &quot;Ik bevestig mijn bestelling&quot; om uw bestelling te bevestigen.';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Besteloverzicht';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'PayPal Bestelreferentie:';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Wit';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Instellingen voor afrondingen wijzigen';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Pdf downloaden';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Kies de plaats van de berichten op de pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Gefeliciteerd! U kunt nu online gaan verkopen.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Opzetten van de beschrijving';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Opgelet: uw instellingen voor afrondingen zijn niet volledig compatibel met de transactiebehandeling van PrestaShop Checkout. Sommige transacties kunnen mogelijk niet worden verwerkt. U kunt dit echter eenvoudig aanpassen. Maar het is gemakkelijk, uw &quot;Afrondingsregel&quot; en &quot;Afrondingstype&quot; instellingen moeten worden ingesteld op &quot;Afronden tot oneindig wanneer halverwege de waarde&quot; en &quot;Afronden voor elk artikel&quot; of klik op de knop hieronder om het automatisch te doen!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Configureer de beschrijving van uw bankafschriften';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Pil';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Vergeet niet dat u geen betalingen kunt innen in de testmodus';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'bekijk dan onze lijst met aanpasbare instellingen';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Bedrijfstype';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Eén module, alle betaalmethoden.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'Geen bevestigingsmail?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Beschikbaar';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Ik accepteer ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Details voor bankafschriften';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'In afwachting van goedkeuring';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Aanvullende informatie';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Beperk uw fraudepercentage';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Bankrekening';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Mevr.';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Beschikbaarheid van de creditcard in de wacht gezet';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Kies de plaats van de knoppen op de pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Zodra PayPal al uw documenten heeft, moet u 48 uur wachten op de definitieve goedkeuring.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Alle transacties';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'U beschikt';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'E-mailbevestiging nodig';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Geen omleiding bij betaling met credit card';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'We kunnen momenteel geen creditcardbetalingen voor u verwerken.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Alle aangepaste thema\'s zijn mogelijk niet volledig compatibel. Om mogelijke integratieproblemen op de betalingspagina te vermijden,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'We hebben de bevestiging van PayPal ontvangen. U kunt nu alle kaarttransacties zonder beperkingen verwerken.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'De e-mail is niet gevonden.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'betalingsvoorkeuren';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Wachtwoord';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Adres';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Valuta\'s';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Kies de plaats van de banners op de pagina';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Opgelet : de valuta\'s die u heeft geactiveerd : {0} worden momenteel niet ondersteund door PrestaShop Checkout. Alsjeblieft deactiveer {0} voor PrestaShop Checkout in uw';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Hulp nodig? Hier vindt u de documentatie bij deze module';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'account';

--- a/translations/pl.php
+++ b/translations/pl.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Oto krótkie podsumowanie twojego zamówienia:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'Identyfikator transakcji PayPal:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'lub';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Inna metoda płatności';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Prosimy o potwierdzenie zamówienia przez kliknięcie „Potwierdzam zamówienie”.';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Podsumowanie zamówienia';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'Nr identyfikacyjny zamówienia PayPal:';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Biały';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Ustawienia zaokrągleń wymagają aktualizacji';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Pobierz Instrukcję użytkownika';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Wybierz miejsce wyświetlania komunikatów';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Gratulacje! Możesz zacząć sprzedawać online już teraz.';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Opis ustawień';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Uwaga, Twoje ustawienia zaokrągleń nie są w pełni kompatybilne z systemem przetwarzania transakcji PrestaShop Checkout. Niektóre transakcje mogą zakończyć się niepowodzeniem. To proste: Twoje ustawienia „Zasada zaokrąglania” i „Rodzaj zaokrąglania” muszą być ustawione na „Zaokrąglij do nieskończoności, gdy wartość jest w połowie” i „Zaokrąglij dla każdej pozycji” lub kliknij przycisk poniżej, aby zrobić to automatycznie!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Skonfiguruj opis wyciągów bankowych';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Okrągły';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Pamiętaj, że w trybie testowym nie możesz pobierać płatności';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'sprawdź naszą listę ustawień, które można dostosować';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Typ firmy';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Jeden moduł, wszystkie metody płatności.';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'E-mail z potwierdzeniem nie dotarł?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Dostępny';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Akceptuję ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Szczegóły dotyczące wyciągów bankowych';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'Oczekująca';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Dodatkowe szczegóły';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Ogranicz liczbę oszustw';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Rachunek bankowy';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Pani';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Zawieszenie dostępności kart kredytowych';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Wybierz miejsce wyświetlania przycisków';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Jak tylko PayPal otrzyma wszystkie Twoje dokumenty, należy odczekać 48 h na ostateczne zatwierdzenie.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Wszystkie transakcje';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Możesz przetworzyć';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'Wymagane potwierdzenie adresu e-mail';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Brak przekierowania w przypadku płatności kartą kredytową';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'Nie możemy w tej chwili przetwarzać płatności kartami płatniczymi dla Ciebie.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Niestandardowe szablony mogą nie być w pełni kompatybilne z modułem. Aby uniknąć potencjalnych problemów z integracją na stronie płatności,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Otrzymaliśmy potwierdzenie z PayPal. Teraz możesz przetwarzać wszystkie transakcje kartą bez limitów.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'Nie znaleziono adresu e-mail.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'preferencjach płatności';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Hasło';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Adres';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Waluty';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Wybierz miejsce wyświetlania banerów';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Ostrzeżenie : waluty, które aktywowałeś : {0} nie są obecnie obsługiwane przez PrestaShop Checkout. Proszę dezaktywować {0} dla PrestaShop Checkout w swoich';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Potrzebujesz pomocy? Tutaj znajdziesz dokumentację tego modułu';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'konto';

--- a/translations/pt.php
+++ b/translations/pt.php
@@ -255,6 +255,7 @@ $_MODULE['<{ps_checkout}prestashop>ps_checkout_bc9189406be84ec297464a514221406d'
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_c884ed19483d45970c5bf23a681e2dd2'] = 'Veja um breve resumo do seu pedido:';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_dbb50a3167fd387cac23808bd55a9ee4'] = 'Identificação da transação PayPal: ';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'ou';
+$_MODULE['<{ps_checkout}prestashop>ps_checkout_eb18dd00e86aff4b5b5d15e938382b49'] = 'Outro método de pagamento';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_edd87c9059d88fea45c0bd6384ce92b9'] = 'Por favor, finalize a sua encomenda clicando em &quot;Confirmo a minha encomenda&quot;.';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f1d3b424cd68795ecaa552883759aceb'] = 'Resumo do pedido';
 $_MODULE['<{ps_checkout}prestashop>ps_checkout_f212c48fb02b2494070e22184cc8906b'] = 'Referência do pedido PayPal:';
@@ -319,6 +320,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_243e4f2f3bd512ca8a6cc83e7a19e103
 $_MODULE['<{ps_checkout}prestashop>translations_25a81701fbfa4a1efdf660a950c1d006'] = 'Branco';
 $_MODULE['<{ps_checkout}prestashop>translations_25d76826f85d2bb976027066e6fcc522'] = 'Configurações de arredondamento a atualizar';
 $_MODULE['<{ps_checkout}prestashop>translations_2607298669ace2fc910321afeb9f8a84'] = 'Baixar PDF';
+$_MODULE['<{ps_checkout}prestashop>translations_26609a4edfbef95f4695a1474d316a2c'] = 'Escolha a localização das mensagens na página';
 $_MODULE['<{ps_checkout}prestashop>translations_26a180e6da68731b08a94399789ff518'] = 'Parabéns! Já pode começar a vender online!';
 $_MODULE['<{ps_checkout}prestashop>translations_26d56092353c630f9ad92df134d3708d'] = 'Descrição da instalação';
 $_MODULE['<{ps_checkout}prestashop>translations_26ec71edbfce31656c47a66bf830ed1c'] = 'Cuidado, as configurações de arredondamento não são totalmente compatíveis com o processamento de transações do PrestaShop Checkout. Pode dar erro em algumas transações. Mas é fácil. As suas configurações de &quot;Regra de Arredondamento&quot; e &quot;Tipo de Arredondamento&quot; necessitam de ser definidas para &quot;Arredondar para o infinito quando o valor estiver a meio&quot; e &quot;Arredondar para cada artigo&quot; ou clique no botão abaixo para fazer isso automaticamente!';
@@ -376,6 +378,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_526d688f37a86d3c3f27d0c5016eb71d
 $_MODULE['<{ps_checkout}prestashop>translations_54c1127bed31e947d0951af3263522cf'] = 'Configure a descrição dos seus extratos bancários';
 $_MODULE['<{ps_checkout}prestashop>translations_5579726f3f99842c8bd6aa672b0ba1df'] = 'Comprimido';
 $_MODULE['<{ps_checkout}prestashop>translations_55926e741046f094a5597085b9a329bb'] = 'Não é possível coletar pagamentos com modo de teste';
+$_MODULE['<{ps_checkout}prestashop>translations_55c93629a14e52832a2a4b1c989140f4'] = 'por favor, verifique nossa lista de configurações personalizadas';
 $_MODULE['<{ps_checkout}prestashop>translations_56396cec5c858be914156d159a387592'] = 'Tipo de empresa';
 $_MODULE['<{ps_checkout}prestashop>translations_565c23511bb8643ac5552fbd5e4ba358'] = 'Um módulo, todas as formas de pagamento';
 $_MODULE['<{ps_checkout}prestashop>translations_57e46658fd7e21e0377d342fd9743dd4'] = 'Nenhum e-mail de confirmação?';
@@ -408,12 +411,14 @@ $_MODULE['<{ps_checkout}prestashop>translations_76f0ed934de85cc7131910b32ede7714
 $_MODULE['<{ps_checkout}prestashop>translations_78945de8de090e90045d299651a68a9b'] = 'Disponível';
 $_MODULE['<{ps_checkout}prestashop>translations_79d0c6669f615687e6a265f73e989d5d'] = 'Aceito os ';
 $_MODULE['<{ps_checkout}prestashop>translations_79f10e23fabf1720054a5fe16a62f760'] = 'Detalhes para extratos bancários';
+$_MODULE['<{ps_checkout}prestashop>translations_7a4711bc25b9893e1092c166e726b084'] = '(merchant ID {0})';
 $_MODULE['<{ps_checkout}prestashop>translations_7c6c2e5d48ab37a007cbf70d3ea25fa4'] = 'Pendente';
 $_MODULE['<{ps_checkout}prestashop>translations_7d6395b374d009ee9cae645ecf8556d0'] = 'Detalhes adicionais';
 $_MODULE['<{ps_checkout}prestashop>translations_7e87484272c2e328136e9d2bba0d8b27'] = 'Limite a sua taxa de fraude';
 $_MODULE['<{ps_checkout}prestashop>translations_7ec35321dd6ed2f0c30fccee83d15a2a'] = 'Conta bancária';
 $_MODULE['<{ps_checkout}prestashop>translations_7f2a1b59ac1ab6d2d892dbbf4f132c40'] = 'Sra.';
 $_MODULE['<{ps_checkout}prestashop>translations_7f79b3c1755a6eaf27e27a183a675477'] = 'Disponibilidade do cartão de crédito colocado em espera';
+$_MODULE['<{ps_checkout}prestashop>translations_8ac88d38d8b578d5b10bf4cf0cf50076'] = 'Escolha a localização dos botões na página';
 $_MODULE['<{ps_checkout}prestashop>translations_807235d3474190247606812059b87a5f'] = 'Assim que o PayPal receber todos os seus documentos, terá de aguardar 48h pela aprovação final.';
 $_MODULE['<{ps_checkout}prestashop>translations_8102d556eface36002bd4e3aef4f4acd'] = 'Todas as transações';
 $_MODULE['<{ps_checkout}prestashop>translations_8215900bbe4e4ddcac7968eefb28256d'] = 'Você pode processar';
@@ -477,6 +482,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_ad69e733ebae8d264bccaa38d68830e8
 $_MODULE['<{ps_checkout}prestashop>translations_adf6671e843f2afa12ff0da097e2cdbf'] = 'Validação de e-mail necessária';
 $_MODULE['<{ps_checkout}prestashop>translations_ae7bd6527c89645a15c3b5e5f1f22dbd'] = 'Sem redirecionamento ao pagar com cartão de crédito';
 $_MODULE['<{ps_checkout}prestashop>translations_af37d2248a1fa9c60e8df22938255f05'] = 'De momento, não podemos processar pagamentos por cartão de crédito para si.';
+$_MODULE['<{ps_checkout}prestashop>translations_b03623c3f090d1119f44d3191397acb1'] = 'Todos os temas personalizados podem não ser totalmente compatíveis. Para evitar possíveis problemas de integração na página de pagamento,';
 $_MODULE['<{ps_checkout}prestashop>translations_b235ad7b91fbeda6f87ac3d7e6f0ff6d'] = 'Nós recebemos a confirmação do PayPal. Agora poderá processar todas as transações com cartão sem limites.';
 $_MODULE['<{ps_checkout}prestashop>translations_b3a3bef1143977b9be6f9058641b1035'] = 'O e-mail não foi encontrado.';
 $_MODULE['<{ps_checkout}prestashop>translations_b52a626dee6ab468117342c9292a45b6'] = 'preferências de pagamento';
@@ -533,6 +539,7 @@ $_MODULE['<{ps_checkout}prestashop>translations_dc43994c00f8f208f0c649524a9bcd46
 $_MODULE['<{ps_checkout}prestashop>translations_dc647eb65e6711e155375218212b3964'] = 'Senha';
 $_MODULE['<{ps_checkout}prestashop>translations_dd7bf230fde8d4836917806aff6a6b27'] = 'Endereço';
 $_MODULE['<{ps_checkout}prestashop>translations_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Divisas';
+$_MODULE['<{ps_checkout}prestashop>translations_e138ea82bff561b002c7916e696f7bd2'] = 'Escolha a localização dos banners na página';
 $_MODULE['<{ps_checkout}prestashop>translations_e1b74123fdda2fd3b4a98308ef5dd782'] = 'Aviso : a moedas que você ativou : {0} não é atualmente suportada pelos PrestaShop Checkout. Por favor desative {0} para PrestaShop Checkout em suas';
 $_MODULE['<{ps_checkout}prestashop>translations_e1e1ce67de4906765f104f24a4280a1d'] = 'Precisa de ajuda? Aqui está a documentação deste módulo';
 $_MODULE['<{ps_checkout}prestashop>translations_e268443e43d93dab7ebef303bbe9642f'] = 'conta';

--- a/views/js/adminOrderView.js
+++ b/views/js/adminOrderView.js
@@ -19,7 +19,7 @@
  */
 
 let ps_checkout = {};
-const {$} = window;
+let {$} = window;
 
 (function() {
   /**

--- a/views/templates/hook/displayPayment.tpl
+++ b/views/templates/hook/displayPayment.tpl
@@ -17,37 +17,29 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *}
 
-{if !$isExpressCheckout}
-  <div id="ps_checkout-loader" class="express-checkout-block mb-2">
-    <div class="express-checkout-block-wrapper">
-      <p class="express-checkout-spinner-text">
-        {$loaderTranslatedText|escape:'htmlall':'UTF-8'}
-      </p>
-      <div class="express-checkout-spinner">
-        <img src="{$spinnerPath|escape:'htmlall':'UTF-8'}" alt="{$loaderTranslatedText|escape:'htmlall':'UTF-8'}">
-      </div>
+<div id="ps_checkout-loader" class="express-checkout-block mb-2">
+  <div class="express-checkout-block-wrapper">
+    <p class="express-checkout-spinner-text">
+      {$loaderTranslatedText|escape:'htmlall':'UTF-8'}
+    </p>
+    <div class="express-checkout-spinner">
+      <img src="{$spinnerPath|escape:'htmlall':'UTF-8'}" alt="{$loaderTranslatedText|escape:'htmlall':'UTF-8'}">
     </div>
   </div>
-{/if}
+</div>
 
 <section id="ps_checkout-displayPayment">
   {if !$is17 && $isExpressCheckout}
-  <div class="express-checkout-block">
+  <div class="express-checkout-block" id="ps_checkout-express-checkout-banner">
     <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
     <p class="express-checkout-label">
       {$translatedText|escape:'htmlall':'UTF-8'}
     </p>
-    <div id="button-paypal" class="ps_checkout-express-checkout-button">
-      <button id="ps_checkout-cancel" class="button btn" type="button">{$cancelTranslatedText|escape:'htmlall':'UTF-8'}</button>
-      <button id="ps_checkout-express-checkout-submit-button" class="button btn btn-default button-medium" type="button" disabled>
-        <span>{l s='I confirm my order' mod='ps_checkout'}<i class="icon-chevron-right right"></i></span>
-      </button>
-    </div>
   </div>
   {/if}
   <div class="payment-options">
     {foreach from=$paymentOptions item="paymentOptionName" key="fundingSource"}
-      <div id="payment-option-{$fundingSource}-container" class="payment-option ps_checkout-payment-option row" style="display: none;">
+      <div id="payment-option-{$fundingSource}-container" class="payment-option row" style="display: none;">
         <div class="col-xs-12">
           <div id="payment-option-{$fundingSource}" class="payment_module closed" data-module-name="ps_checkout-{$fundingSource}">
             <a class="ps_checkout-{$fundingSource}" href="#">

--- a/views/templates/hook/displayPayment.tpl
+++ b/views/templates/hook/displayPayment.tpl
@@ -32,7 +32,7 @@
 
 <section id="ps_checkout-displayPayment">
   {if !$is17 && $isExpressCheckout}
-  <div id="ps_checkout-block" class="express-checkout-block">
+  <div class="express-checkout-block">
     <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
     <p class="express-checkout-label">
       {$translatedText|escape:'htmlall':'UTF-8'}

--- a/views/templates/hook/displayPayment.tpl
+++ b/views/templates/hook/displayPayment.tpl
@@ -32,12 +32,13 @@
 
 <section id="ps_checkout-displayPayment">
   {if !$is17 && $isExpressCheckout}
-  <div class="express-checkout-block">
+  <div id="ps_checkout-block" class="express-checkout-block">
     <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
     <p class="express-checkout-label">
       {$translatedText|escape:'htmlall':'UTF-8'}
     </p>
     <div id="button-paypal" class="ps_checkout-express-checkout-button">
+      <button id="ps_checkout-cancel" class="button btn" type="button">{$cancelTranslatedText|escape:'htmlall':'UTF-8'}</button>
       <button id="ps_checkout-express-checkout-submit-button" class="button btn btn-default button-medium" type="button" disabled>
         <span>{l s='I confirm my order' mod='ps_checkout'}<i class="icon-chevron-right right"></i></span>
       </button>

--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -29,11 +29,12 @@
 </div>
 
 {if $is17 && $isExpressCheckout}
-<div class="express-checkout-block mb-2">
+<div id="ps_checkout-block" class="express-checkout-block mb-2">
   <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
   <p class="express-checkout-label">
     {$translatedText|escape:'htmlall':'UTF-8'}
   </p>
+  <button id="ps_checkout-cancel" class="btn btn-secondary">{$cancelTranslatedText|escape:'htmlall':'UTF-8'}</button>
 </div>
 {elseif $is17}
   <div id="ps_checkout-loader" class="express-checkout-block mb-2">

--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -29,24 +29,25 @@
 </div>
 
 {if $is17 && $isExpressCheckout}
-<div class="express-checkout-block mb-2">
+<div class="express-checkout-block mb-2" id="ps_checkout-express-checkout-banner">
   <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
   <p class="express-checkout-label">
     {$translatedText|escape:'htmlall':'UTF-8'}
   </p>
-  <button id="ps_checkout-cancel" class="btn btn-secondary">{$cancelTranslatedText|escape:'htmlall':'UTF-8'}</button>
 </div>
-{elseif $is17}
-  <div id="ps_checkout-loader" class="express-checkout-block mb-2">
-    <div class="express-checkout-block-wrapper">
-      <p class="express-checkout-spinner-text">
+{/if}
+
+{if $is17}
+<div id="ps_checkout-loader" class="express-checkout-block mb-2">
+  <div class="express-checkout-block-wrapper">
+    <p class="express-checkout-spinner-text">
         {$loaderTranslatedText|escape:'htmlall':'UTF-8'}
-      </p>
-      <div class="express-checkout-spinner">
-        <img src="{$spinnerPath|escape:'htmlall':'UTF-8'}" alt="{$loaderTranslatedText|escape:'htmlall':'UTF-8'}">
-      </div>
+    </p>
+    <div class="express-checkout-spinner">
+      <img src="{$spinnerPath|escape:'htmlall':'UTF-8'}" alt="{$loaderTranslatedText|escape:'htmlall':'UTF-8'}">
     </div>
   </div>
+</div>
 {/if}
 
 {if $is17}

--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -29,7 +29,7 @@
 </div>
 
 {if $is17 && $isExpressCheckout}
-<div id="ps_checkout-block" class="express-checkout-block mb-2">
+<div class="express-checkout-block mb-2">
   <img src="{$paypalLogoPath|escape:'htmlall':'UTF-8'}" class="express-checkout-img" alt="PayPal">
   <p class="express-checkout-label">
     {$translatedText|escape:'htmlall':'UTF-8'}

--- a/views/templates/hook/displayPaymentTop.tpl
+++ b/views/templates/hook/displayPaymentTop.tpl
@@ -58,7 +58,7 @@
         const paymentOptionContainer = document.getElementById(paymentOption.id + '-container');
         const paymentOptionName = paymentOption.getAttribute('data-module-name');
 
-        if (-1 !== paymentOptionName.search('ps_checkout')) {
+        if (!paymentOptionContainer.classList.contains('ps_checkout-payment-option') && -1 !== paymentOptionName.search('ps_checkout')) {
           paymentOptionContainer.style.display = 'none';
         }
       });

--- a/views/templates/hook/header.tpl
+++ b/views/templates/hook/header.tpl
@@ -17,5 +17,5 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *}
 {foreach $contentToPrefetch as $content}
-  <link rel="prefetch" href="{$content.link}" as="{$content.type}">
+  <link rel="prefetch" href="{$content.link|escape:'javascript':'UTF-8'}" as="{$content.type}">
 {/foreach}


### PR DESCRIPTION
- Change ExpressCheckout behavior on payment step: stop to hide others payment methods
- Change card limitation computing on module configuration page
- Add BN-Code to improve PayPal debug
- Improve compliance with custom themes
- Fix fatal error when gift wrapping is enabled
- Fix ExpressCheckout Address country checker
- Fix ExpressCheckout Address creation with erroneous id_state
- Fix ExpressCheckout errors PAYER_ACTION_REQUIRED and ORDER_NOT_APPROVED
- Fix javascript issue with Firefox on BO Order page
- Fix prefetch javascript only when javascript is not loaded
- Fix issues due to usage of expired PayPal Orders

This version update tpl files, if you have tpl override in your theme, please update them.