### PR TITLE
Fix ability to override global selectors

### DIFF
--- a/_dev/js/front/src/utils/globals/index.js
+++ b/_dev/js/front/src/utils/globals/index.js
@@ -21,7 +21,7 @@ window.ps_checkout = window.ps_checkout || {};
 window.ps_checkout.app = window.ps_checkout.app || null;
 
 window.ps_checkout.config = window.ps_checkout.config || {};
-window.ps_checkout.selectors = window.ps_checkout.app || {};
+window.ps_checkout.selectors = window.ps_checkout.selectors || {};
 
 window.ps_checkout.events = window.ps_checkout.events || new EventTarget();
 


### PR DESCRIPTION
I would target the `dev` branch according to contributing instructions, but it looks like that branch is abandoned (last commit almost 2 years ago).

This fixes ability to override DOM selectors. Docs: https://github.com/PrestaShopCorp/ps_checkout/wiki/PrestaShop-Checkout---theme-customization#query-selector-replacement