### PR TITLE
Upgrade PHPStan to latest version (PrestaShop 1.7)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -60,35 +60,50 @@ jobs:
         uses: actions/checkout@v2.0.0
       - name: Run PHP-CS-Fixer
         uses: prestashopcorp/github-action-php-cs-fixer@master
+
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.0.3', '1.7.8.8']
+        prestashop_version: [
+          "1.7.8.8",
+          "1.7.3.0",
+        ]
     steps:
+      - name: Download PrestaShop code source
+        run: |
+          wget -O /tmp/prestashop.zip https://github.com/PrestaShop/PrestaShop/releases/download/${{ matrix.prestashop_version }}/prestashop_${{ matrix.prestashop_version }}.zip
+          unzip -o /tmp/prestashop.zip -d /tmp
+          unzip -o /tmp/prestashop.zip -d /tmp/prestashop
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.2
+
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.composer/cache
           key: php-composer-cache
 
       - run: composer install
+      - run: cd tests/phpstan && composer install
 
-      - name: Pull PrestaShop files (Tag ${{ matrix.presta-versions }})
-        run: docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:${{ matrix.presta-versions }}
+      - name: Run PHPStan
+        env:
+          _PS_ROOT_DIR_: /tmp/prestashop
+        run: tests/phpstan/vendor/bin/phpstan analyze -c tests/phpstan/phpstan-PS-1.7.neon --error-format github
 
-      - name : Run PHPStan
-        run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12 analyse --configuration=/web/module/tests/phpstan/phpstan-PS-1.7.neon --error-format github
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ config_*.xml
 
 ### Composer ###
 composer.phar
-/vendor/
+**/vendor/
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/tests/phpstan/composer.json
+++ b/tests/phpstan/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "phpstan/phpstan": "^1.10"
+    }
+}
+

--- a/tests/phpstan/composer.lock
+++ b/tests/phpstan/composer.lock
@@ -1,0 +1,81 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "06a282a9caaa357cc75a987b3fac0f2f",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-16T15:24:20+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
Since the first implementation of PHPStan in our development process, we did not increase the version because the docker image had changed. We were stuck on `PHPStan - PHP Static Analysis Tool 0.12.89`, a version released on 09/06/2021.

Keeping our tools up-to-date is important for the stability of our projects. However newer versions were using PHP 8 in their Docker image, preventing it to work with old version of PrestaShop.
This PR add PHPStan as a composer dependency so we can control the version used with the lock file, and we updated the CI workflow so PrestaShop versions are manually downloaded and unzipped.

- [ ] Some errors will appear with the rules added. There are to way to fix this: Fix all the errors in the same PR, or add a baseline. I would prefer the first solution as it may fix some issues.

Replaces #1009 