### PR TITLE
Cannot identify right order status in Split Order

### DIFF
--- a/src/ValidateOrder.php
+++ b/src/ValidateOrder.php
@@ -198,7 +198,7 @@ class ValidateOrder
             try {
                 $module->validateOrder(
                     $payload['cartId'],
-                    (int) $this->getOrderState($psCheckoutCart->paypal_funding),
+                    (int)Configuration::get('PS_OS_PAYMENT'),
                     0,
                     $fundingSourceTranslationProvider->getPaymentMethodName($psCheckoutCart->paypal_funding),
                     null,


### PR DESCRIPTION
After the creating split order, module can't change order status second order, it only change first order which store in module->currentOrder.