### PR TITLE
Wrong state when using express checkout

### DIFF
--- a/controllers/front/ExpressCheckout.php
+++ b/controllers/front/ExpressCheckout.php
@@ -265,7 +265,7 @@ class ps_checkoutExpressCheckoutModuleFrontController extends AbstractFrontContr
             /** @var \PrestaShop\Module\PrestashopCheckout\Repository\CountryRepository $countryRepository */
             $countryRepository = $this->module->getService('ps_checkout.repository.country');
 
-            $idState = $countryRepository->getStateId($state);
+            $idState = $countryRepository->getStateId($idCountry, $state);
         }
 
         // check if a PayPal address already exist for the customer and not used

--- a/src/Repository/CountryRepository.php
+++ b/src/Repository/CountryRepository.php
@@ -55,14 +55,25 @@ class CountryRepository
      *
      * @return int
      */
-    public function getStateId($state)
+    public function getStateId($idCountry, $state)
     {
+        $db = \Db::getInstance();
         $query = new \DbQuery();
         $query->select('id_state');
         $query->from('state');
-        $query->where('name LIKE \'%' . pSQL($state) . '%\' OR iso_code LIKE \'%' . pSQL($state) . '%\'');
+        $query->where('iso_code LIKE \'%' . pSQL($state) . '%\'');
         $query->where('active = 1');
+        $query->where('id_country = '.(int)$idCountry);
+        $idState = (int)$db->getValue($query);
+        if($idState > 0)
+            return $idState;
 
-        return (int) \Db::getInstance()->getValue($query);
+        $query = new \DbQuery();
+        $query->select('id_state');
+        $query->from('state');
+        $query->where('name LIKE \'%' . pSQL($state) . '%\'');
+        $query->where('active = 1');
+        $query->where('id_country = '.(int)$idCountry);
+        return (int)$db->getValue($query);
     }
 }


### PR DESCRIPTION
Hello, i've edited the code in CountryRepository as the function getStateId could return completely wrong results.
As an example, there's a shop with states in italy, united states, indonesia and india.
If i create an account with expresscheckout using an italian address with state "Varese" which in short is "VA", the address gets created with state "Nevada".
That's because the current query does not take into account the country and it simply search "VA" in the name.
Furthermore, it should search first into the iso_code as there could be issues as well. Taking into account the country "VA" could return "Genova", "Mantova" ecc...
I hope this solves many problems.