### PR TITLE
test: add data-test on payment methods block

### DIFF
--- a/views/templates/hook/adminAfterHeader/promotionBlock.tpl
+++ b/views/templates/hook/adminAfterHeader/promotionBlock.tpl
@@ -20,7 +20,7 @@
 <div class="container">
     <div class="row">
         <div class="col">
-            <div class="card">
+            <div class="card" data-test="ps-checkout-card">
                 <h3 class="card-header">
                     <i class="material-icons">extension</i> {l s='One module, all payments methods.' mod='ps_checkout'}
                 </h3>


### PR DESCRIPTION
Add new data test to be able to detect that this bloc exist on the page (with automated tests)
![image](https://github.com/PrestaShopCorp/ps_checkout/assets/48441421/e528f48a-a576-4f9b-afa6-26e188d64f71)
