### PR TITLE
[PAYSHIP-3512] Missing create_time & issue OrderPayment

### DIFF
--- a/api/src/ValueObject/PayPalOrderResponse.php
+++ b/api/src/ValueObject/PayPalOrderResponse.php
@@ -58,11 +58,6 @@ class PayPalOrderResponse
     private $links;
 
     /**
-     * @var string
-     */
-    private $createTime;
-
-    /**
      * Constructor to initialize PayPalOrderResponse properties
      */
     public function __construct(
@@ -72,8 +67,7 @@ class PayPalOrderResponse
         $payer,
         $paymentSource,
         array $purchaseUnits,
-        array $links,
-        string $createTime
+        array $links
     ) {
         $this->id = $id;
         $this->status = $status;
@@ -82,7 +76,6 @@ class PayPalOrderResponse
         $this->paymentSource = $paymentSource;
         $this->purchaseUnits = $purchaseUnits;
         $this->links = $links;
-        $this->createTime = $createTime;
     }
 
     /**
@@ -139,14 +132,6 @@ class PayPalOrderResponse
     public function getLinks(): array
     {
         return $this->links;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCreateTime(): string
-    {
-        return $this->createTime;
     }
 
     /**

--- a/core/src/PayPal/Order/Provider/PayPalOrderProvider.php
+++ b/core/src/PayPal/Order/Provider/PayPalOrderProvider.php
@@ -163,8 +163,7 @@ class PayPalOrderProvider implements PayPalOrderProviderInterface
             $data['payer'] ?? null,
             $data['payment_source'] ?? null,
             $data['purchase_units'],
-            $data['links'],
-            $data['create_time']
+            $data['links']
         );
     }
 }


### PR DESCRIPTION
## Self-Checks
- [ ] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: [PAYSHIP-3512](https://forge.prestashop.com/browse/PAYSHIP-3512)

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->

## QA Checklist Labels
- [X] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->

## Additional Context
The create_time on order response is available only in createOrder response, others requests will only returns update_time.

## Frontend Changes
<!-- If applicable, provide visual elements such as screenshots, GIFs, or videos to demonstrate frontend changes. -->
<br><br>

[!] Don't forget to include JIRA task number in PR name or branch name. [!]

[!] Don't forget to update *changelog.md* with new changes. [!]

- [ ] Verify if the version is correct.
- [ ] Update demo environments used for testing.
- [ ] Ensure changelog contains all changes.
- [ ] Update documentation if needed.
- [ ] Test if everything works properly.