### PR TITLE
Cast cart->id_customer to int before calling getFundingSourceTokens

### DIFF
--- a/ps17/ps_checkout.php
+++ b/ps17/ps_checkout.php
@@ -680,7 +680,7 @@ class Ps_Checkout extends PaymentModule
 
         $paymentOptions = [];
 
-        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens($cart->id_customer) as $fundingSource) {
+        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens((int) $cart->id_customer) as $fundingSource) {
             $paymentOptions[] = $fundingSource->getName();
         }
 

--- a/ps8/ps_checkout.php
+++ b/ps8/ps_checkout.php
@@ -679,7 +679,7 @@ class Ps_Checkout extends PaymentModule
 
         $paymentOptions = [];
 
-        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens($cart->id_customer) as $fundingSource) {
+        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens((int) $cart->id_customer) as $fundingSource) {
             $paymentOptions[] = $fundingSource->getName();
         }
 

--- a/ps9/ps_checkout.php
+++ b/ps9/ps_checkout.php
@@ -679,7 +679,7 @@ class Ps_Checkout extends PaymentModule
 
         $paymentOptions = [];
 
-        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens($cart->id_customer) as $fundingSource) {
+        foreach ($fundingSourceTokenPresenter->getFundingSourceTokens((int) $cart->id_customer) as $fundingSource) {
             $paymentOptions[] = $fundingSource->getName();
         }
 


### PR DESCRIPTION
Cast cart->id_customer to int before calling getFundingSourceTokens as in third party checkout context, id_customer may be empty on initial checkout form load.

## Self-Checks
- [x] I have performed a self-review of my code.

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->
In third party checkout, when payment methods are called with no user, cart->id_customer will be empty, which would result in internal server error when calling typed-parameter method public function getFundingSourceTokens(int $customerId)

In previous ps_checkout module versions, cart->id_customer was casted to int in the FundingSourceProvider.php, with: 
```
public function getSavedTokens($customerId)
    {
        if ((int) $customerId && $this->payPalConfiguration->isVaultingEnabled()) {
```

## QA Checklist Labels
- [x] Regression (third party checkout module support)

<br><br>

It's very simple code change without any visual impact and with no impact to standard implementation in the native Prestashop checkout, it just adds more resilience and support for third party checkout modules.
- [x] Tested on dev store and also in production.