### PR TITLE
Remove from translations '%.' which fail IT translations

### DIFF
--- a/presentation/src/Presenter/FundingSource/FundingSourceTranslationProvider.php
+++ b/presentation/src/Presenter/FundingSource/FundingSourceTranslationProvider.php
@@ -60,7 +60,7 @@ class FundingSourceTranslationProvider implements FundingSourceTranslationProvid
 
         switch ($fundingSourceName) {
             case 'card':
-                return $this->translator->trans('Pay by Card - 100% secure payments');
+                return $this->translator->trans('Pay by Card - Secure payments');
             case 'paypal':
                 return $this->translator->trans('Pay with a PayPal account');
             case 'paylater':

--- a/presentation/src/Presenter/Settings/Front/Modules/TranslationModule.php
+++ b/presentation/src/Presenter/Settings/Front/Modules/TranslationModule.php
@@ -74,7 +74,7 @@ class TranslationModule implements PresenterInterface
                 'loader-component.label.header' => $this->translator->trans('Thanks for your purchase!'),
                 'loader-component.label.body' => $this->translator->trans('Please wait, we are processing your payment'),
                 'loader-component.label.body.longer' => $this->translator->trans('This is taking longer than expected. Please wait...'),
-                'payment-method-logos.title' => $this->translator->trans('100% secure payments'),
+                'payment-method-logos.title' => $this->translator->trans('Secure payments'),
                 'express-button.cart.separator' => $this->translator->trans('or'),
                 'express-button.checkout.express-checkout' => $this->translator->trans('Express Checkout'),
                 'ok' => $this->translator->trans('Ok'),

--- a/ps17/src/Presentation/Translator.php
+++ b/ps17/src/Presentation/Translator.php
@@ -68,7 +68,7 @@ class Translator implements TranslatorInterface
             'This is taking longer than expected. Please wait...' => $this->module->l('This is taking longer than expected. Please wait...', 'Translator'),
             'Ok' => $this->module->l('Ok', 'Translator'),
             'Cancel' => $this->module->l('Cancel', 'Translator'),
-            '100% secure payments' => $this->module->l('100% secure payments', 'Translator'),
+            'Secure payments' => $this->module->l('Secure payments', 'Translator'),
             'or' => $this->module->l('or', 'Translator'),
             'Express Checkout' => $this->module->l('Express Checkout', 'Translator'),
             'Please wait, loading additional payment methods.' => $this->module->l('Please wait, loading additional payment methods.', 'Translator'),
@@ -76,7 +76,7 @@ class Translator implements TranslatorInterface
             'Warning' => $this->module->l('Warning', 'Translator'),
 
             'Card' => $this->module->l('Card', 'Translator'),
-            'Pay by Card - 100% secure payments' => $this->module->l('Pay by Card - 100% secure payments', 'Translator'),
+            'Pay by Card - Secure payments' => $this->module->l('Pay by Card - Secure payments', 'Translator'),
             'Pay with a PayPal account' => $this->module->l('Pay with a PayPal account', 'Translator'),
             'Pay in installments with PayPal Pay Later' => $this->module->l('Pay in installments with PayPal Pay Later', 'Translator'),
             'Pay by %s' => $this->module->l('Pay by %s', 'Translator'),

--- a/ps17/translations/de.php
+++ b/ps17/translations/de.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Dies dauert länger als erwartet. Bitte warten…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Abbrechen';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = '100% sichere Zahlungen';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Sichere Zahlungen';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'oder';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Schneller Checkout';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Karte';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Bezahlen mit Karte - 100% sichere Zahlungen';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Bezahlen mit Karte - Sichere Zahlungen';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Bezahlen Sie mit einem PayPal-Konto';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Bezahlen ratenzahlung mit PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Bezahlen mit %s';

--- a/ps17/translations/en.php
+++ b/ps17/translations/en.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'This is taking longer than expected. Please wait...';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Cancel';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = '100% secure payments';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Secure payments';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'or';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Express Checkout';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Card';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Pay by Card - 100% secure payments';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Pay by Card - Secure payments';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Pay with a PayPal account';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Pay in installments with PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Pay by %s';

--- a/ps17/translations/es.php
+++ b/ps17/translations/es.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Esto está tardando más de lo esperado. Por favor, espera…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Cancelar';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Pagos 100% seguros';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Pagos seguros';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'o';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Compra rápida';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Tarjeta';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Pagar con tarjeta - Pagos 100% seguros';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Pagar con tarjeta - Pagos seguros';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Pagar con PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Pagar en varios plazos con PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Pagar con %s';

--- a/ps17/translations/fr.php
+++ b/ps17/translations/fr.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Veuillez patienter, cela prend un peu plus de temps...';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Annuler';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Paiement 100% sécurisé';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Paiement sécurisé';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'ou';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Achat rapide';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Carte';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Payer par Carte';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Payer par Carte';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Payer avec un compte PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Payer en plusieurs fois avec PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Payer avec %s';

--- a/ps17/translations/it.php
+++ b/ps17/translations/it.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Ci stiamo impiegando più del previsto. Attendere prego…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Annulla';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Pagamenti sicuri al 100%';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Pagamenti sicuri';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'o';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Acquisto rapido';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Carta';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Paga tramite carta - Pagamenti sicuri al 100%';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Paga tramite carta - Pagamenti sicuri';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Paga con un conto PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Paga a rate con PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Paga tramite %s';

--- a/ps17/translations/it.php
+++ b/ps17/translations/it.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Ci stiamo impiegando più del previsto. Attendere prego…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Annulla';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Pagamenti sicuri al 100%.';
+$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Pagamenti sicuri al 100%';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'o';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Acquisto rapido';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Carta';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Paga tramite carta - Pagamenti sicuri al 100%.';
+$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Paga tramite carta - Pagamenti sicuri al 100%';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Paga con un conto PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Paga a rate con PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Paga tramite %s';

--- a/ps17/translations/nl.php
+++ b/ps17/translations/nl.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Dit duurt langer dan verwacht. Even geduld alstublieft…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Annuleren';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = '100% veilige betalingen';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Veilige betalingen';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'of';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Gebruik Fast checkout';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Kaart';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Betalen met kaart- 100% veilige betalingen';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Betalen met kaart- veilige betalingen';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Betalen met PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Betalen in termijnen met PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Betalen met %s';

--- a/ps17/translations/pl.php
+++ b/ps17/translations/pl.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'To trwa dłużej niż oczekiwano. Proszę czekać…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Anuluj';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = '100% bezpieczne płatności';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Bezpieczne płatności';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'lub';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Express Checkout';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Karta';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Zapłać z Karta - 100% bezpieczne płatności';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Zapłać z Karta - bezpieczne płatności';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Zapłać z PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Płatności ratalne z PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Zapłać z %s';

--- a/ps17/translations/pt.php
+++ b/ps17/translations/pt.php
@@ -167,11 +167,11 @@ $_MODULE['<{ps_checkout}prestashop>translator_b4a89c5a9a46cf77f29e1c2d42af9083']
 $_MODULE['<{ps_checkout}prestashop>translator_e8780ac6730b52a2ebe7d18f308ff411'] = 'Isto está a demorar mais do que o esperado. Por favor, aguarde…';
 $_MODULE['<{ps_checkout}prestashop>translator_a60852f204ed8028c1c58808b746d115'] = 'Ok';
 $_MODULE['<{ps_checkout}prestashop>translator_ea4788705e6873b424c65e91c2846b19'] = 'Cancelar';
-$_MODULE['<{ps_checkout}prestashop>translator_2f2401d57093e7d31bf2689fb87f72f6'] = 'Pagamentos 100% seguros';
+$_MODULE['<{ps_checkout}prestashop>translator_90882b25ee7a8a13908647d038ea9420'] = 'Pagamentos seguros';
 $_MODULE['<{ps_checkout}prestashop>translator_e81c4e4f2b7b93b481e13a8553c2ae1b'] = 'ou';
 $_MODULE['<{ps_checkout}prestashop>translator_2e3e721e530a957f81d5b5dcff0bf0e1'] = 'Pagamento rápido';
 $_MODULE['<{ps_checkout}prestashop>translator_1d565b9e5303987bb1b1938d5d458bca'] = 'Cartão';
-$_MODULE['<{ps_checkout}prestashop>translator_983fe12e91079dcb00c74772b50747a3'] = 'Pagar com cartão - Pagamentos 100% seguros';
+$_MODULE['<{ps_checkout}prestashop>translator_c5ddac9cef20e114d7fd3e5897125bc4'] = 'Pagar com cartão - Pagamentos seguros';
 $_MODULE['<{ps_checkout}prestashop>translator_34ace703adbf14df140d3c02234f67bd'] = 'Pagar com PayPal';
 $_MODULE['<{ps_checkout}prestashop>translator_fc9b4762660906602b63bcd99e5e9747'] = 'Pague em parcelas com PayPal Pay Later';
 $_MODULE['<{ps_checkout}prestashop>translator_f990493af3321939ca512f8f2cace108'] = 'Pagar com %s';

--- a/ps8/src/Presentation/Translator.php
+++ b/ps8/src/Presentation/Translator.php
@@ -68,7 +68,7 @@ class Translator implements TranslatorInterface
             'This is taking longer than expected. Please wait...' => $this->translator->trans('This is taking longer than expected. Please wait...', $parameters, 'Modules.Checkout.Pscheckout'),
             'Ok' => $this->translator->trans('Ok', $parameters, 'Modules.Checkout.Pscheckout'),
             'Cancel' => $this->translator->trans('Cancel', $parameters, 'Modules.Checkout.Pscheckout'),
-            '100% secure payments' => $this->translator->trans('100% secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Secure payments' => $this->translator->trans('Secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
             'or' => $this->translator->trans('or', $parameters, 'Modules.Checkout.Pscheckout'),
             'Express Checkout' => $this->translator->trans('Express Checkout', $parameters, 'Modules.Checkout.Pscheckout'),
             'Please wait, loading additional payment methods.' => $this->translator->trans('Please wait, loading additional payment methods.', $parameters, 'Modules.Checkout.Pscheckout'),
@@ -76,7 +76,7 @@ class Translator implements TranslatorInterface
             'Warning' => $this->translator->trans('Warning', $parameters, 'Modules.Checkout.Pscheckout'),
 
             'Card' => $this->translator->trans('Card', $parameters, 'Modules.Checkout.Pscheckout'),
-            'Pay by Card - 100% secure payments' => $this->translator->trans('Pay by Card - 100% secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Pay by Card - Secure payments' => $this->translator->trans('Pay by Card - Secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay with a PayPal account' => $this->translator->trans('Pay with a PayPal account', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay in installments with PayPal Pay Later' => $this->translator->trans('Pay in installments with PayPal Pay Later', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay by %s' => $this->translator->trans('Pay by %s', $parameters, 'Modules.Checkout.Pscheckout'),

--- a/ps8/translations/de-DE/ModulesCheckoutPscheckout.de-DE.xlf
+++ b/ps8/translations/de-DE/ModulesCheckoutPscheckout.de-DE.xlf
@@ -547,9 +547,9 @@
         <target>Bezahlen Sie mit einem PayPal-Konto</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Mit Karte bezahlen - 100% sichere Zahlungen</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Mit Karte bezahlen - Sichere Zahlungen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Abbrechen</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% sichere Zahlungen</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Sichere Zahlungen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
+++ b/ps8/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
@@ -547,9 +547,9 @@
         <target>Pay with a PayPal account</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancel</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% secure payments</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/es-ES/ModulesCheckoutPscheckout.es-ES.xlf
+++ b/ps8/translations/es-ES/ModulesCheckoutPscheckout.es-ES.xlf
@@ -547,9 +547,9 @@
         <target>Pagar con PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pagar con tarjeta - pagos 100% seguros</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pagar con tarjeta - pagos seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancelar</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagos 100% seguros</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagos seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
+++ b/ps8/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
@@ -547,8 +547,8 @@
         <target>Payer avec un compte PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
         <target>Payer par Carte</target>
         <note>Line: </note>
       </trans-unit>
@@ -672,9 +672,9 @@
         <target>Annuler</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Paiement 100% sécurisé</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Paiement sécurisé</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
+++ b/ps8/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
@@ -674,7 +674,7 @@
       </trans-unit>
       <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
         <source>100% secure payments</source>
-        <target>Pagamenti sicuri al 100%.</target>
+        <target>Pagamenti sicuri al 100%</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
+++ b/ps8/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
@@ -547,9 +547,9 @@
         <target>Paga con un conto PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Paga tramite carta - pagamenti 100% sicuri</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Paga tramite carta - pagamenti sicuri</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Annulla</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagamenti sicuri al 100%</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagamenti sicuri</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/nl-NL/ModulesCheckoutPscheckout.nl-NL.xlf
+++ b/ps8/translations/nl-NL/ModulesCheckoutPscheckout.nl-NL.xlf
@@ -547,9 +547,9 @@
         <target>Betalen met PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Annuleren</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% veilige betalingen</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Veilige betalingen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/pl-PL/ModulesCheckoutPscheckout.pl-PL.xlf
+++ b/ps8/translations/pl-PL/ModulesCheckoutPscheckout.pl-PL.xlf
@@ -547,9 +547,9 @@
         <target>Zapłać z PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Anuluj</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% bezpieczne płatności</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Bezpieczne płatności</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps8/translations/pt-PT/ModulesCheckoutPscheckout.pt-PT.xlf
+++ b/ps8/translations/pt-PT/ModulesCheckoutPscheckout.pt-PT.xlf
@@ -547,9 +547,9 @@
         <target>Pagar com PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - secure payments</source>
+        <target>Pay by Card - secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancelar</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagamentos 100% seguros</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagamentos Seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/src/Presentation/Translator.php
+++ b/ps9/src/Presentation/Translator.php
@@ -68,7 +68,7 @@ class Translator implements TranslatorInterface
             'This is taking longer than expected. Please wait...' => $this->translator->trans('This is taking longer than expected. Please wait...', $parameters, 'Modules.Checkout.Pscheckout'),
             'Ok' => $this->translator->trans('Ok', $parameters, 'Modules.Checkout.Pscheckout'),
             'Cancel' => $this->translator->trans('Cancel', $parameters, 'Modules.Checkout.Pscheckout'),
-            '100% secure payments' => $this->translator->trans('100% secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Secure payments' => $this->translator->trans('Secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
             'or' => $this->translator->trans('or', $parameters, 'Modules.Checkout.Pscheckout'),
             'Express Checkout' => $this->translator->trans('Express Checkout', $parameters, 'Modules.Checkout.Pscheckout'),
             'Please wait, loading additional payment methods.' => $this->translator->trans('Please wait, loading additional payment methods.', $parameters, 'Modules.Checkout.Pscheckout'),
@@ -76,7 +76,7 @@ class Translator implements TranslatorInterface
             'Warning' => $this->translator->trans('Warning', $parameters, 'Modules.Checkout.Pscheckout'),
 
             'Card' => $this->translator->trans('Card', $parameters, 'Modules.Checkout.Pscheckout'),
-            'Pay by Card - 100% secure payments' => $this->translator->trans('Pay by Card - 100% secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Pay by Card - Secure payments' => $this->translator->trans('Pay by Card - Secure payments', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay with a PayPal account' => $this->translator->trans('Pay with a PayPal account', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay in installments with PayPal Pay Later' => $this->translator->trans('Pay in installments with PayPal Pay Later', $parameters, 'Modules.Checkout.Pscheckout'),
             'Pay by %s' => $this->translator->trans('Pay by %s', $parameters, 'Modules.Checkout.Pscheckout'),

--- a/ps9/translations/de-DE/ModulesCheckoutPscheckout.de-DE.xlf
+++ b/ps9/translations/de-DE/ModulesCheckoutPscheckout.de-DE.xlf
@@ -547,9 +547,9 @@
         <target>Bezahlen Sie mit einem PayPal-Konto</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Mit Karte bezahlen - 100% sichere Zahlungen</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Mit Karte bezahlen - Sichere Zahlungen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Abbrechen</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% sichere Zahlungen</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Sichere Zahlungen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
+++ b/ps9/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
@@ -547,9 +547,9 @@
         <target>Pay with a PayPal account</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancel</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% secure payments</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/es-ES/ModulesCheckoutPscheckout.es-ES.xlf
+++ b/ps9/translations/es-ES/ModulesCheckoutPscheckout.es-ES.xlf
@@ -547,9 +547,9 @@
         <target>Pagar con PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pagar con tarjeta - pagos 100% seguros</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pagar con tarjeta - pagos seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancelar</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagos 100% seguros</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagos seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
+++ b/ps9/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
@@ -547,8 +547,8 @@
         <target>Payer avec un compte PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
         <target>Payer par Carte</target>
         <note>Line: </note>
       </trans-unit>
@@ -672,9 +672,9 @@
         <target>Annuler</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Paiement 100% sécurisé</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Paiement sécurisé</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
+++ b/ps9/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
@@ -674,7 +674,7 @@
       </trans-unit>
       <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
         <source>100% secure payments</source>
-        <target>Pagamenti sicuri al 100%.</target>
+        <target>Pagamenti sicuri al 100%</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
+++ b/ps9/translations/it-IT/ModulesCheckoutPscheckout.it-IT.xlf
@@ -547,9 +547,9 @@
         <target>Paga con un conto PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Paga tramite carta - pagamenti 100% sicuri</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Paga tramite carta - pagamenti sicuri</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Annulla</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagamenti sicuri al 100%</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagamenti sicuri</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/nl-NL/ModulesCheckoutPscheckout.nl-NL.xlf
+++ b/ps9/translations/nl-NL/ModulesCheckoutPscheckout.nl-NL.xlf
@@ -547,9 +547,9 @@
         <target>Betalen met PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Annuleren</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% veilige betalingen</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Veilige betalingen</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/pl-PL/ModulesCheckoutPscheckout.pl-PL.xlf
+++ b/ps9/translations/pl-PL/ModulesCheckoutPscheckout.pl-PL.xlf
@@ -547,9 +547,9 @@
         <target>Zapłać z PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - Secure payments</source>
+        <target>Pay by Card - Secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Anuluj</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>100% bezpieczne płatności</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Bezpieczne płatności</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">

--- a/ps9/translations/pt-PT/ModulesCheckoutPscheckout.pt-PT.xlf
+++ b/ps9/translations/pt-PT/ModulesCheckoutPscheckout.pt-PT.xlf
@@ -547,9 +547,9 @@
         <target>Pagar com PayPal</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="983fe12e91079dcb00c74772b50747a3">
-        <source>Pay by Card - 100% secure payments</source>
-        <target>Pay by Card - 100% secure payments</target>
+      <trans-unit id="c5ddac9cef20e114d7fd3e5897125bc4">
+        <source>Pay by Card - secure payments</source>
+        <target>Pay by Card - secure payments</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="1d565b9e5303987bb1b1938d5d458bca">
@@ -672,9 +672,9 @@
         <target>Cancelar</target>
         <note>Line: </note>
       </trans-unit>
-      <trans-unit id="2f2401d57093e7d31bf2689fb87f72f6">
-        <source>100% secure payments</source>
-        <target>Pagamentos 100% seguros</target>
+      <trans-unit id="90882b25ee7a8a13908647d038ea9420">
+        <source>Secure payments</source>
+        <target>Pagamentos Seguros</target>
         <note>Line: </note>
       </trans-unit>
       <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">


### PR DESCRIPTION
## Self-Checks
- [x] I have performed a self-review of my code.
- [x] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: https://forge.prestashop.com/browse/PAYSHIP-3808

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->

## QA Checklist Labels
- [x] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

