### PR TITLE
Fix fatal error when purchase unit has no items key

### DIFF
--- a/core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php
+++ b/core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php
@@ -74,7 +74,7 @@ class UpdatePayPalOrderPurchaseUnitAction implements UpdatePayPalOrderPurchaseUn
                 $orderResponse->getId(),
                 crc32(json_encode($purchaseUnit)),
                 $purchaseUnit['reference_id'],
-                $purchaseUnit['items']
+                $purchaseUnit['items'] ?? []
             );
 
             $this->payPalOrderPurchaseUnitRepository->save($payPalPurchaseUnit);

--- a/core/src/PayPal/Order/Processor/CreatePayPalOrderProcessor.php
+++ b/core/src/PayPal/Order/Processor/CreatePayPalOrderProcessor.php
@@ -220,7 +220,7 @@ class CreatePayPalOrderProcessor implements CreatePayPalOrderProcessorInterface
                 $orderResponse->getId(),
                 crc32(json_encode($purchaseUnit)),
                 $purchaseUnit['reference_id'],
-                $purchaseUnit['items']
+                $purchaseUnit['items'] ?? []
             );
 
             $this->payPalOrderPurchaseUnitRepository->save($payPalPurchaseUnit);


### PR DESCRIPTION
## Description

`CreatePayPalOrderProcessor::savePurchaseUnits()` and `UpdatePayPalOrderPurchaseUnitAction::execute()` crash with a fatal error when PayPal returns a purchase unit without an `items` key.

### Error

```
PHP Warning: Undefined array key "items" in CreatePayPalOrderProcessor.php on line 223

PHP Fatal error: Uncaught TypeError: PayPalOrderPurchaseUnit::__construct():
Argument #4 ($items) must be of type array, null given
```

## Root cause

`$purchaseUnit['items']` is accessed without checking the key exists. When PayPal omits `items` from the response, `null` is passed to the constructor which expects `array`.

## Fix

Use null coalescing operator to default to an empty array:

```php
$purchaseUnit['items'] ?? []
```

Applied in both:
- `core/src/PayPal/Order/Processor/CreatePayPalOrderProcessor.php`
- `core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php`

## Environment

- ps_checkout version: 8.5.1.0 (v5.1.0)
- PrestaShop: 8.x
- PHP: 8.1