### PR TITLE
[PAYSHIP-388{0,3}]: Hook Authorization & Capture callbacks

### DIFF
--- a/.claude/skills/merchant-sdk-integration/SKILL.md
+++ b/.claude/skills/merchant-sdk-integration/SKILL.md
@@ -29,7 +29,6 @@ Load the UMD bundle via a `<script>` tag, then create and render the component:
     url: "https://checkout-app.example.com",
     order: { /* Raw PayPal Order JSON */ },
     isTestMode: false,
-    transactionActions: { /* Optional action overrides keyed by transaction ID */ },
     onSubmit: async (type, transactionId, data) => {
       // Handle the action (API call, etc.)
       return { message: "Action completed." };
@@ -77,7 +76,6 @@ interface PrestaShopCheckoutProps {
   url?: string;                                          // URL of the hosted child app (iframe src)
   order: PayPalOrder;                                    // Raw PayPal Order JSON from Orders v2 API
   isTestMode?: boolean;                                  // Display test mode indicator
-  transactionActions?: Record<string, TransactionActions>; // Action overrides keyed by transaction ID
   onSubmit?: (                                           // Action callback (see above)
     type: TransactionActionType,
     transactionId: string,
@@ -89,7 +87,6 @@ interface PrestaShopCheckoutProps {
 - `url` — Defaults to `window.location.origin` if omitted.
 - `order` — Required. The raw PayPal Order object from the Orders v2 API response.
 - `isTestMode` — Optional. Displays a test/production mode indicator.
-- `transactionActions` — Optional. Overrides available actions per transaction ID.
 - `onSubmit` — Optional. Called when the user triggers a transaction action.
 
 ## Type Reference
@@ -120,19 +117,6 @@ interface PurchaseUnit {
 ```
 
 Each authorization, capture, and refund object includes `id`, `status`, `amount`, `create_time`, and type-specific breakdown fields.
-
-### TransactionActions
-
-Controls which action buttons are shown. A `boolean` enables/disables; a `number` sets the maximum amount for the action. Keyed by transaction ID in `transactionActions`.
-
-```ts
-interface TransactionActions {
-  capture?: boolean | number;   // true or max capturable amount
-  void?: boolean;
-  reauthorize?: boolean;
-  refund?: boolean | number;    // true or max refundable amount
-}
-```
 
 ### TransactionActionData
 
@@ -264,13 +248,6 @@ const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
     payment_source: { paypal: {} },
   },
   isTestMode: false,
-  transactionActions: {
-    "0AE12345BC678901D": {
-      capture: 125.50,
-      void: true,
-      reauthorize: true,
-    },
-  },
   onSubmit: async (type, transactionId, data) => {
     const response = await fetch("/api/checkout/action", {
       method: "POST",
@@ -325,9 +302,6 @@ const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
       },
     },
   },
-  transactionActions: {
-    "CAP-001": { refund: 200.00 },
-  },
   onSubmit: async (type, transactionId, data) => {
     const response = await fetch("/api/checkout/action", {
       method: "POST",
@@ -351,16 +325,15 @@ let checkoutInstance;
 checkoutInstance = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
   url: "https://checkout-app.example.com",
   order: currentOrder,
-  transactionActions: currentActions,
   onSubmit: async (type, transactionId, data) => {
     await performAction(type, transactionId, data);
 
     // Fetch updated data from your backend
     const updated = await fetch(`/api/orders/${currentOrder.id}`);
-    const { order, transactionActions } = await updated.json();
+    const { order } = await updated.json();
 
     // Push new props into the iframe
-    await checkoutInstance.updateProps({ order, transactionActions });
+    await checkoutInstance.updateProps({ order });
 
     return { message: "Action completed and data refreshed." };
   },

--- a/.claude/skills/merchant-sdk-integration/SKILL.md
+++ b/.claude/skills/merchant-sdk-integration/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: merchant-sdk-integration
+description: >-
+  Use when helping developers integrate the PrestaShop Checkout merchant SDK
+  into a parent application (merchant backoffice). Covers loading the UMD bundle,
+  creating and rendering the Zoid component, handling onSubmit callbacks,
+  updating props dynamically, and full type/enum reference.
+metadata:
+  version: "2.0"
+compatibility: Requires @krakenjs/zoid ^10.5.0.
+---
+
+# PrestaShop Checkout Merchant SDK Integration
+
+## Quick Start
+
+Load the UMD bundle via a `<script>` tag, then create and render the component:
+
+```html
+<!-- 1. Load the SDK bundle -->
+<script src="https://your-cdn.example.com/merchant-sdk.umd.js"></script>
+
+<!-- 2. Provide a container element -->
+<div id="prestashop-checkout"></div>
+
+<script>
+  // 3. Create the component instance with props
+  const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+    url: "https://checkout-app.example.com",
+    order: { /* Raw PayPal Order JSON */ },
+    isTestMode: false,
+    transactionActions: { /* Optional action overrides keyed by transaction ID */ },
+    onSubmit: async (type, transactionId, data) => {
+      // Handle the action (API call, etc.)
+      return { message: "Action completed." };
+    },
+  });
+
+  // 4. Render into the container
+  checkout.render("#prestashop-checkout");
+</script>
+```
+
+The bundle exposes `window.PrestaShopCheckoutSDK` with a `PrestaShopCheckout` factory function.
+
+## onSubmit Callback
+
+Called when the user triggers a transaction action (capture, void, reauthorize, refund) inside the embedded component.
+
+```ts
+onSubmit?: (
+  type: TransactionActionType,
+  transactionId: string,
+  data?: TransactionActionData,
+) => void | SubmitResult | Promise<void | SubmitResult>;
+```
+
+**Parameters:**
+
+| Parameter       | Type                     | Description                                      |
+|-----------------|--------------------------|--------------------------------------------------|
+| `type`          | `TransactionActionType`  | The action: `"capture"`, `"void"`, `"reauthorize"`, or `"refund"` |
+| `transactionId` | `string`                | The PayPal transaction ID the action applies to  |
+| `data`          | `TransactionActionData?` | Optional action data (e.g., `{ amount: 50.00 }`) |
+
+**Return value:**
+
+- Return `void` or `undefined` for no feedback.
+- Return `{ message: "..." }` (`SubmitResult`) to display a success message.
+- Throw an `Error` to signal failure — the component will display the error.
+- May be `async` (return a `Promise`).
+
+## Component Props
+
+```ts
+interface PrestaShopCheckoutProps {
+  url?: string;                                          // URL of the hosted child app (iframe src)
+  order: PayPalOrder;                                    // Raw PayPal Order JSON from Orders v2 API
+  isTestMode?: boolean;                                  // Display test mode indicator
+  transactionActions?: Record<string, TransactionActions>; // Action overrides keyed by transaction ID
+  onSubmit?: (                                           // Action callback (see above)
+    type: TransactionActionType,
+    transactionId: string,
+    data?: TransactionActionData,
+  ) => void | SubmitResult | Promise<void | SubmitResult>;
+}
+```
+
+- `url` — Defaults to `window.location.origin` if omitted.
+- `order` — Required. The raw PayPal Order object from the Orders v2 API response.
+- `isTestMode` — Optional. Displays a test/production mode indicator.
+- `transactionActions` — Optional. Overrides available actions per transaction ID.
+- `onSubmit` — Optional. Called when the user triggers a transaction action.
+
+## Type Reference
+
+### PayPalOrder (subset)
+
+The SDK accepts the raw JSON response from PayPal's Orders v2 API. Key fields used:
+
+```ts
+interface PayPalOrder {
+  id: string;
+  status: OrderStatus;
+  intent: OrderIntent;          // "CAPTURE" or "AUTHORIZE"
+  purchase_units: PurchaseUnit[];
+  payment_source?: PaymentSource;
+  create_time?: string;
+}
+
+interface PurchaseUnit {
+  reference_id?: string;
+  amount: { currency_code: string; value: string };
+  payments?: {
+    authorizations?: PayPalAuthorization[];
+    captures?: PayPalCapture[];
+    refunds?: PayPalRefund[];
+  };
+}
+```
+
+Each authorization, capture, and refund object includes `id`, `status`, `amount`, `create_time`, and type-specific breakdown fields.
+
+### TransactionActions
+
+Controls which action buttons are shown. A `boolean` enables/disables; a `number` sets the maximum amount for the action. Keyed by transaction ID in `transactionActions`.
+
+```ts
+interface TransactionActions {
+  capture?: boolean | number;   // true or max capturable amount
+  void?: boolean;
+  reauthorize?: boolean;
+  refund?: boolean | number;    // true or max refundable amount
+}
+```
+
+### TransactionActionData
+
+```ts
+interface TransactionActionData {
+  amount?: number;
+}
+```
+
+### SubmitResult
+
+```ts
+interface SubmitResult {
+  message?: string;
+}
+```
+
+## Enum Reference
+
+All enums use PayPal-native SCREAMING_SNAKE_CASE values.
+
+### TransactionActionType
+
+| Key           | Value            |
+|---------------|------------------|
+| `Capture`     | `"capture"`      |
+| `Void`        | `"void"`         |
+| `Reauthorize` | `"reauthorize"`  |
+| `Refund`      | `"refund"`       |
+
+### OrderStatus
+
+| Value                    | Description            |
+|--------------------------|------------------------|
+| `CREATED`                | Order created          |
+| `SAVED`                  | Order saved            |
+| `APPROVED`               | Payer approved         |
+| `VOIDED`                 | Order voided           |
+| `COMPLETED`              | Order completed        |
+| `PAYER_ACTION_REQUIRED`  | Payer action needed    |
+
+### OrderIntent
+
+| Value       | Description                |
+|-------------|----------------------------|
+| `CAPTURE`   | Direct capture             |
+| `AUTHORIZE` | Authorize then capture     |
+
+### AuthorizationStatus
+
+| Value               | Description         |
+|---------------------|---------------------|
+| `CREATED`           | Authorization created |
+| `CAPTURED`          | Fully captured      |
+| `DENIED`            | Authorization denied |
+| `PARTIALLY_CAPTURED`| Partially captured  |
+| `VOIDED`            | Authorization voided |
+| `PENDING`           | Authorization pending |
+
+### CaptureStatus
+
+| Value               | Description           |
+|---------------------|-----------------------|
+| `COMPLETED`         | Capture completed     |
+| `DECLINED`          | Capture declined      |
+| `PARTIALLY_REFUNDED`| Partially refunded    |
+| `PENDING`           | Capture pending       |
+| `REFUNDED`          | Fully refunded        |
+| `FAILED`            | Capture failed        |
+
+### RefundStatus
+
+| Value       | Description     |
+|-------------|-----------------|
+| `CANCELLED` | Refund cancelled |
+| `FAILED`    | Refund failed   |
+| `PENDING`   | Refund pending  |
+| `COMPLETED` | Refund completed |
+
+### SellerProtectionStatus
+
+| Value                | Description         |
+|----------------------|---------------------|
+| `ELIGIBLE`           | Fully eligible      |
+| `PARTIALLY_ELIGIBLE` | Partially eligible  |
+| `NOT_ELIGIBLE`       | Not eligible        |
+
+### LiabilityShift
+
+| Value     | Description                |
+|-----------|----------------------------|
+| `POSSIBLE`| Liability shifted to bank  |
+| `NO`      | Merchant bears liability   |
+| `UNKNOWN` | Unknown liability shift    |
+
+### PaymentMode
+
+Unchanged from v1. Used internally by the SDK to display payment method logos. The SDK derives PaymentMode from `payment_source` automatically — you do not need to set it.
+
+## Common Integration Scenarios
+
+### Authorization + Capture Flow
+
+An order in auth-capture mode where the merchant captures the full authorized amount:
+
+```js
+const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+  url: "https://checkout-app.example.com",
+  order: {
+    id: "5O190127TN364715T",
+    status: "APPROVED",
+    intent: "AUTHORIZE",
+    purchase_units: [{
+      reference_id: "default",
+      amount: { currency_code: "EUR", value: "125.50" },
+      payments: {
+        authorizations: [{
+          id: "0AE12345BC678901D",
+          status: "CREATED",
+          amount: { currency_code: "EUR", value: "125.50" },
+          create_time: "2025-12-01T10:00:00Z",
+          expiration_time: "2025-12-30T10:00:00Z",
+          seller_protection: { status: "ELIGIBLE" },
+        }],
+        captures: [],
+        refunds: [],
+      },
+    }],
+    payment_source: { paypal: {} },
+  },
+  isTestMode: false,
+  transactionActions: {
+    "0AE12345BC678901D": {
+      capture: 125.50,
+      void: true,
+      reauthorize: true,
+    },
+  },
+  onSubmit: async (type, transactionId, data) => {
+    const response = await fetch("/api/checkout/action", {
+      method: "POST",
+      body: JSON.stringify({ type, transactionId, ...data }),
+    });
+    if (!response.ok) throw new Error("Action failed");
+    return { message: `${type} completed successfully.` };
+  },
+});
+
+checkout.render("#prestashop-checkout");
+```
+
+### Completed Payment with Partial Refund Available
+
+```js
+const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+  url: "https://checkout-app.example.com",
+  order: {
+    id: "ORDER-002",
+    status: "COMPLETED",
+    intent: "CAPTURE",
+    purchase_units: [{
+      reference_id: "default",
+      amount: { currency_code: "EUR", value: "200.00" },
+      payments: {
+        captures: [{
+          id: "CAP-001",
+          status: "COMPLETED",
+          amount: { currency_code: "EUR", value: "200.00" },
+          create_time: "2025-06-15T10:00:00Z",
+          seller_protection: { status: "ELIGIBLE" },
+          seller_receivable_breakdown: {
+            gross_amount: { currency_code: "EUR", value: "200.00" },
+            paypal_fee: { currency_code: "EUR", value: "5.80" },
+            net_amount: { currency_code: "EUR", value: "194.20" },
+          },
+        }],
+      },
+    }],
+    payment_source: {
+      card: {
+        brand: "VISA",
+        last_digits: "4242",
+        authentication_result: {
+          liability_shift: "POSSIBLE",
+          three_d_secure: {
+            authentication_status: "Y",
+            enrollment_status: "Y",
+          },
+        },
+      },
+    },
+  },
+  transactionActions: {
+    "CAP-001": { refund: 200.00 },
+  },
+  onSubmit: async (type, transactionId, data) => {
+    const response = await fetch("/api/checkout/action", {
+      method: "POST",
+      body: JSON.stringify({ type, transactionId, ...data }),
+    });
+    if (!response.ok) throw new Error("Refund failed");
+    return { message: `Refunded ${data?.amount} EUR.` };
+  },
+});
+
+checkout.render("#prestashop-checkout");
+```
+
+### Refreshing Data After an Action
+
+After a successful `onSubmit`, refresh the component by calling `updateProps` with fresh data:
+
+```js
+let checkoutInstance;
+
+checkoutInstance = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+  url: "https://checkout-app.example.com",
+  order: currentOrder,
+  transactionActions: currentActions,
+  onSubmit: async (type, transactionId, data) => {
+    await performAction(type, transactionId, data);
+
+    // Fetch updated data from your backend
+    const updated = await fetch(`/api/orders/${currentOrder.id}`);
+    const { order, transactionActions } = await updated.json();
+
+    // Push new props into the iframe
+    await checkoutInstance.updateProps({ order, transactionActions });
+
+    return { message: "Action completed and data refreshed." };
+  },
+});
+
+checkoutInstance.render("#prestashop-checkout");
+```
+
+### Test Mode
+
+Set `isTestMode: true` to display a test mode indicator:
+
+```js
+const checkout = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+  order: { /* ... */ },
+  isTestMode: true,
+});
+```
+
+## Architecture Notes
+
+- **Zoid iframe**: The SDK uses `@krakenjs/zoid` to render the checkout component inside an iframe. The parent page loads the UMD bundle which registers the Zoid component. The child app runs inside the iframe.
+- **`window.xprops`**: Inside the iframe, the child app accesses parent-provided props via `window.xprops`. It listens for dynamic updates via `window.xprops.onProps(callback)`.
+- **`url` prop**: The `url` prop sets the iframe `src`. It defaults to `window.location.origin`. In production, point it to your hosted child app URL.
+- **Data derivation**: The SDK derives all display data (financials, payment mode, transaction list, 3DS status) from the raw PayPal Order JSON using internal composables. The parent only needs to pass the raw API response.
+- **Build commands**:
+  - `yarn run dev` — Dev server with playground at `http://localhost:5173/playground.html`
+  - `yarn run build` — Build the child app to `app/dist/`
+  - `yarn run build:sdk` — Build the UMD bundle to `dist/sdk/merchant-sdk.umd.js`
+  - `yarn run serve:sdk` — Preview the UMD bundle on port `5174`
+- **Playground**: Access `http://localhost:5173/playground.html` during development to simulate the parent application with editable JSON props.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ make install-module        # Install the module in PrestaShop via console
 ```
 
 All `make` test commands run inside the Docker container using `$MODULE_VERSION` and `$PS_VERSION_TAG` from `.env`.
+`make phpstan` runs locally without Docker. All `make *-test` commands require a running Docker container (`make up`).
 
 Code style check without fixing: `composer cs` (from root).
 
@@ -114,6 +115,10 @@ The `ps<version>/src/` directory (namespace `PsCheckout\Module\`) contains only 
 - `prerelease.yml` — pre-release pipeline
 - `publish-to-marketplace.yml` — publishes to PrestaShop Marketplace
 
+### PHPStan workflow
+
+`make phpstan` runs locally (no Docker needed). When modifying shared packages, always run `make phpstan` and fix reported errors. Only regenerate the baseline (`make phpstan-baseline`) if errors are pre-existing or unfixable (e.g., baseline count mismatches from removed code).
+
 ### PHP-CS-Fixer scope
 
 PHP-CS-Fixer applies to: `api/`, `core/`, `infrastructure/`, `presentation/`, `utility/` — not to the `ps17/`, `ps8/`, `ps9/` version directories. Rules: PSR-2, AFL-3.0 header comment, no unused imports.
@@ -133,3 +138,4 @@ Follow [PrestaShop coding standards](https://devdocs.prestashop-project.org/8/de
 - `views/templates/hook/partials/<name>.tpl` — thin wrapper: guard with `typeof ps_checkout_<name> !== 'undefined'`, then call `.initialize({...})` with Smarty-escaped config values
 - Register in `hookActionAdminControllerSetMedia` via `addJS(...'?version=' . $this->version . '&rand=' . time(), false)`
 - JS files under `ps{8,9,17}/views/js/` are identical across versions — create one, `cp` to the other two
+- Admin controllers (`ps{8,9,17}/controllers/admin/`) are nearly identical across versions — apply the same edit to all three. Exception: ps9 uses `\Exception` (namespaced), ps8/ps17 use `Exception` (global).

--- a/api/src/Http/Exception/PayPalError.php
+++ b/api/src/Http/Exception/PayPalError.php
@@ -367,6 +367,8 @@ class PayPalError
                 throw new PayPalException('Credit card number is invalid.', PayPalException::CREDIT_CARD_NUMBER_IS_INVALID, $previous);
             case 'CARD_EXPIRATION_YEAR_IS_INVALID':
                 throw new PayPalException('Expiration year outside of acceptable range.', PayPalException::CARD_EXPIRATION_YEAR_IS_INVALID, $previous);
+            case 'REAUTHORIZATION_TOO_SOON':
+                throw new PayPalException('Reauthorization of authorization happened too soon.', PayPalException::REAUTHORIZATION_TOO_SOON, $previous);
             default:
                 throw new PayPalException($this->message, PayPalException::UNKNOWN, $previous);
         }

--- a/api/src/Http/Exception/PayPalException.php
+++ b/api/src/Http/Exception/PayPalException.php
@@ -345,4 +345,6 @@ class PayPalException extends PsCheckoutException
     const CREDIT_CARD_NUMBER_IS_INVALID = 160;
 
     const CARD_EXPIRATION_YEAR_IS_INVALID = 161;
+
+    const REAUTHORIZATION_TOO_SOON = 162;
 }

--- a/api/src/Http/PaymentHttpClient.php
+++ b/api/src/Http/PaymentHttpClient.php
@@ -114,11 +114,13 @@ class PaymentHttpClient extends PsrHttpClientAdapter implements PaymentHttpClien
      */
     public function reauthorizeAuthorization(string $authorizationId, ?ReauthorizeAuthorizationRequestDto $requestDto = null): PaymentAuthorizationResponseDto
     {
-        $payload = $this->serializer->serialize($requestDto ?? [], JsonEncoder::FORMAT, [
-            AbstractObjectNormalizer::SKIP_NULL_VALUES => true
-        ]);
-
-        $response = $this->sendRequest(new Request('POST', "authorizations/$authorizationId/reauthorize", [], $payload));
+        $payload = [];
+        if ($requestDto) {
+            $payload = $this->serializer->serialize($requestDto, JsonEncoder::FORMAT, [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true
+            ]);
+        }
+        $response = $this->sendRequest(new Request('POST', "authorizations/$authorizationId/reauthorize", [], empty($payload) ? '{}' : $payload));
 
         return $this->serializer->deserialize($response->getBody(), PaymentAuthorizationResponseDto::class, JsonEncoder::FORMAT);
     }

--- a/api/src/ValueObject/PayPalOrderResponse.php
+++ b/api/src/ValueObject/PayPalOrderResponse.php
@@ -423,4 +423,23 @@ class PayPalOrderResponse
 
         return '';
     }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'id' => $this->id,
+            'status' => $this->status,
+            'intent' => $this->intent,
+            'purchase_units' => $this->purchaseUnits,
+        ];
+
+        if ($this->paymentSource !== null) {
+            $data['payment_source'] = $this->paymentSource;
+        }
+
+        return $data;
+    }
 }

--- a/core/src/Hook/Handlers/index.php
+++ b/core/src/Hook/Handlers/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/src/Hook/index.php
+++ b/core/src/Hook/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/src/PayPal/Payment/Authorization/Action/AuthorizationActionInterface.php
+++ b/core/src/PayPal/Payment/Authorization/Action/AuthorizationActionInterface.php
@@ -38,8 +38,9 @@ interface AuthorizationActionInterface
      * Execute the authorization action.
      *
      * @param PayPalOrderResponse $payPalOrder
+     * @param array<string, mixed> $payload
      *
      * @return PayPalOrderAuthorization
      */
-    public function execute(PayPalOrderResponse $payPalOrder);
+    public function execute(PayPalOrderResponse $payPalOrder, array $payload = []);
 }

--- a/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
@@ -66,7 +66,7 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
         // Check PayPal order status must be COMPLETED
         if ($payPalOrder->getStatus() !== PayPalOrderStatus::COMPLETED) {
             throw new PsCheckoutException(
-                sprintf('PayPal Order %s status must be APPROVED, current status: %s', $payPalOrder->getId(), $payPalOrder->getStatus()),
+                sprintf('PayPal Order %s status must be COMPLETED, current status: %s', $payPalOrder->getId(), $payPalOrder->getStatus()),
                 PsCheckoutException::PAYPAL_ORDER_STATUS_INVALID
             );
         }

--- a/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
@@ -61,10 +61,10 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(PayPalOrderResponse $payPalOrder)
+    public function execute(PayPalOrderResponse $payPalOrder, array $payload = [])
     {
-        // Check PayPal order status must be APPROVED
-        if ($payPalOrder->getStatus() !== PayPalOrderStatus::APPROVED) {
+        // Check PayPal order status must be COMPLETED
+        if ($payPalOrder->getStatus() !== PayPalOrderStatus::COMPLETED) {
             throw new PsCheckoutException(
                 sprintf('PayPal Order %s status must be APPROVED, current status: %s', $payPalOrder->getId(), $payPalOrder->getStatus()),
                 PsCheckoutException::PAYPAL_ORDER_STATUS_INVALID
@@ -131,7 +131,7 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
             );
         }
 
-        $captureResponse = $this->paymentHttpClient->captureAuthorization($authorizationId);
+        $captureResponse = $this->paymentHttpClient->captureAuthorization($authorizationId, $payload);
 
         /**
          * @var array{

--- a/core/src/PayPal/Payment/Authorization/Action/ReauthorizeAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/ReauthorizeAuthorizationAction.php
@@ -87,7 +87,7 @@ final class ReauthorizeAuthorizationAction implements AuthorizationActionInterfa
     /**
      * @inheritDoc
      */
-    public function execute(PayPalOrderResponse $payPalOrder)
+    public function execute(PayPalOrderResponse $payPalOrder, array $payload = [])
     {
         if ($payPalOrder->getIntent() !== PayPalOrderIntent::AUTHORIZE) {
             $this->logger->error('PayPal Order intent must be AUTHORIZE', ['order_id' => $payPalOrder->getId()]);

--- a/core/src/PayPal/Payment/Authorization/Action/VoidAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/VoidAuthorizationAction.php
@@ -59,7 +59,7 @@ final class VoidAuthorizationAction implements AuthorizationActionInterface
     /**
      * {@inheritDoc}
      */
-    public function execute(PayPalOrderResponse $payPalOrder): PayPalOrderAuthorization
+    public function execute(PayPalOrderResponse $payPalOrder, array $payload = []): PayPalOrderAuthorization
     {
         // Check intent must be AUTHORIZE
         if ($payPalOrder->getIntent() !== 'AUTHORIZE') {

--- a/core/src/PayPal/Payment/Authorization/Configuration/index.php
+++ b/core/src/PayPal/Payment/Authorization/Configuration/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/src/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessor.php
+++ b/core/src/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessor.php
@@ -60,7 +60,7 @@ class AuthorizationActionProcessor implements AuthorizationActionProcessorInterf
     /**
      * @inheritDoc
      */
-    public function process(string $action, ?string $orderId): array
+    public function process(string $action, ?string $orderId, array $payload = []): array
     {
         if (!$orderId) {
             return [
@@ -80,8 +80,10 @@ class AuthorizationActionProcessor implements AuthorizationActionProcessorInterf
         try {
             $payPalOrderResponse = $this->payPalOrderProvider->getById($orderId);
 
-            $handler->execute($payPalOrderResponse);
+            $handler->execute($payPalOrderResponse, $payload);
         } catch (Exception $e) {
+            \Sentry\captureException($e);
+
             $this->logger->error('Failed to execute authorization action: ' . $e->getMessage());
 
             return [

--- a/core/src/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessorInterface.php
+++ b/core/src/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessorInterface.php
@@ -25,6 +25,7 @@ interface AuthorizationActionProcessorInterface
     /**
      * @param string $action
      * @param string|null $orderId
+     * @param array<string, mixed> $payload
      *
      * @return array{
      *     status: bool,
@@ -32,5 +33,5 @@ interface AuthorizationActionProcessorInterface
      *     error?: array{message: string, code: int}
      * }
      */
-    public function process(string $action, ?string $orderId): array;
+    public function process(string $action, ?string $orderId, array $payload = []): array;
 }

--- a/core/src/Webhook/Configuration/index.php
+++ b/core/src/Webhook/Configuration/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+++ b/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
@@ -31,6 +31,7 @@ use PsCheckout\Core\Webhook\Configuration\WebhookCategoryConfiguration;
 use PsCheckout\Core\Webhook\Configuration\WebhookEventTypeConfiguration;
 use PsCheckout\Core\WebhookDispatcher\ValueObject\DispatchWebhookRequest;
 use Psr\Log\LoggerInterface;
+use function Sentry\init;
 
 class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
 {
@@ -96,8 +97,12 @@ class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
             return true;
         }
 
-        $orderId = $dispatchWebhookRequest->getOrderId();
+        if ($dispatchWebhookRequest->getEventType() === WebhookEventTypeConfiguration::PAYMENT_AUTHORIZATION_VOIDED) {
+            $this->log('Payment authorization voided, skipping', $dispatchWebhookRequest);
+            return true;
+        }
 
+        $orderId = $dispatchWebhookRequest->getOrderId();
         if (!$orderId) {
             throw new PsCheckoutException('orderId must not be empty', PsCheckoutException::PSCHECKOUT_WEBHOOK_ORDER_ID_EMPTY);
         }

--- a/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+++ b/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
@@ -31,7 +31,6 @@ use PsCheckout\Core\Webhook\Configuration\WebhookCategoryConfiguration;
 use PsCheckout\Core\Webhook\Configuration\WebhookEventTypeConfiguration;
 use PsCheckout\Core\WebhookDispatcher\ValueObject\DispatchWebhookRequest;
 use Psr\Log\LoggerInterface;
-use function Sentry\init;
 
 class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
 {
@@ -99,6 +98,7 @@ class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
 
         if ($dispatchWebhookRequest->getEventType() === WebhookEventTypeConfiguration::PAYMENT_AUTHORIZATION_VOIDED) {
             $this->log('Payment authorization voided, skipping', $dispatchWebhookRequest);
+
             return true;
         }
 

--- a/core/tests/Unit/Hook/Handlers/index.php
+++ b/core/tests/Unit/Hook/Handlers/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/tests/Unit/Hook/index.php
+++ b/core/tests/Unit/Hook/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
+++ b/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
@@ -62,7 +62,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -119,7 +119,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -170,7 +170,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -215,7 +215,7 @@ class CaptureAuthorizationActionTest extends TestCase
 
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -261,7 +261,7 @@ class CaptureAuthorizationActionTest extends TestCase
         $this->assertEquals(PayPalAuthorizationStatus::CAPTURED, $result->getStatus());
     }
 
-    public function testThrowsExceptionWhenOrderStatusNotApproved(): void
+    public function testThrowsExceptionWhenOrderStatusNotCompleted(): void
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
@@ -277,7 +277,7 @@ class CaptureAuthorizationActionTest extends TestCase
         );
 
         $this->expectException(PsCheckoutException::class);
-        $this->expectExceptionMessage('PayPal Order ORDER-123 status must be APPROVED, current status: CREATED');
+        $this->expectExceptionMessage('PayPal Order ORDER-123 status must be COMPLETED, current status: CREATED');
         $this->expectExceptionCode(PsCheckoutException::PAYPAL_ORDER_STATUS_INVALID);
 
         $this->action->execute($payPalOrder);
@@ -287,7 +287,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'CAPTURE',
             [
                 'id' => 'AUTH-456',
@@ -329,7 +329,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -351,7 +351,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -373,7 +373,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',
@@ -395,7 +395,7 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         $payPalOrder = $this->createPayPalOrder(
             'ORDER-123',
-            PayPalOrderStatus::APPROVED,
+            PayPalOrderStatus::COMPLETED,
             'AUTHORIZE',
             [
                 'id' => 'AUTH-456',

--- a/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
+++ b/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
@@ -204,6 +204,63 @@ class CaptureAuthorizationActionTest extends TestCase
         $this->assertEquals(PayPalAuthorizationStatus::CAPTURED, $result->getStatus());
     }
 
+    public function testSuccessfulCaptureWithPayload(): void
+    {
+        $payload = [
+            'amount' => [
+                'value' => '50.00',
+                'currency_code' => 'EUR',
+            ],
+        ];
+
+        $payPalOrder = $this->createPayPalOrder(
+            'ORDER-123',
+            PayPalOrderStatus::APPROVED,
+            'AUTHORIZE',
+            [
+                'id' => 'AUTH-456',
+                'status' => PayPalAuthorizationStatus::CREATED,
+                'expiration_time' => '2100-01-28T23:59:59Z',
+                'create_time' => '2099-12-31T23:59:59Z',
+                'update_time' => '2099-12-31T23:59:59Z',
+            ]
+        );
+
+        $capturedAuthData = [
+            'id' => 'AUTH-456',
+            'status' => PayPalAuthorizationStatus::CAPTURED,
+            'create_time' => '2099-12-31T23:59:59Z',
+            'update_time' => '2099-12-31T23:59:59Z',
+        ];
+
+        $this->paymentHttpClient->expects($this->once())
+            ->method('captureAuthorization')
+            ->with('AUTH-456', $payload)
+            ->willReturn($this->createHttpResponse($capturedAuthData));
+
+        $existingEntity = new PayPalOrderAuthorization(
+            'AUTH-456',
+            'ORDER-123',
+            PayPalAuthorizationStatus::CREATED,
+            '2100-01-28T23:59:59Z',
+            '2025-01-01T00:00:00Z',
+            '2025-01-01T00:00:00Z'
+        );
+
+        $this->authorizationRepository->expects($this->once())
+            ->method('getById')
+            ->with('AUTH-456')
+            ->willReturn($existingEntity);
+
+        $this->authorizationRepository->expects($this->once())
+            ->method('save');
+
+        $result = $this->action->execute($payPalOrder, $payload);
+
+        $this->assertEquals('AUTH-456', $result->getId());
+        $this->assertEquals(PayPalAuthorizationStatus::CAPTURED, $result->getStatus());
+    }
+
     public function testThrowsExceptionWhenOrderStatusNotApproved(): void
     {
         $payPalOrder = $this->createPayPalOrder(

--- a/core/tests/Unit/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessorTest.php
+++ b/core/tests/Unit/PayPal/Payment/Authorization/Processor/AuthorizationActionProcessorTest.php
@@ -347,6 +347,35 @@ class AuthorizationActionProcessorTest extends TestCase
         $this->assertEquals($exceptionCode, $result['error']['code']);
     }
 
+    public function testProcessCaptureActionWithPayload(): void
+    {
+        $orderId = 'ORDER-PAYLOAD';
+        $payload = [
+            'amount' => [
+                'value' => '50.00',
+                'currency_code' => 'EUR',
+            ],
+        ];
+        $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
+
+        $this->payPalOrderProvider
+            ->expects($this->once())
+            ->method('getById')
+            ->with($orderId)
+            ->willReturn($payPalOrderResponse);
+
+        $this->captureAction
+            ->expects($this->once())
+            ->method('execute')
+            ->with($payPalOrderResponse, $payload);
+
+        $result = $this->processor->process('capture', $orderId, $payload);
+
+        $this->assertTrue($result['status']);
+        $this->assertArrayNotHasKey('httpCode', $result);
+        $this->assertArrayNotHasKey('error', $result);
+    }
+
     public function testProcessWithExceptionCodeZero(): void
     {
         $orderId = 'ORDER-NO-CODE';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       PS_FOLDER_INSTALL: install
       PS_FOLDER_ADMIN: admin1
       PS_ENABLE_SSL: ${SSL_ENABLED}
+      SENTRY_DSN: ${SENTRY_DSN}
     depends_on:
       - mysql
     ports:

--- a/infrastructure/src/Bootstrap/Install/OrderStateInstaller.php
+++ b/infrastructure/src/Bootstrap/Install/OrderStateInstaller.php
@@ -130,6 +130,24 @@ class OrderStateInstaller implements InstallerInterface
             $this->configuration->set(OrderStateConfiguration::PS_CHECKOUT_STATE_AUTHORIZED, $authorizedStateId);
         }
 
+        if (!$this->checkAlreadyInstalled(OrderStateConfiguration::PS_CHECKOUT_STATE_VOIDED)) {
+            $voidedStateId = $this->createOrderState(
+                '#DC143C',
+                [
+                    'en' => 'Authorization voided',
+                    'fr' => 'Autorisation annulée',
+                    'es' => 'Autorización anulada',
+                    'it' => 'Autorizzazione annullata',
+                    'nl' => 'Autorisatie ongeldig gemaakt',
+                    'de' => 'Autorisierung aufgehoben',
+                    'pl' => 'Autoryzacja unieważniona',
+                    'pt' => 'Autorização anulada',
+                ]
+            );
+
+            $this->configuration->set(OrderStateConfiguration::PS_CHECKOUT_STATE_VOIDED, $voidedStateId);
+        }
+
         return true;
     }
 

--- a/presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
+++ b/presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
@@ -28,7 +28,7 @@ class MerchantOrderViewPresenter
      * @param PayPalOrderResponse $paypalOrderResponse
      * @param bool $isProductionEnv
      *
-     * @return array{order: array, transactionActions: array<string, array<string, mixed>>, isTestMode: bool}
+     * @return array{order: array, isTestMode: bool}
      */
     public function present(
         PayPalOrderResponse $paypalOrderResponse,
@@ -36,100 +36,7 @@ class MerchantOrderViewPresenter
     ): array {
         return [
             'order' => $paypalOrderResponse->toArray(),
-            'transactionActions' => $this->buildTransactionActionsMap($paypalOrderResponse),
             'isTestMode' => !$isProductionEnv,
         ];
-    }
-
-    /**
-     * @param PayPalOrderResponse $paypalOrderResponse
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    private function buildTransactionActionsMap(PayPalOrderResponse $paypalOrderResponse): array
-    {
-        /** @var array<string, array<string, mixed>> $actions */
-        $actions = [];
-        $purchaseUnits = $paypalOrderResponse->getPurchaseUnits();
-
-        if (empty($purchaseUnits) || !isset($purchaseUnits[0]['payments'])) {
-            return $actions;
-        }
-
-        $payments = $purchaseUnits[0]['payments'];
-
-        $capturedTotal = 0.0;
-        if (!empty($payments['captures'])) {
-            foreach ($payments['captures'] as $capture) {
-                /** @var string $captureStatus */
-                $captureStatus = isset($capture['status']) ? (string) $capture['status'] : '';
-                if (in_array($captureStatus, ['COMPLETED', 'PARTIALLY_REFUNDED', 'PENDING'], true)) {
-                    $capturedTotal += isset($capture['amount']['value']) ? (float) $capture['amount']['value'] : 0.0;
-                }
-            }
-        }
-
-        if (!empty($payments['authorizations'])) {
-            foreach ($payments['authorizations'] as $authorization) {
-                $status = $authorization['status'];
-                $id = $authorization['id'];
-                $amount = (float) $authorization['amount']['value'];
-
-                switch ($status) {
-                    case 'CREATED':
-                    case 'PENDING':
-                        $actions[$id] = [
-                            'capture' => $amount,
-                            'void' => true,
-                            'reauthorize' => true,
-                        ];
-
-                        break;
-                    case 'PARTIALLY_CAPTURED':
-                        $leftToCapture = max(0.0, $amount - $capturedTotal);
-                        $actions[$id] = [
-                            'capture' => $leftToCapture,
-                            'void' => true,
-                            'reauthorize' => true,
-                        ];
-
-                        break;
-                }
-            }
-        }
-
-        if (!empty($payments['captures'])) {
-            foreach ($payments['captures'] as $capture) {
-                /** @var string $status */
-                $status = isset($capture['status']) ? (string) $capture['status'] : '';
-                /** @var string $id */
-                $id = isset($capture['id']) ? (string) $capture['id'] : '';
-                $captureAmount = isset($capture['amount']['value']) ? (float) $capture['amount']['value'] : 0.0;
-
-                if (!in_array($status, ['COMPLETED', 'PARTIALLY_REFUNDED'], true)) {
-                    continue;
-                }
-
-                $refundedTotal = 0.0;
-                if (!empty($payments['refunds'])) {
-                    foreach ($payments['refunds'] as $refund) {
-                        /** @var string $refundStatus */
-                        $refundStatus = isset($refund['status']) ? (string) $refund['status'] : '';
-                        if (in_array($refundStatus, ['COMPLETED', 'PENDING'], true)) {
-                            $refundedTotal += isset($refund['amount']['value']) ? (float) $refund['amount']['value'] : 0.0;
-                        }
-                    }
-                }
-
-                $maxRefundable = max(0.0, $captureAmount - $refundedTotal);
-                if ($maxRefundable > 0) {
-                    $actions[$id] = [
-                        'refund' => $maxRefundable,
-                    ];
-                }
-            }
-        }
-
-        return $actions;
     }
 }

--- a/presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
+++ b/presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
@@ -21,170 +21,115 @@
 namespace PsCheckout\Presentation\Presenter\PayPalOrder;
 
 use PsCheckout\Api\ValueObject\PayPalOrderResponse;
-use PsCheckout\Core\PayPal\Order\Entity\PayPalOrder;
 
 class MerchantOrderViewPresenter
 {
     /**
-     * @var PayPalOrderPresenterInterface
-     */
-    private $payPalOrderPresenter;
-
-    /**
-     * @param PayPalOrderPresenterInterface $payPalOrderPresenter
-     */
-    public function __construct(PayPalOrderPresenterInterface $payPalOrderPresenter)
-    {
-        $this->payPalOrderPresenter = $payPalOrderPresenter;
-    }
-
-    /**
      * @param PayPalOrderResponse $paypalOrderResponse
-     * @param PayPalOrder $payPalOrder
      * @param bool $isProductionEnv
      *
-     * @return array{orderData: array<string, mixed>, transactionList: list<array<string, mixed>>}
+     * @return array{order: array, transactionActions: array<string, array<string, mixed>>, isTestMode: bool}
      */
     public function present(
         PayPalOrderResponse $paypalOrderResponse,
-        PayPalOrder $payPalOrder,
         bool $isProductionEnv
     ): array {
-        $presenterData = $this->payPalOrderPresenter->present($paypalOrderResponse);
-
-        /** @var list<array<string, mixed>> $transactions */
-        $transactions = isset($presenterData['transactions']) && is_array($presenterData['transactions']) ? $presenterData['transactions'] : [];
-
-        $currency = $this->extractCurrency($paypalOrderResponse);
-
-        $orderData = $this->buildOrderData($presenterData, $transactions, $payPalOrder, $isProductionEnv, $currency);
-        $transactionList = $this->buildTransactionList($transactions);
-
         return [
-            'orderData' => $orderData,
-            'transactionList' => $transactionList,
+            'order' => $paypalOrderResponse->toArray(),
+            'transactionActions' => $this->buildTransactionActionsMap($paypalOrderResponse),
+            'isTestMode' => !$isProductionEnv,
         ];
     }
 
     /**
      * @param PayPalOrderResponse $paypalOrderResponse
      *
-     * @return string
+     * @return array<string, array<string, mixed>>
      */
-    private function extractCurrency(PayPalOrderResponse $paypalOrderResponse): string
+    private function buildTransactionActionsMap(PayPalOrderResponse $paypalOrderResponse): array
     {
-        foreach ($paypalOrderResponse->getPurchaseUnits() as $purchase) {
-            if (!empty($purchase['amount']['currency_code'])) {
-                return $purchase['amount']['currency_code'];
+        /** @var array<string, array<string, mixed>> $actions */
+        $actions = [];
+        $purchaseUnits = $paypalOrderResponse->getPurchaseUnits();
+
+        if (empty($purchaseUnits) || !isset($purchaseUnits[0]['payments'])) {
+            return $actions;
+        }
+
+        $payments = $purchaseUnits[0]['payments'];
+
+        $capturedTotal = 0.0;
+        if (!empty($payments['captures'])) {
+            foreach ($payments['captures'] as $capture) {
+                /** @var string $captureStatus */
+                $captureStatus = isset($capture['status']) ? (string) $capture['status'] : '';
+                if (in_array($captureStatus, ['COMPLETED', 'PARTIALLY_REFUNDED', 'PENDING'], true)) {
+                    $capturedTotal += isset($capture['amount']['value']) ? (float) $capture['amount']['value'] : 0.0;
+                }
             }
         }
 
-        return '';
-    }
+        if (!empty($payments['authorizations'])) {
+            foreach ($payments['authorizations'] as $authorization) {
+                $status = $authorization['status'];
+                $id = $authorization['id'];
+                $amount = (float) $authorization['amount']['value'];
 
-    /**
-     * @param array<string, mixed> $presenterData
-     * @param list<array<string, mixed>> $transactions
-     * @param PayPalOrder $payPalOrder
-     * @param bool $isProductionEnv
-     * @param string $currency
-     *
-     * @return array<string, mixed>
-     */
-    private function buildOrderData(
-        array $presenterData,
-        array $transactions,
-        PayPalOrder $payPalOrder,
-        bool $isProductionEnv,
-        string $currency
-    ): array {
-        $isAuthorizeIntent = strtoupper((string) ($presenterData['intent'] ?? '')) === 'AUTHORIZE';
+                switch ($status) {
+                    case 'CREATED':
+                    case 'PENDING':
+                        $actions[$id] = [
+                            'capture' => $amount,
+                            'void' => true,
+                            'reauthorize' => true,
+                        ];
 
-        $authTotal = 0.0;
-        $captured = 0.0;
+                        break;
+                    case 'PARTIALLY_CAPTURED':
+                        $leftToCapture = max(0.0, $amount - $capturedTotal);
+                        $actions[$id] = [
+                            'capture' => $leftToCapture,
+                            'void' => true,
+                            'reauthorize' => true,
+                        ];
 
-        foreach ($transactions as $tx) {
-            $txType = $tx['type']['value'] ?? '';
-            $txAmount = (float) $tx['amount'];
-
-            if ($txType === 'authorization') {
-                $authTotal += $txAmount;
-            } elseif ($txType === 'capture') {
-                $captured += $txAmount;
+                        break;
+                }
             }
         }
 
-        if ($isAuthorizeIntent && $authTotal > 0) {
-            $total = $authTotal;
-            $leftToCapture = max(0.0, $authTotal - $captured);
-        } else {
-            $total = (float) $presenterData['total'];
-            $captured = 0.0;
-            $leftToCapture = 0.0;
+        if (!empty($payments['captures'])) {
+            foreach ($payments['captures'] as $capture) {
+                /** @var string $status */
+                $status = isset($capture['status']) ? (string) $capture['status'] : '';
+                /** @var string $id */
+                $id = isset($capture['id']) ? (string) $capture['id'] : '';
+                $captureAmount = isset($capture['amount']['value']) ? (float) $capture['amount']['value'] : 0.0;
+
+                if (!in_array($status, ['COMPLETED', 'PARTIALLY_REFUNDED'], true)) {
+                    continue;
+                }
+
+                $refundedTotal = 0.0;
+                if (!empty($payments['refunds'])) {
+                    foreach ($payments['refunds'] as $refund) {
+                        /** @var string $refundStatus */
+                        $refundStatus = isset($refund['status']) ? (string) $refund['status'] : '';
+                        if (in_array($refundStatus, ['COMPLETED', 'PENDING'], true)) {
+                            $refundedTotal += isset($refund['amount']['value']) ? (float) $refund['amount']['value'] : 0.0;
+                        }
+                    }
+                }
+
+                $maxRefundable = max(0.0, $captureAmount - $refundedTotal);
+                if ($maxRefundable > 0) {
+                    $actions[$id] = [
+                        'refund' => $maxRefundable,
+                    ];
+                }
+            }
         }
 
-        $fees = (float) $presenterData['fees'];
-        $balance = (float) $presenterData['balance'];
-
-        $is3DSecureAvailable = !empty($presenterData['is3DSecureAvailable']);
-        $isLiabilityShifted = !empty($presenterData['isLiabilityShifted']);
-        $threeDSecure = $is3DSecureAvailable ? 'Success' : 'N/A';
-        $liabilityShift = $isLiabilityShifted ? 'Bank' : 'N/A';
-
-        $orderStatus = $presenterData['status']['translated'] ?? '';
-        $paymentSourceName = $presenterData['paymentSourceName'] ?? 'PayPal';
-
-        return [
-            'reference' => 'ORDER-' . $payPalOrder->getIdCart(),
-            'total' => $total,
-            'currency' => $currency,
-            'status' => $orderStatus,
-            'balance' => $balance,
-            'paymentMode' => $paymentSourceName,
-            'isTestMode' => !$isProductionEnv,
-            'threeDSecure' => $threeDSecure,
-            'liabilityShift' => $liabilityShift,
-            'financials' => [
-                'gross' => $total,
-                'fees' => $fees,
-                'net' => $total + $fees,
-                'captured' => $captured,
-                'leftToCapture' => $leftToCapture,
-            ],
-        ];
-    }
-
-    /**
-     * @param list<array<string, mixed>> $transactions
-     *
-     * @return list<array<string, mixed>>
-     */
-    private function buildTransactionList(array $transactions): array
-    {
-        $list = [];
-
-        foreach ($transactions as $tx) {
-            $list[] = [
-                'id' => $tx['id'],
-                'type' => $tx['type']['translated'] ?? '',
-                'status' => $tx['status']['translated'] ?? '',
-                'date' => $tx['date'],
-                'amount' => (float) $tx['amount'],
-                'currency' => $tx['currency'],
-                'reference' => $tx['id'],
-                'expirationTime' => $tx['expiration_time'] ?? '',
-                'isRefundable' => !empty($tx['isRefundable']),
-                'maxAmountRefundable' => isset($tx['maxAmountRefundable']) ? (float) $tx['maxAmountRefundable'] : 0.0,
-                'details' => [
-                    'total' => (float) $tx['amount'],
-                    'gross' => isset($tx['gross_amount']) ? (float) $tx['gross_amount'] : null,
-                    'fee' => isset($tx['paypal_fee']) ? (float) $tx['paypal_fee'] : null,
-                    'net' => isset($tx['net_amount']) ? (float) $tx['net_amount'] : null,
-                    'sellerProtection' => $tx['seller_protection']['translated'] ?? '',
-                ],
-            ];
-        }
-
-        return $list;
+        return $actions;
     }
 }

--- a/ps17/config/admin/presenter.yml
+++ b/ps17/config/admin/presenter.yml
@@ -54,8 +54,6 @@ services:
 
   PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter:
     class: PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter
-    arguments:
-      - '@PsCheckout\Presentation\Presenter\PayPalOrder\PayPalOrderPresenter'
 
   PsCheckout\Presentation\Presenter\Date\DatePresenter:
     class: PsCheckout\Presentation\Presenter\Date\DatePresenter

--- a/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -27,6 +27,7 @@ use PsCheckout\Core\Order\Exception\OrderException;
 use PsCheckout\Core\OrderState\OrderStateException;
 use PsCheckout\Core\OrderState\Service\OrderStateMapper;
 use PsCheckout\Core\PayPal\Order\Action\RefundPayPalOrderAction;
+use PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider;
 use PsCheckout\Core\PayPal\Payment\Authorization\Configuration\AuthorizationAction;
 use PsCheckout\Core\PayPal\Payment\Authorization\Processor\AuthorizationActionProcessor;
@@ -800,95 +801,20 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessGetOrderViewData()
     {
-        /** @var Translator $translator **/
-        $translator = $this->module->getService(Translator::class);
         $id_order = (int) Tools::getValue('id_order');
 
-        if (empty($id_order)) {
-            $this->exitWithResponse([
-                'httpCode' => 400,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('No PrestaShop Order identifier received'),
-                ],
-            ]);
-        }
-
-        $order = new Order($id_order);
-
-        /** @var PayPalOrderRepository $payPalOrderRepository */
-        $payPalOrderRepository = $this->module->getService(PayPalOrderRepository::class);
-        $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
-
-        if (!$payPalOrder) {
-            try {
-                $migrationSuccessful = $payPalOrderRepository->attemptToMigratePsCheckoutCart($order->id_cart);
-                if ($migrationSuccessful) {
-                    $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
-                }
-            } catch (\Exception $e) {
-                \Sentry\captureException($e);
-
-                $logger = $this->module->getService(LoggerInterface::class);
-                $logger->error(
-                    'Attempted to migrate order to V5 database structure. Encountered error: ' . $e->getMessage(),
-                    [
-                        'exception' => $e,
-                        'cart_id' => $order->id_cart,
-                    ]
-                );
-            }
-        }
-
-        if (!$payPalOrder) {
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', [$order->id]),
-                ],
-            ]);
-        }
-
-        /** @var Configuration $configuration */
-        $configuration = $this->module->getService(Configuration::class);
-
-        if ($configuration->get(PayPalConfiguration::PS_CHECKOUT_PAYMENT_MODE) !== $payPalOrder->getEnvironment()) {
-            $this->exitWithResponse([
-                'httpCode' => 422,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', [$payPalOrder->getId()]),
-                ],
-            ]);
-        }
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        $isProductionEnv = $payPalOrder->getEnvironment() === PayPalConfiguration::MODE_LIVE;
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
 
         /** @var MerchantOrderViewPresenter $presenter */
         $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $payPalOrder, $isProductionEnv);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
 
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'orderData' => $data['orderData'],
-            'transactionList' => $data['transactionList'],
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
         ]);
     }
 
@@ -897,10 +823,22 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         /** @var Translator $translator **/
         $translator = $this->module->getService(Translator::class);
 
-        $payPalOrderId = Tools::getValue('orderPayPalRefundOrder');
-        $captureId = Tools::getValue('orderPayPalRefundTransaction');
-        $amount = Tools::getValue('orderPayPalRefundAmount');
-        $currency = Tools::getValue('orderPayPalRefundCurrency');
+        $id_order = (int) Tools::getValue('id_order');
+        $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
+        $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
+
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payPalOrderId = $payPalOrder->getId();
+        $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
+
+        if (!$currency) {
+            /** @var PayPalOrderProvider $paypalOrderProvider */
+            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+            $orderAmount = $paypalOrderResponse->getOrderAmount();
+            $currency = $orderAmount['currency_code'] ?? '';
+        }
 
         /** @var RefundPayPalOrderAction $refundPayPalOrderAction */
         $refundPayPalOrderAction = $this->module->getService(RefundPayPalOrderAction::class);
@@ -975,10 +913,36 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrderId);
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $translator->trans('Refund has been processed by PayPal.'),
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'content' => $translator->trans('Refund has been processed by PayPal.'),
+            'message' => $translator->trans('Refund has been processed by PayPal.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
         ]);
     }
 
@@ -1002,6 +966,95 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         parent::ajaxRender($value, $controller, $method);
 
         exit;
+    }
+
+    /**
+     * @param int $idOrder
+     *
+     * @return array{0: \PsCheckout\Infrastructure\Repository\PayPalOrder, 1: \PsCheckout\Api\ValueObject\PayPalOrderResponse, 2: bool}
+     */
+    private function resolvePayPalOrder(int $idOrder): array
+    {
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        if (empty($idOrder)) {
+            $this->exitWithResponse([
+                'httpCode' => 400,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('No PrestaShop Order identifier received'),
+                ],
+            ]);
+        }
+
+        $order = new Order($idOrder);
+
+        /** @var PayPalOrderRepository $payPalOrderRepository */
+        $payPalOrderRepository = $this->module->getService(PayPalOrderRepository::class);
+        $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
+
+        if (!$payPalOrder) {
+            try {
+                $migrationSuccessful = $payPalOrderRepository->attemptToMigratePsCheckoutCart($order->id_cart);
+                if ($migrationSuccessful) {
+                    $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
+                }
+            } catch (\Exception $e) {
+                \Sentry\captureException($e);
+
+                $logger = $this->module->getService(LoggerInterface::class);
+                $logger->error(
+                    'Attempted to migrate order to V5 database structure. Encountered error: ' . $e->getMessage(),
+                    [
+                        'exception' => $e,
+                        'cart_id' => $order->id_cart,
+                    ]
+                );
+            }
+        }
+
+        if (!$payPalOrder) {
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', [$order->id]),
+                ],
+            ]);
+        }
+
+        /** @var Configuration $configuration */
+        $configuration = $this->module->getService(Configuration::class);
+
+        if ($configuration->get(PayPalConfiguration::PS_CHECKOUT_PAYMENT_MODE) !== $payPalOrder->getEnvironment()) {
+            $this->exitWithResponse([
+                'httpCode' => 422,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', [$payPalOrder->getId()]),
+                ],
+            ]);
+        }
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        $isProductionEnv = $payPalOrder->getEnvironment() === PayPalConfiguration::MODE_LIVE;
+
+        return [$payPalOrder, $paypalOrderResponse, $isProductionEnv];
     }
 
     /**
@@ -1112,31 +1165,153 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessCaptureAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::CAPTURE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payload = [];
+        $amount = Tools::getValue('amount');
+        $currency = Tools::getValue('currency');
+
+        if ($amount && $currency) {
+            $payload['amount'] = [
+                'value' => $amount,
+                'currency_code' => $currency,
+            ];
+        }
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::CAPTURE, $payPalOrder->getId(), $payload);
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization captured successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessVoidAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::VOID, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::VOID, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization voided successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessReauthorizeAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::REAUTHORIZE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::REAUTHORIZE, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 }

--- a/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -813,7 +813,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'httpCode' => 200,
             'status' => true,
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -941,7 +940,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $translator->trans('Refund has been processed by PayPal.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1216,7 +1214,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization captured successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1263,7 +1260,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization voided successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1310,7 +1306,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization reauthorized successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }

--- a/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -826,15 +826,12 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
         $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
 
-        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
 
         $payPalOrderId = $payPalOrder->getId();
         $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
 
         if (!$currency) {
-            /** @var PayPalOrderProvider $paypalOrderProvider */
-            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
             $orderAmount = $paypalOrderResponse->getOrderAmount();
             $currency = $orderAmount['currency_code'] ?? '';
         }
@@ -912,36 +909,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrderId);
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 200,
-                'status' => true,
-                'message' => $translator->trans('Refund has been processed by PayPal.'),
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $translator->trans('Refund has been processed by PayPal.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrderId, $isProductionEnv, $translator->trans('Refund has been processed by PayPal.'));
     }
 
     /**
@@ -1186,36 +1154,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization captured successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1232,36 +1171,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization voided successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1278,22 +1188,34 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+    }
+
+    /**
+     * @param string $payPalOrderId
+     * @param bool $isProductionEnv
+     * @param string $message
+     *
+     * @return void
+     */
+    private function exitWithRefreshedOrderData(string $payPalOrderId, bool $isProductionEnv, string $message)
+    {
         /** @var PayPalOrderCache $cache */
         $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
+        $cache->delete($payPalOrderId);
 
         /** @var PayPalOrderProvider $paypalOrderProvider */
         $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
 
         try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
         } catch (Exception $exception) {
             \Sentry\captureException($exception);
 
             $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $message,
             ]);
         }
 
@@ -1304,7 +1226,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'message' => $message,
             'order' => $data['order'],
             'isTestMode' => $data['isTestMode'],
         ]);

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -337,30 +337,6 @@ parameters:
 			path: ../api/src/Http/PaymentHttpClient.php
 
 		-
-			message: '#^Cannot call method getBody\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../api/src/Http/PsrHttpClientAdapter.php
-
-		-
-			message: '#^Cannot call method getContents\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../api/src/Http/PsrHttpClientAdapter.php
-
-		-
-			message: '#^Cannot call method getHeaders\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../api/src/Http/PsrHttpClientAdapter.php
-
-		-
-			message: '#^Cannot call method getStatusCode\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../api/src/Http/PsrHttpClientAdapter.php
-
-		-
 			message: '#^Method PsCheckout\\Api\\Http\\PsrHttpClientAdapter\:\:__construct\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -368,12 +344,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$config of method Prestashop\\ModuleLibGuzzleAdapter\\ClientFactory\:\:getClient\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../api/src/Http/PsrHttpClientAdapter.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../api/src/Http/PsrHttpClientAdapter.php

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -337,6 +337,30 @@ parameters:
 			path: ../api/src/Http/PaymentHttpClient.php
 
 		-
+			message: '#^Cannot call method getBody\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../api/src/Http/PsrHttpClientAdapter.php
+
+		-
+			message: '#^Cannot call method getContents\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../api/src/Http/PsrHttpClientAdapter.php
+
+		-
+			message: '#^Cannot call method getHeaders\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../api/src/Http/PsrHttpClientAdapter.php
+
+		-
+			message: '#^Cannot call method getStatusCode\(\) on GuzzleHttp\\Exception\\ResponseInterface\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../api/src/Http/PsrHttpClientAdapter.php
+
+		-
 			message: '#^Method PsCheckout\\Api\\Http\\PsrHttpClientAdapter\:\:__construct\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -344,6 +368,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$config of method Prestashop\\ModuleLibGuzzleAdapter\\ClientFactory\:\:getClient\(\) expects array\<string, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../api/src/Http/PsrHttpClientAdapter.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../api/src/Http/PsrHttpClientAdapter.php
@@ -3533,12 +3563,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php
-
-		-
-			message: '#^Call to an undefined method PsCheckout\\Api\\ValueObject\\PayPalOrderResponse\|PsCheckout\\Core\\PayPal\\Order\\Response\\ValueObject\\CreatePayPalOrderResponse\:\:toArray\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: ../core/src/PayPal/Order/Cache/PayPalOrderCache.php
 
 		-
 			message: '#^Call to method get\(\) on an unknown class Symfony\\Component\\Cache\\Adapter\\CacheItem\.$#'
@@ -11047,32 +11071,26 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''translated'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Cannot access offset ''value'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to float\.$#'
 			identifier: cast.double
-			count: 10
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 4
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
-			message: '#^Parameter \#1 \$presenterData of method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:buildOrderData\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
+			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -11071,24 +11071,6 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to float\.$#'
-			identifier: cast.double
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/ps17/views/css/adminOrderViewSdk.css
+++ b/ps17/views/css/adminOrderViewSdk.css
@@ -1,6 +1,6 @@
 #ps-checkout-merchant-order-view {
     width: 100%;
-    height: 100%;
+    height: 1500px;
 }
 #ps-checkout-merchant-order-view > div,
 #ps-checkout-merchant-order-view iframe {

--- a/ps17/views/js/adminOrderViewSdk.js
+++ b/ps17/views/js/adminOrderViewSdk.js
@@ -45,6 +45,8 @@ var ps_checkout_merchant = {};
       });
       var appUrl = sdkScript ? new URL(sdkScript.src).origin : undefined;
 
+      var checkoutComponent = null;
+
       var actionMap = {
         capture:     'CaptureAuthorization',
         void:        'VoidAuthorization',
@@ -52,22 +54,40 @@ var ps_checkout_merchant = {};
         refund:      'RefundOrder',
       };
 
-      function onSubmit(type, transaction, data) {
-        console.log('[ps_checkout] onSubmit:', type, transaction, data);
+      function onSubmit(type, transactionId, data) {
         var action = actionMap[type];
         if (!action || !ajaxUrl) {
-          console.warn('[ps_checkout] Unknown action type or missing AJAX URL:', type);
-          return;
+          return Promise.reject(new Error('Unknown action type or missing AJAX URL'));
         }
-        var payload = Object.assign({ id_transaction: transaction.id }, data || {});
-        fetch(ajaxUrl + '&action=' + action, {
+        var params = new URLSearchParams({
+          ajax: 1,
+          action: action,
+          id_order: orderId,
+          id_transaction: transactionId,
+        });
+        if (data) {
+          Object.keys(data).forEach(function (key) {
+            params.append(key, data[key]);
+          });
+        }
+        return fetch(ajaxUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
         })
           .then(function (res) { return res.json(); })
-          .then(function (json) { console.log('[ps_checkout] AJAX response:', json); })
-          .catch(function (err) { console.error('[ps_checkout] AJAX error:', err); });
+          .then(function (json) {
+            if (!json.status) {
+              throw new Error((json.errors || []).join(', ') || (json.error && json.error.message) || 'Unknown error');
+            }
+            if (checkoutComponent && json.order) {
+              checkoutComponent.updateProps({
+                order: json.order,
+                transactionActions: json.transactionActions || {},
+              });
+            }
+            return { message: json.message || '' };
+          });
       }
 
       container.innerHTML = '<div class="d-print-none text-muted p-3">Loading PayPal order data\u2026</div>';
@@ -85,14 +105,14 @@ var ps_checkout_merchant = {};
 
           container.innerHTML = '';
 
-          var checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+          checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
             url: appUrl,
-            orderData: json.orderData,
-            transactionList: json.transactionList,
+            order: json.order,
+            isTestMode: json.isTestMode || false,
+            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);
-          console.log('[ps_checkout] PrestaShopCheckout initialized with real order data.');
         })
         .catch(function (err) {
           console.error('[ps_checkout] Failed to load PayPal order data:', err);

--- a/ps17/views/js/adminOrderViewSdk.js
+++ b/ps17/views/js/adminOrderViewSdk.js
@@ -83,7 +83,6 @@ var ps_checkout_merchant = {};
             if (checkoutComponent && json.order) {
               checkoutComponent.updateProps({
                 order: json.order,
-                transactionActions: json.transactionActions || {},
               });
             }
             return { message: json.message || '' };
@@ -109,7 +108,6 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
-            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);

--- a/ps8/config/admin/presenter.yml
+++ b/ps8/config/admin/presenter.yml
@@ -55,8 +55,6 @@ services:
 
   PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter:
     class: PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter
-    arguments:
-      - '@PsCheckout\Presentation\Presenter\PayPalOrder\PayPalOrderPresenter'
 
   PsCheckout\Presentation\Presenter\Date\DatePresenter:
     class: PsCheckout\Presentation\Presenter\Date\DatePresenter

--- a/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -808,7 +808,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'httpCode' => 200,
             'status' => true,
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -936,7 +935,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $translator->trans('Refund has been processed by PayPal.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1206,7 +1204,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization captured successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1253,7 +1250,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization voided successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1300,7 +1296,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization reauthorized successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }

--- a/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -821,15 +821,12 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
         $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
 
-        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
 
         $payPalOrderId = $payPalOrder->getId();
         $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
 
         if (!$currency) {
-            /** @var PayPalOrderProvider $paypalOrderProvider */
-            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
             $orderAmount = $paypalOrderResponse->getOrderAmount();
             $currency = $orderAmount['currency_code'] ?? '';
         }
@@ -907,36 +904,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrderId);
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 200,
-                'status' => true,
-                'message' => $translator->trans('Refund has been processed by PayPal.'),
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $translator->trans('Refund has been processed by PayPal.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrderId, $isProductionEnv, $translator->trans('Refund has been processed by PayPal.'));
     }
 
     /**
@@ -1176,36 +1144,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization captured successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1222,36 +1161,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization voided successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1268,22 +1178,34 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+    }
+
+    /**
+     * @param string $payPalOrderId
+     * @param bool $isProductionEnv
+     * @param string $message
+     *
+     * @return void
+     */
+    private function exitWithRefreshedOrderData(string $payPalOrderId, bool $isProductionEnv, string $message)
+    {
         /** @var PayPalOrderCache $cache */
         $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
+        $cache->delete($payPalOrderId);
 
         /** @var PayPalOrderProvider $paypalOrderProvider */
         $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
 
         try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
         } catch (Exception $exception) {
             \Sentry\captureException($exception);
 
             $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $message,
             ]);
         }
 
@@ -1294,7 +1216,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'message' => $message,
             'order' => $data['order'],
             'isTestMode' => $data['isTestMode'],
         ]);

--- a/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -26,6 +26,7 @@ use PsCheckout\Core\Order\Exception\OrderException;
 use PsCheckout\Core\OrderState\OrderStateException;
 use PsCheckout\Core\OrderState\Service\OrderStateMapper;
 use PsCheckout\Core\PayPal\Order\Action\RefundPayPalOrderAction;
+use PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider;
 use PsCheckout\Core\PayPal\Payment\Authorization\Configuration\AuthorizationAction;
 use PsCheckout\Core\PayPal\Payment\Authorization\Processor\AuthorizationActionProcessor;
@@ -795,94 +796,20 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessGetOrderViewData()
     {
-        /** @var Translator $translator **/
-        $translator = $this->module->getService(Translator::class);
         $id_order = (int) Tools::getValue('id_order');
 
-        if (empty($id_order)) {
-            $this->exitWithResponse([
-                'httpCode' => 400,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('No PrestaShop Order identifier received'),
-                ],
-            ]);
-        }
-
-        $order = new Order($id_order);
-
-        /** @var PayPalOrderRepository $payPalOrderRepository */
-        $payPalOrderRepository = $this->module->getService(PayPalOrderRepository::class);
-        $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
-
-        if (!$payPalOrder) {
-            try {
-                $migrationSuccessful = $payPalOrderRepository->attemptToMigratePsCheckoutCart($order->id_cart);
-                if ($migrationSuccessful) {
-                    $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
-                }
-            } catch (Exception $e) {
-                \Sentry\captureException($e);
-                $logger = $this->module->getService(LoggerInterface::class);
-                $logger->error(
-                    'Attempted to migrate order to V5 database structure. Encountered error: ' . $e->getMessage(),
-                    [
-                        'exception' => $e,
-                        'cart_id' => $order->id_cart,
-                    ]
-                );
-            }
-        }
-
-        if (!$payPalOrder) {
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', [$order->id]),
-                ],
-            ]);
-        }
-
-        /** @var Configuration $configuration */
-        $configuration = $this->module->getService(Configuration::class);
-
-        if ($configuration->get(PayPalConfiguration::PS_CHECKOUT_PAYMENT_MODE) !== $payPalOrder->getEnvironment()) {
-            $this->exitWithResponse([
-                'httpCode' => 422,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', [$payPalOrder->getId()]),
-                ],
-            ]);
-        }
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        $isProductionEnv = $payPalOrder->getEnvironment() === PayPalConfiguration::MODE_LIVE;
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
 
         /** @var MerchantOrderViewPresenter $presenter */
         $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $payPalOrder, $isProductionEnv);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
 
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'orderData' => $data['orderData'],
-            'transactionList' => $data['transactionList'],
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
         ]);
     }
 
@@ -891,10 +818,22 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         /** @var Translator $translator **/
         $translator = $this->module->getService(Translator::class);
 
-        $payPalOrderId = Tools::getValue('orderPayPalRefundOrder');
-        $captureId = Tools::getValue('orderPayPalRefundTransaction');
-        $amount = Tools::getValue('orderPayPalRefundAmount');
-        $currency = Tools::getValue('orderPayPalRefundCurrency');
+        $id_order = (int) Tools::getValue('id_order');
+        $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
+        $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
+
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payPalOrderId = $payPalOrder->getId();
+        $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
+
+        if (!$currency) {
+            /** @var PayPalOrderProvider $paypalOrderProvider */
+            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+            $orderAmount = $paypalOrderResponse->getOrderAmount();
+            $currency = $orderAmount['currency_code'] ?? '';
+        }
 
         /** @var RefundPayPalOrderAction $refundPayPalOrderAction */
         $refundPayPalOrderAction = $this->module->getService(RefundPayPalOrderAction::class);
@@ -969,10 +908,36 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrderId);
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $translator->trans('Refund has been processed by PayPal.'),
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'content' => $translator->trans('Refund has been processed by PayPal.'),
+            'message' => $translator->trans('Refund has been processed by PayPal.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
         ]);
     }
 
@@ -996,6 +961,94 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         parent::ajaxRender($value, $controller, $method);
 
         exit;
+    }
+
+    /**
+     * @param int $idOrder
+     *
+     * @return array{0: \PsCheckout\Infrastructure\Repository\PayPalOrder, 1: \PsCheckout\Api\ValueObject\PayPalOrderResponse, 2: bool}
+     */
+    private function resolvePayPalOrder(int $idOrder): array
+    {
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        if (empty($idOrder)) {
+            $this->exitWithResponse([
+                'httpCode' => 400,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('No PrestaShop Order identifier received'),
+                ],
+            ]);
+        }
+
+        $order = new Order($idOrder);
+
+        /** @var PayPalOrderRepository $payPalOrderRepository */
+        $payPalOrderRepository = $this->module->getService(PayPalOrderRepository::class);
+        $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
+
+        if (!$payPalOrder) {
+            try {
+                $migrationSuccessful = $payPalOrderRepository->attemptToMigratePsCheckoutCart($order->id_cart);
+                if ($migrationSuccessful) {
+                    $payPalOrder = $payPalOrderRepository->getOneByCartId($order->id_cart);
+                }
+            } catch (Exception $e) {
+                \Sentry\captureException($e);
+                $logger = $this->module->getService(LoggerInterface::class);
+                $logger->error(
+                    'Attempted to migrate order to V5 database structure. Encountered error: ' . $e->getMessage(),
+                    [
+                        'exception' => $e,
+                        'cart_id' => $order->id_cart,
+                    ]
+                );
+            }
+        }
+
+        if (!$payPalOrder) {
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', [$order->id]),
+                ],
+            ]);
+        }
+
+        /** @var Configuration $configuration */
+        $configuration = $this->module->getService(Configuration::class);
+
+        if ($configuration->get(PayPalConfiguration::PS_CHECKOUT_PAYMENT_MODE) !== $payPalOrder->getEnvironment()) {
+            $this->exitWithResponse([
+                'httpCode' => 422,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', [$payPalOrder->getId()]),
+                ],
+            ]);
+        }
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        $isProductionEnv = $payPalOrder->getEnvironment() === PayPalConfiguration::MODE_LIVE;
+
+        return [$payPalOrder, $paypalOrderResponse, $isProductionEnv];
     }
 
     /**
@@ -1102,31 +1155,153 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessCaptureAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::CAPTURE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payload = [];
+        $amount = Tools::getValue('amount');
+        $currency = Tools::getValue('currency');
+
+        if ($amount && $currency) {
+            $payload['amount'] = [
+                'value' => $amount,
+                'currency_code' => $currency,
+            ];
+        }
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::CAPTURE, $payPalOrder->getId(), $payload);
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization captured successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessVoidAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::VOID, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::VOID, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization voided successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessReauthorizeAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::REAUTHORIZE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::REAUTHORIZE, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 }

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -3523,12 +3523,6 @@ parameters:
 			path: ../core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php
 
 		-
-			message: '#^Call to an undefined method PsCheckout\\Api\\ValueObject\\PayPalOrderResponse\|PsCheckout\\Core\\PayPal\\Order\\Response\\ValueObject\\CreatePayPalOrderResponse\:\:toArray\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: ../core/src/PayPal/Order/Cache/PayPalOrderCache.php
-
-		-
 			message: '#^Call to method get\(\) on an unknown class Symfony\\Component\\Cache\\Adapter\\CacheItem\.$#'
 			identifier: class.notFound
 			count: 1
@@ -11101,32 +11095,26 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''translated'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Cannot access offset ''value'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to float\.$#'
 			identifier: cast.double
-			count: 10
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 4
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
-			message: '#^Parameter \#1 \$presenterData of method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:buildOrderData\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
+			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -11095,24 +11095,6 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to float\.$#'
-			identifier: cast.double
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/ps8/ps_checkout.php
+++ b/ps8/ps_checkout.php
@@ -272,11 +272,11 @@ class Ps_Checkout extends PaymentModule
                 break;
             case 'AdminOrders':
                 $this->context->controller->addJS(
-                    $this->getPathUri() . 'views/js/adminOrderView.js?version=' . $this->version . '&time='.time(),
+                    $this->getPathUri() . 'views/js/adminOrderView.js?version=' . $this->version,
                     false
                 );
                 $this->context->controller->addCss(
-                    $this->_path . 'views/css/adminOrderView.css?version=' . $this->version . '&time='.time(),
+                    $this->_path . 'views/css/adminOrderView.css?version=' . $this->version,
                     'all',
                     null,
                     false
@@ -291,13 +291,13 @@ class Ps_Checkout extends PaymentModule
                     $merchantSdkUrl = $merchantSdkUrl . $merchantSdkVersion . PayPalSdkConfiguration::SDK_MERCHANT_ENDPOINT;
                 }
 
-                $this->context->controller->addJS($merchantSdkUrl . '?time='.time(), false);
+                $this->context->controller->addJS($merchantSdkUrl, false);
                 $this->context->controller->addJS(
-                    $this->getPathUri() . 'views/js/adminOrderViewSdk.js?version=' . $this->version . '&time='.time(),
+                    $this->getPathUri() . 'views/js/adminOrderViewSdk.js?version=' . $this->version,
                     false
                 );
                 $this->context->controller->addCss(
-                    $this->_path . 'views/css/adminOrderViewSdk.css?version=' . $this->version . '&time='.time(),
+                    $this->_path . 'views/css/adminOrderViewSdk.css?version=' . $this->version,
                     'all',
                     null,
                     false

--- a/ps8/ps_checkout.php
+++ b/ps8/ps_checkout.php
@@ -291,13 +291,13 @@ class Ps_Checkout extends PaymentModule
                     $merchantSdkUrl = $merchantSdkUrl . $merchantSdkVersion . PayPalSdkConfiguration::SDK_MERCHANT_ENDPOINT;
                 }
 
-                $this->context->controller->addJS($merchantSdkUrl, false);
+                $this->context->controller->addJS($merchantSdkUrl . '?time='.time(), false);
                 $this->context->controller->addJS(
-                    $this->getPathUri() . 'views/js/adminOrderViewSdk.js?version=' . $this->version,
+                    $this->getPathUri() . 'views/js/adminOrderViewSdk.js?version=' . $this->version . '&time='.time(),
                     false
                 );
                 $this->context->controller->addCss(
-                    $this->_path . 'views/css/adminOrderViewSdk.css?version=' . $this->version,
+                    $this->_path . 'views/css/adminOrderViewSdk.css?version=' . $this->version . '&time='.time(),
                     'all',
                     null,
                     false

--- a/ps8/ps_checkout.php
+++ b/ps8/ps_checkout.php
@@ -272,11 +272,11 @@ class Ps_Checkout extends PaymentModule
                 break;
             case 'AdminOrders':
                 $this->context->controller->addJS(
-                    $this->getPathUri() . 'views/js/adminOrderView.js?version=' . $this->version,
+                    $this->getPathUri() . 'views/js/adminOrderView.js?version=' . $this->version . '&time='.time(),
                     false
                 );
                 $this->context->controller->addCss(
-                    $this->_path . 'views/css/adminOrderView.css?version=' . $this->version,
+                    $this->_path . 'views/css/adminOrderView.css?version=' . $this->version . '&time='.time(),
                     'all',
                     null,
                     false

--- a/ps8/views/css/adminOrderViewSdk.css
+++ b/ps8/views/css/adminOrderViewSdk.css
@@ -1,6 +1,6 @@
 #ps-checkout-merchant-order-view {
     width: 100%;
-    height: 100%;
+    height: 1500px;
 }
 #ps-checkout-merchant-order-view > div,
 #ps-checkout-merchant-order-view iframe {

--- a/ps8/views/js/adminOrderViewSdk.js
+++ b/ps8/views/js/adminOrderViewSdk.js
@@ -45,6 +45,8 @@ var ps_checkout_merchant = {};
       });
       var appUrl = sdkScript ? new URL(sdkScript.src).origin : undefined;
 
+      var checkoutComponent = null;
+
       var actionMap = {
         capture:     'CaptureAuthorization',
         void:        'VoidAuthorization',
@@ -52,22 +54,40 @@ var ps_checkout_merchant = {};
         refund:      'RefundOrder',
       };
 
-      function onSubmit(type, transaction, data) {
-        console.log('[ps_checkout] onSubmit:', type, transaction, data);
+      function onSubmit(type, transactionId, data) {
         var action = actionMap[type];
         if (!action || !ajaxUrl) {
-          console.warn('[ps_checkout] Unknown action type or missing AJAX URL:', type);
-          return;
+          return Promise.reject(new Error('Unknown action type or missing AJAX URL'));
         }
-        var payload = Object.assign({ id_transaction: transaction.id }, data || {});
-        fetch(ajaxUrl + '&action=' + action, {
+        var params = new URLSearchParams({
+          ajax: 1,
+          action: action,
+          id_order: orderId,
+          id_transaction: transactionId,
+        });
+        if (data) {
+          Object.keys(data).forEach(function (key) {
+            params.append(key, data[key]);
+          });
+        }
+        return fetch(ajaxUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
         })
           .then(function (res) { return res.json(); })
-          .then(function (json) { console.log('[ps_checkout] AJAX response:', json); })
-          .catch(function (err) { console.error('[ps_checkout] AJAX error:', err); });
+          .then(function (json) {
+            if (!json.status) {
+              throw new Error((json.errors || []).join(', ') || (json.error && json.error.message) || 'Unknown error');
+            }
+            if (checkoutComponent && json.order) {
+              checkoutComponent.updateProps({
+                order: json.order,
+                transactionActions: json.transactionActions || {},
+              });
+            }
+            return { message: json.message || '' };
+          });
       }
 
       container.innerHTML = '<div class="d-print-none text-muted p-3">Loading PayPal order data\u2026</div>';
@@ -85,14 +105,14 @@ var ps_checkout_merchant = {};
 
           container.innerHTML = '';
 
-          var checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+          checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
             url: appUrl,
-            orderData: json.orderData,
-            transactionList: json.transactionList,
+            order: json.order,
+            isTestMode: json.isTestMode || false,
+            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);
-          console.log('[ps_checkout] PrestaShopCheckout initialized with real order data.');
         })
         .catch(function (err) {
           console.error('[ps_checkout] Failed to load PayPal order data:', err);

--- a/ps8/views/js/adminOrderViewSdk.js
+++ b/ps8/views/js/adminOrderViewSdk.js
@@ -83,7 +83,6 @@ var ps_checkout_merchant = {};
             if (checkoutComponent && json.order) {
               checkoutComponent.updateProps({
                 order: json.order,
-                transactionActions: json.transactionActions || {},
               });
             }
             return { message: json.message || '' };
@@ -109,7 +108,6 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
-            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);

--- a/ps9/config/admin/presenter.yml
+++ b/ps9/config/admin/presenter.yml
@@ -55,8 +55,6 @@ services:
 
   PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter:
     class: PsCheckout\Presentation\Presenter\PayPalOrder\MerchantOrderViewPresenter
-    arguments:
-      - '@PsCheckout\Presentation\Presenter\PayPalOrder\PayPalOrderPresenter'
 
   PsCheckout\Presentation\Presenter\Date\DatePresenter:
     class: PsCheckout\Presentation\Presenter\Date\DatePresenter

--- a/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -823,15 +823,12 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
         $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
 
-        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
 
         $payPalOrderId = $payPalOrder->getId();
         $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
 
         if (!$currency) {
-            /** @var PayPalOrderProvider $paypalOrderProvider */
-            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
             $orderAmount = $paypalOrderResponse->getOrderAmount();
             $currency = $orderAmount['currency_code'] ?? '';
         }
@@ -909,36 +906,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrderId);
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
-        } catch (\Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 200,
-                'status' => true,
-                'message' => $translator->trans('Refund has been processed by PayPal.'),
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $translator->trans('Refund has been processed by PayPal.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrderId, $isProductionEnv, $translator->trans('Refund has been processed by PayPal.'));
     }
 
     /**
@@ -1182,36 +1150,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (\Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization captured successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1228,36 +1167,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        /** @var PayPalOrderCache $cache */
-        $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
-
-        /** @var PayPalOrderProvider $paypalOrderProvider */
-        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
-
-        try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
-        } catch (\Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
-            ]);
-        }
-
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'message' => $this->module->l('Authorization voided successfully.'),
-            'order' => $data['order'],
-            'isTestMode' => $data['isTestMode'],
-        ]);
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1274,22 +1184,34 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+    }
+
+    /**
+     * @param string $payPalOrderId
+     * @param bool $isProductionEnv
+     * @param string $message
+     *
+     * @return void
+     */
+    private function exitWithRefreshedOrderData(string $payPalOrderId, bool $isProductionEnv, string $message)
+    {
         /** @var PayPalOrderCache $cache */
         $cache = $this->module->getService(PayPalOrderCache::class);
-        $cache->delete($payPalOrder->getId());
+        $cache->delete($payPalOrderId);
 
         /** @var PayPalOrderProvider $paypalOrderProvider */
         $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
 
         try {
-            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
         } catch (\Exception $exception) {
             \Sentry\captureException($exception);
 
             $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [$exception->getMessage()],
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $message,
             ]);
         }
 
@@ -1300,7 +1222,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         $this->exitWithResponse([
             'httpCode' => 200,
             'status' => true,
-            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'message' => $message,
             'order' => $data['order'],
             'isTestMode' => $data['isTestMode'],
         ]);

--- a/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -810,7 +810,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'httpCode' => 200,
             'status' => true,
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -938,7 +937,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $translator->trans('Refund has been processed by PayPal.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1212,7 +1210,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization captured successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1259,7 +1256,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization voided successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }
@@ -1306,7 +1302,6 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             'status' => true,
             'message' => $this->module->l('Authorization reauthorized successfully.'),
             'order' => $data['order'],
-            'transactionActions' => $data['transactionActions'],
             'isTestMode' => $data['isTestMode'],
         ]);
     }

--- a/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -27,6 +27,7 @@ use PsCheckout\Core\Order\Exception\OrderException;
 use PsCheckout\Core\OrderState\OrderStateException;
 use PsCheckout\Core\OrderState\Service\OrderStateMapper;
 use PsCheckout\Core\PayPal\Order\Action\RefundPayPalOrderAction;
+use PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider;
 use PsCheckout\Core\PayPal\Payment\Authorization\Configuration\AuthorizationAction;
 use PsCheckout\Core\PayPal\Payment\Authorization\Processor\AuthorizationActionProcessor;
@@ -797,11 +798,184 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessGetOrderViewData()
     {
-        /** @var Translator $translator **/
-        $translator = $this->module->getService(Translator::class);
         $id_order = (int) Tools::getValue('id_order');
 
-        if (empty($id_order)) {
+        list($payPalOrder, $paypalOrderResponse, $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
+    }
+
+    public function ajaxProcessRefundOrder()
+    {
+        /** @var Translator $translator **/
+        $translator = $this->module->getService(Translator::class);
+
+        $id_order = (int) Tools::getValue('id_order');
+        $captureId = Tools::getValue('id_transaction') ?: Tools::getValue('orderPayPalRefundTransaction');
+        $amount = Tools::getValue('amount') ?: Tools::getValue('orderPayPalRefundAmount');
+
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payPalOrderId = $payPalOrder->getId();
+        $currency = Tools::getValue('currency') ?: Tools::getValue('orderPayPalRefundCurrency');
+
+        if (!$currency) {
+            /** @var PayPalOrderProvider $paypalOrderProvider */
+            $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+            $orderAmount = $paypalOrderResponse->getOrderAmount();
+            $currency = $orderAmount['currency_code'] ?? '';
+        }
+
+        /** @var RefundPayPalOrderAction $refundPayPalOrderAction */
+        $refundPayPalOrderAction = $this->module->getService(RefundPayPalOrderAction::class);
+
+        try {
+            $payPalRefund = new PayPalRefund($payPalOrderId, $captureId, $currency, $amount);
+
+            $refundPayPalOrderAction->execute($payPalRefund);
+        } catch (PayPalRefundException $exception) {
+            \Sentry\captureException($exception);
+
+            switch ($exception->getCode()) {
+                case PayPalRefundException::INVALID_ORDER_ID:
+                    $error = $translator->trans('PayPal Order is invalid.');
+
+                    break;
+                case PayPalRefundException::INVALID_TRANSACTION_ID:
+                    $error = $translator->trans('PayPal Transaction is invalid.');
+
+                    break;
+                case PayPalRefundException::INVALID_CURRENCY:
+                    $error = $translator->trans('PayPal refund currency is invalid.');
+
+                    break;
+                case PayPalRefundException::INVALID_AMOUNT:
+                    $error = $translator->trans('PayPal refund amount is invalid.');
+
+                    break;
+                case PayPalRefundException::REFUND_FAILED:
+                    $error = $translator->trans('PayPal refund failed.');
+
+                    break;
+                default:
+                    $error = '';
+
+                    break;
+            }
+            $this->exitWithResponse([
+                'httpCode' => 400,
+                'status' => false,
+                'errors' => [$error],
+            ]);
+        } catch (OrderException $exception) {
+            \Sentry\captureException($exception);
+
+            if ($exception->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                $this->exitWithResponse([
+                    'httpCode' => 200,
+                    'status' => true,
+                    'content' => $translator->trans('Refund has been processed by PayPal, but order status change or email sending failed.'),
+                ]);
+            } elseif ($exception->getCode() !== OrderException::ORDER_HAS_ALREADY_THIS_STATUS) {
+                $this->exitWithResponse([
+                    'httpCode' => 500,
+                    'status' => false,
+                    'errors' => [
+                        $exception->getMessage(),
+                    ],
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+        } catch (\Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [
+                    $translator->trans('Refund cannot be processed by PayPal.'),
+                ],
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrderId);
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrderId);
+        } catch (\Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 200,
+                'status' => true,
+                'message' => $translator->trans('Refund has been processed by PayPal.'),
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $translator->trans('Refund has been processed by PayPal.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAnonymousAllowed(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param string|null $value
+     * @param string|null $controller
+     * @param string|null $method
+     *
+     * @throws PrestaShopException
+     */
+    protected function ajaxRender($value = null, $controller = null, $method = null)
+    {
+        parent::ajaxRender($value, $controller, $method);
+
+        exit;
+    }
+
+    /**
+     * @param int $idOrder
+     *
+     * @return array{0: \PsCheckout\Infrastructure\Repository\PayPalOrder, 1: \PsCheckout\Api\ValueObject\PayPalOrderResponse, 2: bool}
+     */
+    private function resolvePayPalOrder(int $idOrder): array
+    {
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        if (empty($idOrder)) {
             $this->exitWithResponse([
                 'httpCode' => 400,
                 'status' => false,
@@ -811,7 +985,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             ]);
         }
 
-        $order = new Order($id_order);
+        $order = new Order($idOrder);
 
         /** @var PayPalOrderRepository $payPalOrderRepository */
         $payPalOrderRepository = $this->module->getService(PayPalOrderRepository::class);
@@ -876,128 +1050,7 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
         $isProductionEnv = $payPalOrder->getEnvironment() === PayPalConfiguration::MODE_LIVE;
 
-        /** @var MerchantOrderViewPresenter $presenter */
-        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
-        $data = $presenter->present($paypalOrderResponse, $payPalOrder, $isProductionEnv);
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'orderData' => $data['orderData'],
-            'transactionList' => $data['transactionList'],
-        ]);
-    }
-
-    public function ajaxProcessRefundOrder()
-    {
-        /** @var Translator $translator **/
-        $translator = $this->module->getService(Translator::class);
-
-        $payPalOrderId = Tools::getValue('orderPayPalRefundOrder');
-        $captureId = Tools::getValue('orderPayPalRefundTransaction');
-        $amount = Tools::getValue('orderPayPalRefundAmount');
-        $currency = Tools::getValue('orderPayPalRefundCurrency');
-
-        /** @var RefundPayPalOrderAction $refundPayPalOrderAction */
-        $refundPayPalOrderAction = $this->module->getService(RefundPayPalOrderAction::class);
-
-        try {
-            $payPalRefund = new PayPalRefund($payPalOrderId, $captureId, $currency, $amount);
-
-            $refundPayPalOrderAction->execute($payPalRefund);
-        } catch (PayPalRefundException $exception) {
-            \Sentry\captureException($exception);
-
-            switch ($exception->getCode()) {
-                case PayPalRefundException::INVALID_ORDER_ID:
-                    $error = $translator->trans('PayPal Order is invalid.');
-
-                    break;
-                case PayPalRefundException::INVALID_TRANSACTION_ID:
-                    $error = $translator->trans('PayPal Transaction is invalid.');
-
-                    break;
-                case PayPalRefundException::INVALID_CURRENCY:
-                    $error = $translator->trans('PayPal refund currency is invalid.');
-
-                    break;
-                case PayPalRefundException::INVALID_AMOUNT:
-                    $error = $translator->trans('PayPal refund amount is invalid.');
-
-                    break;
-                case PayPalRefundException::REFUND_FAILED:
-                    $error = $translator->trans('PayPal refund failed.');
-
-                    break;
-                default:
-                    $error = '';
-
-                    break;
-            }
-            $this->exitWithResponse([
-                'httpCode' => 400,
-                'status' => false,
-                'errors' => [$error],
-            ]);
-        } catch (OrderException $exception) {
-            \Sentry\captureException($exception);
-
-            if ($exception->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
-                $this->exitWithResponse([
-                    'httpCode' => 200,
-                    'status' => true,
-                    'content' => $translator->trans('Refund has been processed by PayPal, but order status change or email sending failed.'),
-                ]);
-            } elseif ($exception->getCode() !== OrderException::ORDER_HAS_ALREADY_THIS_STATUS) {
-                $this->exitWithResponse([
-                    'httpCode' => 500,
-                    'status' => false,
-                    'errors' => [
-                        $exception->getMessage(),
-                    ],
-                    'error' => $exception->getMessage(),
-                ]);
-            }
-        } catch (Exception $exception) {
-            \Sentry\captureException($exception);
-
-            $this->exitWithResponse([
-                'httpCode' => 500,
-                'status' => false,
-                'errors' => [
-                    $translator->trans('Refund cannot be processed by PayPal.'),
-                ],
-                'error' => $exception->getMessage(),
-            ]);
-        }
-
-        $this->exitWithResponse([
-            'httpCode' => 200,
-            'status' => true,
-            'content' => $translator->trans('Refund has been processed by PayPal.'),
-        ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isAnonymousAllowed(): bool
-    {
-        return false;
-    }
-
-    /**
-     * @param string|null $value
-     * @param string|null $controller
-     * @param string|null $method
-     *
-     * @throws PrestaShopException
-     */
-    protected function ajaxRender($value = null, $controller = null, $method = null)
-    {
-        parent::ajaxRender($value, $controller, $method);
-
-        exit;
+        return [$payPalOrder, $paypalOrderResponse, $isProductionEnv];
     }
 
     /**
@@ -1108,31 +1161,153 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
 
     public function ajaxProcessCaptureAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::CAPTURE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        $payload = [];
+        $amount = Tools::getValue('amount');
+        $currency = Tools::getValue('currency');
+
+        if ($amount && $currency) {
+            $payload['amount'] = [
+                'value' => $amount,
+                'currency_code' => $currency,
+            ];
+        }
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::CAPTURE, $payPalOrder->getId(), $payload);
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (\Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization captured successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessVoidAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::VOID, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::VOID, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (\Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization voided successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 
     public function ajaxProcessReauthorizeAuthorization()
     {
-        /**
-         * @var AuthorizationActionProcessor $processor
-         */
-        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $id_order = (int) Tools::getValue('id_order');
 
-        $this->exitWithResponse($processor->process(AuthorizationAction::REAUTHORIZE, Tools::getValue('orderId')));
+        list($payPalOrder, , $isProductionEnv) = $this->resolvePayPalOrder($id_order);
+
+        /** @var AuthorizationActionProcessor $processor */
+        $processor = $this->module->getService(AuthorizationActionProcessor::class);
+        $result = $processor->process(AuthorizationAction::REAUTHORIZE, $payPalOrder->getId());
+
+        if (!$result['status']) {
+            $this->exitWithResponse($result);
+        }
+
+        /** @var PayPalOrderCache $cache */
+        $cache = $this->module->getService(PayPalOrderCache::class);
+        $cache->delete($payPalOrder->getId());
+
+        /** @var PayPalOrderProvider $paypalOrderProvider */
+        $paypalOrderProvider = $this->module->getService(PayPalOrderProvider::class);
+
+        try {
+            $paypalOrderResponse = $paypalOrderProvider->getById($payPalOrder->getId());
+        } catch (\Exception $exception) {
+            \Sentry\captureException($exception);
+
+            $this->exitWithResponse([
+                'httpCode' => 500,
+                'status' => false,
+                'errors' => [$exception->getMessage()],
+            ]);
+        }
+
+        /** @var MerchantOrderViewPresenter $presenter */
+        $presenter = $this->module->getService(MerchantOrderViewPresenter::class);
+        $data = $presenter->present($paypalOrderResponse, $isProductionEnv);
+
+        $this->exitWithResponse([
+            'httpCode' => 200,
+            'status' => true,
+            'message' => $this->module->l('Authorization reauthorized successfully.'),
+            'order' => $data['order'],
+            'transactionActions' => $data['transactionActions'],
+            'isTestMode' => $data['isTestMode'],
+        ]);
     }
 }

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -3523,12 +3523,6 @@ parameters:
 			path: ../core/src/PayPal/Order/Action/UpdatePayPalOrderPurchaseUnitAction.php
 
 		-
-			message: '#^Call to an undefined method PsCheckout\\Api\\ValueObject\\PayPalOrderResponse\|PsCheckout\\Core\\PayPal\\Order\\Response\\ValueObject\\CreatePayPalOrderResponse\:\:toArray\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: ../core/src/PayPal/Order/Cache/PayPalOrderCache.php
-
-		-
 			message: '#^Call to method get\(\) on an unknown class Symfony\\Component\\Cache\\Adapter\\CacheItem\.$#'
 			identifier: class.notFound
 			count: 1
@@ -11101,32 +11095,26 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''translated'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Cannot access offset ''value'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to float\.$#'
 			identifier: cast.double
-			count: 10
+			count: 3
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 4
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 
 		-
-			message: '#^Parameter \#1 \$presenterData of method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:buildOrderData\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
+			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
 

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -11095,24 +11095,6 @@ parameters:
 			path: ../presentation/src/Presenter/OrderSummary/OrderSummaryPresenterInterface.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to float\.$#'
-			identifier: cast.double
-			count: 3
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 4
-			path: ../presentation/src/Presenter/PayPalOrder/MerchantOrderViewPresenter.php
-
-		-
 			message: '#^Method PsCheckout\\Presentation\\Presenter\\PayPalOrder\\MerchantOrderViewPresenter\:\:present\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/ps9/views/css/adminOrderViewSdk.css
+++ b/ps9/views/css/adminOrderViewSdk.css
@@ -1,6 +1,6 @@
 #ps-checkout-merchant-order-view {
     width: 100%;
-    height: 100%;
+    height: 1500px;
 }
 #ps-checkout-merchant-order-view > div,
 #ps-checkout-merchant-order-view iframe {

--- a/ps9/views/js/adminOrderViewSdk.js
+++ b/ps9/views/js/adminOrderViewSdk.js
@@ -45,6 +45,8 @@ var ps_checkout_merchant = {};
       });
       var appUrl = sdkScript ? new URL(sdkScript.src).origin : undefined;
 
+      var checkoutComponent = null;
+
       var actionMap = {
         capture:     'CaptureAuthorization',
         void:        'VoidAuthorization',
@@ -52,22 +54,40 @@ var ps_checkout_merchant = {};
         refund:      'RefundOrder',
       };
 
-      function onSubmit(type, transaction, data) {
-        console.log('[ps_checkout] onSubmit:', type, transaction, data);
+      function onSubmit(type, transactionId, data) {
         var action = actionMap[type];
         if (!action || !ajaxUrl) {
-          console.warn('[ps_checkout] Unknown action type or missing AJAX URL:', type);
-          return;
+          return Promise.reject(new Error('Unknown action type or missing AJAX URL'));
         }
-        var payload = Object.assign({ id_transaction: transaction.id }, data || {});
-        fetch(ajaxUrl + '&action=' + action, {
+        var params = new URLSearchParams({
+          ajax: 1,
+          action: action,
+          id_order: orderId,
+          id_transaction: transactionId,
+        });
+        if (data) {
+          Object.keys(data).forEach(function (key) {
+            params.append(key, data[key]);
+          });
+        }
+        return fetch(ajaxUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
         })
           .then(function (res) { return res.json(); })
-          .then(function (json) { console.log('[ps_checkout] AJAX response:', json); })
-          .catch(function (err) { console.error('[ps_checkout] AJAX error:', err); });
+          .then(function (json) {
+            if (!json.status) {
+              throw new Error((json.errors || []).join(', ') || (json.error && json.error.message) || 'Unknown error');
+            }
+            if (checkoutComponent && json.order) {
+              checkoutComponent.updateProps({
+                order: json.order,
+                transactionActions: json.transactionActions || {},
+              });
+            }
+            return { message: json.message || '' };
+          });
       }
 
       container.innerHTML = '<div class="d-print-none text-muted p-3">Loading PayPal order data\u2026</div>';
@@ -85,14 +105,14 @@ var ps_checkout_merchant = {};
 
           container.innerHTML = '';
 
-          var checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
+          checkoutComponent = window.PrestaShopCheckoutSDK.PrestaShopCheckout({
             url: appUrl,
-            orderData: json.orderData,
-            transactionList: json.transactionList,
+            order: json.order,
+            isTestMode: json.isTestMode || false,
+            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);
-          console.log('[ps_checkout] PrestaShopCheckout initialized with real order data.');
         })
         .catch(function (err) {
           console.error('[ps_checkout] Failed to load PayPal order data:', err);

--- a/ps9/views/js/adminOrderViewSdk.js
+++ b/ps9/views/js/adminOrderViewSdk.js
@@ -83,7 +83,6 @@ var ps_checkout_merchant = {};
             if (checkoutComponent && json.order) {
               checkoutComponent.updateProps({
                 order: json.order,
-                transactionActions: json.transactionActions || {},
               });
             }
             return { message: json.message || '' };
@@ -109,7 +108,6 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
-            transactionActions: json.transactionActions || {},
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);


### PR DESCRIPTION


## Self-Checks
- [x] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: 
- [PAYSHIP-3880](https://forge.prestashop.com/browse/PAYSHIP-3880)
- [PAYSHIP-3881](https://forge.prestashop.com/browse/PAYSHIP-3881)
- [PAYSHIP-3882](https://forge.prestashop.com/browse/PAYSHIP-3882)
- [PAYSHIP-3883](https://forge.prestashop.com/browse/PAYSHIP-3883)

## Summary

This PR introduces the **PayPal Authorization payment flow** for PrestaShop Checkout v5.3.x, along with Merchant SDK integration, modernized webhook handling, and infrastructure improvements.

## QA Checklist Labels
- [ ] Bug fix? <!-- Maps to "bug" label -->
- [x] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->

## Additional Context

- **Wire authorization action callbacks (capture, void, reauthorize, refund) end-to-end** from the merchant SDK Zoid component through the admin AJAX controller to PayPal, returning refreshed order data so the UI updates in place without page reload
- **Add `$payload` parameter to authorization action interfaces** to support partial capture (custom amount/currency forwarded to PayPal's capture API)
- **Fix `onSubmit` Content-Type** from `application/json` to `application/x-www-form-urlencoded` so `Tools::getValue()` can route AJAX actions correctly
- **Simplify `MerchantOrderViewPresenter`** — the merchant SDK now owns order/transaction presentation logic internally, so the PHP presenter passes the raw PayPal order response (`toArray()`) and `isTestMode` flag instead of building `orderData`/`transactionList` maps
- **Extract `resolvePayPalOrder()` and `exitWithRefreshedOrderData()` helpers** in admin controllers, eliminating ~80 duplicated lines per action method across all three version shells
- **Remove dead `transactionActions` code** from JS, PHP presenter, AJAX responses, and PHPStan baselines
- **Add new "Authorization voided" order state** with multi-language translations, installed during module setup
- **Fix `CaptureAuthorizationAction` status check** — error message said "APPROVED" but code actually checks for "COMPLETED"
- **Add `PayPalOrderResponse::toArray()`** to serialize the value object for SDK consumption

