### PR TITLE
fix(presentation): pass admin locale to merchant SDK for i18n

### DIFF
--- a/ps17/ps_checkout.php
+++ b/ps17/ps_checkout.php
@@ -987,6 +987,7 @@ class Ps_Checkout extends PaymentModule
             'moduleName' => $this->displayName,
             'orderPrestaShopId' => $order->id,
             'orderPayPalBaseUrl' => $this->context->link->getAdminLink('AdminAjaxPrestashopCheckout'),
+            'locale' => $this->context->language->iso_code,
         ]);
 
         return $this->display(__FILE__, 'views/templates/hook/displayAdminOrderLeft.tpl');
@@ -1012,6 +1013,7 @@ class Ps_Checkout extends PaymentModule
             'moduleName' => $this->displayName,
             'orderPrestaShopId' => $order->id,
             'orderPayPalBaseUrl' => $this->context->link->getAdminLink('AdminAjaxPrestashopCheckout'),
+            'locale' => $this->context->language->iso_code,
         ]);
 
         return $this->display(__FILE__, 'views/templates/hook/displayAdminOrderMainBottom.tpl');

--- a/ps17/views/js/adminOrderViewSdk.js
+++ b/ps17/views/js/adminOrderViewSdk.js
@@ -26,6 +26,7 @@ var ps_checkout_merchant = {};
       var containerId = config.containerId;
       var ajaxUrl    = config.ajaxUrl;
       var orderId    = config.orderId;
+      var locale     = config.locale;
 
       var container = document.getElementById(containerId);
       if (!container) {
@@ -108,6 +109,7 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
+            locale: locale,
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);

--- a/ps17/views/templates/hook/displayAdminOrderLeft.tpl
+++ b/ps17/views/templates/hook/displayAdminOrderLeft.tpl
@@ -31,4 +31,4 @@
 </div>
 
 {include file='./partials/adminOrderView.tpl' legacy=true orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}
-{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}
+{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl locale=$locale}

--- a/ps17/views/templates/hook/displayAdminOrderMainBottom.tpl
+++ b/ps17/views/templates/hook/displayAdminOrderMainBottom.tpl
@@ -35,4 +35,4 @@
 <div class="card mt-2" id="ps-checkout-merchant-order-view"></div>
 
 {*{include file='./partials/adminOrderView.tpl' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}*}
-{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}
+{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl locale=$locale}

--- a/ps17/views/templates/hook/partials/adminOrderViewSdk.tpl
+++ b/ps17/views/templates/hook/partials/adminOrderViewSdk.tpl
@@ -22,6 +22,7 @@
       containerId: '{$containerId|escape:'javascript':'UTF-8'}',
       ajaxUrl: '{$orderPayPalBaseUrl|escape:'javascript':'UTF-8'}',
       orderId: {$orderPrestaShopId|intval},
+      locale: '{$locale|escape:'javascript':'UTF-8'}',
     });
   }
 </script>

--- a/ps8/ps_checkout.php
+++ b/ps8/ps_checkout.php
@@ -984,6 +984,7 @@ class Ps_Checkout extends PaymentModule
             'moduleName' => $this->displayName,
             'orderPrestaShopId' => $order->id,
             'orderPayPalBaseUrl' => $this->context->link->getAdminLink('AdminAjaxPrestashopCheckout'),
+            'locale' => $this->context->language->iso_code,
         ]);
 
         return $this->display(__FILE__, 'views/templates/hook/displayAdminOrderMainBottom.tpl');

--- a/ps8/views/js/adminOrderViewSdk.js
+++ b/ps8/views/js/adminOrderViewSdk.js
@@ -26,6 +26,7 @@ var ps_checkout_merchant = {};
       var containerId = config.containerId;
       var ajaxUrl    = config.ajaxUrl;
       var orderId    = config.orderId;
+      var locale     = config.locale;
 
       var container = document.getElementById(containerId);
       if (!container) {
@@ -108,6 +109,7 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
+            locale: locale,
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);

--- a/ps8/views/templates/hook/displayAdminOrderMainBottom.tpl
+++ b/ps8/views/templates/hook/displayAdminOrderMainBottom.tpl
@@ -35,4 +35,4 @@
 <div class="card mt-2" id="ps-checkout-merchant-order-view"></div>
 
 {*{include file='./partials/adminOrderView.tpl' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}*}
-{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}
+{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl locale=$locale}

--- a/ps8/views/templates/hook/partials/adminOrderViewSdk.tpl
+++ b/ps8/views/templates/hook/partials/adminOrderViewSdk.tpl
@@ -22,6 +22,7 @@
       containerId: '{$containerId|escape:'javascript':'UTF-8'}',
       ajaxUrl: '{$orderPayPalBaseUrl|escape:'javascript':'UTF-8'}',
       orderId: {$orderPrestaShopId|intval},
+      locale: '{$locale|escape:'javascript':'UTF-8'}',
     });
   }
 </script>

--- a/ps9/ps_checkout.php
+++ b/ps9/ps_checkout.php
@@ -986,6 +986,7 @@ class Ps_Checkout extends PaymentModule
             'moduleName' => $this->displayName,
             'orderPrestaShopId' => $order->id,
             'orderPayPalBaseUrl' => $this->context->link->getAdminLink('AdminAjaxPrestashopCheckout'),
+            'locale' => $this->context->language->iso_code,
         ]);
 
         return $this->display(__FILE__, 'views/templates/hook/displayAdminOrderMainBottom.tpl');

--- a/ps9/views/js/adminOrderViewSdk.js
+++ b/ps9/views/js/adminOrderViewSdk.js
@@ -26,6 +26,7 @@ var ps_checkout_merchant = {};
       var containerId = config.containerId;
       var ajaxUrl    = config.ajaxUrl;
       var orderId    = config.orderId;
+      var locale     = config.locale;
 
       var container = document.getElementById(containerId);
       if (!container) {
@@ -108,6 +109,7 @@ var ps_checkout_merchant = {};
             url: appUrl,
             order: json.order,
             isTestMode: json.isTestMode || false,
+            locale: locale,
             onSubmit: onSubmit,
           });
           checkoutComponent.render('#' + containerId);

--- a/ps9/views/templates/hook/displayAdminOrderMainBottom.tpl
+++ b/ps9/views/templates/hook/displayAdminOrderMainBottom.tpl
@@ -35,4 +35,4 @@
 <div class="card mt-2" id="ps-checkout-merchant-order-view"></div>
 
 {*{include file='./partials/adminOrderView.tpl' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}*}
-{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl}
+{include file='./partials/adminOrderViewSdk.tpl' containerId='ps-checkout-merchant-order-view' orderPrestaShopId=$orderPrestaShopId orderPayPalBaseUrl=$orderPayPalBaseUrl locale=$locale}

--- a/ps9/views/templates/hook/partials/adminOrderViewSdk.tpl
+++ b/ps9/views/templates/hook/partials/adminOrderViewSdk.tpl
@@ -22,6 +22,7 @@
       containerId: '{$containerId|escape:'javascript':'UTF-8'}',
       ajaxUrl: '{$orderPayPalBaseUrl|escape:'javascript':'UTF-8'}',
       orderId: {$orderPrestaShopId|intval},
+      locale: '{$locale|escape:'javascript':'UTF-8'}',
     });
   }
 </script>


### PR DESCRIPTION
The merchant SDK was using navigator.language (browser locale) instead of the PrestaShop admin employee's language. Pass the employee's iso_code through the Smarty template chain to the Zoid component as a locale prop.

## Self-Checks
- [ ] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: [XXXX](https://forge.prestashop.com/browse/XXXX)

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->

## QA Checklist Labels
- [ ] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->

## Additional Context
<!-- Provide a concise description of the changes made in this PR. -->

## Frontend Changes
<!-- If applicable, provide visual elements such as screenshots, GIFs, or videos to demonstrate frontend changes. -->
<br><br>

[!] Don't forget to include JIRA task number in PR name or branch name. [!]

[!] Don't forget to update *changelog.md* with new changes. [!]

- [ ] Verify if the version is correct.
- [ ] Update demo environments used for testing.
- [ ] Ensure changelog contains all changes.
- [ ] Update documentation if needed.
- [ ] Test if everything works properly.