### PR TITLE
[PAYSHIP-3943] Fix authorization partial-capture refund incorrectly marked as Refunded

### DIFF
--- a/core/src/OrderState/Action/SetRefundedOrderStateAction.php
+++ b/core/src/OrderState/Action/SetRefundedOrderStateAction.php
@@ -132,7 +132,7 @@ class SetRefundedOrderStateAction implements SetOrderStateActionInterface
 
     private function handleAuthorizationRefund(PayPalRefundOrder $refundOrder, PayPalOrderResponse $payPalOrderResponse): void
     {
-        $orderTotal = (float) $refundOrder->getTotalAmount();
+        $orderTotal = (float) $payPalOrderResponse->getOrderAmountValue();
 
         $totalCaptured = array_reduce($payPalOrderResponse->getCaptures(), function ($totalCaptured, $capture) {
             return $totalCaptured + (float) $capture['amount']['value'];

--- a/core/tests/Integration/OrderState/Action/SetRefundedOrderStateActionTest.php
+++ b/core/tests/Integration/OrderState/Action/SetRefundedOrderStateActionTest.php
@@ -155,6 +155,10 @@ class SetRefundedOrderStateActionTest extends BaseTestCase
         $payPalOrderResponseData = [
             'intent' => 'AUTHORIZE',
             'purchase_units' => [[
+                'amount' => [
+                    'currency_code' => 'EUR',
+                    'value' => '22.94',
+                ],
                 'payments' => [
                     'captures' => [[
                         'id' => 'CAPTURE-1',
@@ -174,9 +178,9 @@ class SetRefundedOrderStateActionTest extends BaseTestCase
             ]],
         ];
 
-        $order = OrderFactory::create(['current_state' => 1, 'total_paid' => '22.94']);
+        $order = OrderFactory::create(['current_state' => 1, 'total_paid' => '10.00']);
         $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
-        $payPalRefundOrder = PayPalRefundOrderFactory::create(['id' => $order->id, 'totalPaid' => 22.94]);
+        $payPalRefundOrder = PayPalRefundOrderFactory::create(['id' => $order->id, 'totalPaid' => 10.00]);
 
         $this->payPalOrderProvider->expects($this->once())
             ->method('getById')
@@ -203,6 +207,10 @@ class SetRefundedOrderStateActionTest extends BaseTestCase
         $payPalOrderResponseData = [
             'intent' => 'AUTHORIZE',
             'purchase_units' => [[
+                'amount' => [
+                    'currency_code' => 'EUR',
+                    'value' => '22.94',
+                ],
                 'payments' => [
                     'captures' => [[
                         'id' => 'CAPTURE-1',
@@ -251,6 +259,10 @@ class SetRefundedOrderStateActionTest extends BaseTestCase
         $payPalOrderResponseData = [
             'intent' => 'AUTHORIZE',
             'purchase_units' => [[
+                'amount' => [
+                    'currency_code' => 'EUR',
+                    'value' => '22.94',
+                ],
                 'payments' => [
                     'captures' => [[
                         'id' => 'CAPTURE-1',
@@ -270,9 +282,9 @@ class SetRefundedOrderStateActionTest extends BaseTestCase
             ]],
         ];
 
-        $order = OrderFactory::create(['current_state' => 1, 'total_paid' => '22.94']);
+        $order = OrderFactory::create(['current_state' => 1, 'total_paid' => '10.00']);
         $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
-        $payPalRefundOrder = PayPalRefundOrderFactory::create(['id' => $order->id, 'totalPaid' => 22.94]);
+        $payPalRefundOrder = PayPalRefundOrderFactory::create(['id' => $order->id, 'totalPaid' => 10.00]);
 
         $this->payPalOrderProvider->expects($this->once())
             ->method('getById')


### PR DESCRIPTION
## Summary

- Fix order state calculation for authorization refunds on partially captured orders: use PayPal's `purchase_units[0].amount.value` (full authorized amount) instead of PrestaShop's `getTotalPaid()` (captured amount only)
- Update test data to reflect production behavior where `totalPaid` matches the captured amount, not the full authorization

## Root cause

`handleAuthorizationRefund()` used `$refundOrder->getTotalAmount()` which returns `getTotalPaid()` — the amount actually captured (e.g., €10), not the full authorized amount (e.g., €22.94). This caused `$orderFullyCaptured` to incorrectly evaluate as `true` when captures only partially covered the authorization, resulting in "Refunded" instead of "Partially refunded".

## Test plan

- [x] `make phpstan` — passes with no errors
- [x] `make integration-test` — updated authorization refund tests pass
- [ ] Manual QA: authorization order (€22.94) → partial capture (€10) → full refund (€10) → order state should be "Partially refunded"

Jira: https://forge.prestashop.com/browse/PAYSHIP-3943

🤖 Generated with [Claude Code](https://claude.com/claude-code)