### PR TITLE
[PAYSHIP-3956] Persist paymentSource after capture/authorize

### DIFF
--- a/core/src/PayPal/Order/Action/AuthorizePayPalOrderAction.php
+++ b/core/src/PayPal/Order/Action/AuthorizePayPalOrderAction.php
@@ -30,6 +30,7 @@ use PsCheckout\Core\PayPal\Order\Entity\PayPalOrderAuthorization;
 use PsCheckout\Core\PayPal\Order\Handler\EventHandlerInterface;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProviderInterface;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
 class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
@@ -65,6 +66,11 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
     private $payPalOrderAuthorizationRepository;
 
     /**
+     * @var PayPalOrderRepositoryInterface
+     */
+    private $payPalOrderRepository;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -76,7 +82,8 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
         EventHandlerInterface $paymentDeniedEventHandler,
         PayPalOrderProviderInterface $payPalOrderProvider,
         PayPalOrderAuthorizationRepositoryInterface $payPalOrderAuthorizationRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        PayPalOrderRepositoryInterface $payPalOrderRepository
     ) {
         $this->orderHttpClient = $orderHttpClient;
         $this->payPalOrderCache = $payPalOrderCache;
@@ -85,6 +92,7 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
         $this->payPalOrderProvider = $payPalOrderProvider;
         $this->payPalOrderAuthorizationRepository = $payPalOrderAuthorizationRepository;
         $this->logger = $logger;
+        $this->payPalOrderRepository = $payPalOrderRepository;
     }
 
     /**
@@ -106,6 +114,14 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
         $this->payPalOrderCache->set($orderId, array_replace_recursive($cachedOrder, $orderPayPal));
 
         $payPalOrderResponse = $this->payPalOrderProvider->getById($orderId);
+
+        if ($payPalOrderResponse->getPaymentSource()) {
+            $payPalOrderEntity = $this->payPalOrderRepository->getOneBy(['id' => $orderId]);
+            if ($payPalOrderEntity) {
+                $payPalOrderEntity->setPaymentSource($payPalOrderResponse->getPaymentSource());
+                $this->payPalOrderRepository->save($payPalOrderEntity);
+            }
+        }
 
         $authorization = $payPalOrderResponse->getAuthorization();
 

--- a/core/src/PayPal/Order/Action/AuthorizePayPalOrderAction.php
+++ b/core/src/PayPal/Order/Action/AuthorizePayPalOrderAction.php
@@ -82,8 +82,8 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
         EventHandlerInterface $paymentDeniedEventHandler,
         PayPalOrderProviderInterface $payPalOrderProvider,
         PayPalOrderAuthorizationRepositoryInterface $payPalOrderAuthorizationRepository,
-        LoggerInterface $logger,
-        PayPalOrderRepositoryInterface $payPalOrderRepository
+        PayPalOrderRepositoryInterface $payPalOrderRepository,
+        LoggerInterface $logger
     ) {
         $this->orderHttpClient = $orderHttpClient;
         $this->payPalOrderCache = $payPalOrderCache;
@@ -91,8 +91,8 @@ class AuthorizePayPalOrderAction implements AuthorizePayPalOrderActionInterface
         $this->paymentDeniedEventHandler = $paymentDeniedEventHandler;
         $this->payPalOrderProvider = $payPalOrderProvider;
         $this->payPalOrderAuthorizationRepository = $payPalOrderAuthorizationRepository;
-        $this->logger = $logger;
         $this->payPalOrderRepository = $payPalOrderRepository;
+        $this->logger = $logger;
     }
 
     /**

--- a/core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
+++ b/core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
@@ -118,6 +118,14 @@ class CapturePayPalOrderAction implements CapturePayPalOrderActionInterface
             throw new PsCheckoutException('Capture declined', PsCheckoutException::PAYPAL_PAYMENT_CAPTURE_DECLINED);
         }
 
+        if ($payPalOrderResponse->getPaymentSource()) {
+            $payPalOrderEntity = $this->payPalOrderRepository->getOneBy(['id' => $orderPayPal['id']]);
+            if ($payPalOrderEntity) {
+                $payPalOrderEntity->setPaymentSource($payPalOrderResponse->getPaymentSource());
+                $this->payPalOrderRepository->save($payPalOrderEntity);
+            }
+        }
+
         if ($payPalOrderResponse->getStatus() === PayPalCaptureStatus::COMPLETED) {
             $this->orderCompletedEventHandler->handle($payPalOrderResponse);
         }

--- a/core/tests/Unit/PayPal/Action/AuthorizePayPalOrderActionTest.php
+++ b/core/tests/Unit/PayPal/Action/AuthorizePayPalOrderActionTest.php
@@ -106,8 +106,8 @@ class AuthorizePayPalOrderActionTest extends TestCase
             $this->paymentDeniedEventHandler,
             $this->payPalOrderProvider,
             $this->payPalOrderAuthorizationRepository,
-            $this->logger,
-            $this->payPalOrderRepository
+            $this->payPalOrderRepository,
+            $this->logger
         );
     }
 

--- a/core/tests/Unit/PayPal/Action/AuthorizePayPalOrderActionTest.php
+++ b/core/tests/Unit/PayPal/Action/AuthorizePayPalOrderActionTest.php
@@ -33,6 +33,7 @@ use PsCheckout\Core\PayPal\Order\Entity\PayPalOrderAuthorization;
 use PsCheckout\Core\PayPal\Order\Handler\EventHandlerInterface;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProviderInterface;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Core\Tests\Integration\Factory\PayPalOrderResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -76,6 +77,11 @@ class AuthorizePayPalOrderActionTest extends TestCase
     private $logger;
 
     /**
+     * @var MockObject|PayPalOrderRepositoryInterface
+     */
+    private $payPalOrderRepository;
+
+    /**
      * @var AuthorizePayPalOrderAction
      */
     private $action;
@@ -91,6 +97,7 @@ class AuthorizePayPalOrderActionTest extends TestCase
         $this->payPalOrderProvider = $this->createMock(PayPalOrderProviderInterface::class);
         $this->payPalOrderAuthorizationRepository = $this->createMock(PayPalOrderAuthorizationRepositoryInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->payPalOrderRepository = $this->createMock(PayPalOrderRepositoryInterface::class);
 
         $this->action = new AuthorizePayPalOrderAction(
             $this->orderHttpClient,
@@ -99,7 +106,8 @@ class AuthorizePayPalOrderActionTest extends TestCase
             $this->paymentDeniedEventHandler,
             $this->payPalOrderProvider,
             $this->payPalOrderAuthorizationRepository,
-            $this->logger
+            $this->logger,
+            $this->payPalOrderRepository
         );
     }
 

--- a/ps17/config/front/process.yml
+++ b/ps17/config/front/process.yml
@@ -284,3 +284,4 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
       - '@Psr\Log\LoggerInterface'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'

--- a/ps17/config/front/process.yml
+++ b/ps17/config/front/process.yml
@@ -283,5 +283,5 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Handler\PaymentDeniedEventHandler'
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
-      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@Psr\Log\LoggerInterface'

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -3201,7 +3201,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 4
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
 
 		-
@@ -3302,12 +3302,6 @@ parameters:
 
 		-
 			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$configuration is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
-
-		-
-			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$payPalOrderRepository is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php

--- a/ps8/config/front/process.yml
+++ b/ps8/config/front/process.yml
@@ -284,3 +284,4 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
       - '@Psr\Log\LoggerInterface'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'

--- a/ps8/config/front/process.yml
+++ b/ps8/config/front/process.yml
@@ -283,5 +283,5 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Handler\PaymentDeniedEventHandler'
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
-      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@Psr\Log\LoggerInterface'

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -3189,7 +3189,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 4
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
 
 		-
@@ -3290,12 +3290,6 @@ parameters:
 
 		-
 			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$configuration is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
-
-		-
-			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$payPalOrderRepository is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php

--- a/ps9/config/front/process.yml
+++ b/ps9/config/front/process.yml
@@ -284,3 +284,4 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
       - '@Psr\Log\LoggerInterface'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'

--- a/ps9/config/front/process.yml
+++ b/ps9/config/front/process.yml
@@ -283,5 +283,5 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Handler\PaymentDeniedEventHandler'
       - '@PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProvider'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
-      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@Psr\Log\LoggerInterface'

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -3189,7 +3189,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 4
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
 
 		-
@@ -3290,12 +3290,6 @@ parameters:
 
 		-
 			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$configuration is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php
-
-		-
-			message: '#^Property PsCheckout\\Core\\PayPal\\Order\\Action\\CapturePayPalOrderAction\:\:\$payPalOrderRepository is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: ../core/src/PayPal/Order/Action/CapturePayPalOrderAction.php


### PR DESCRIPTION
## Summary
- Persist `paymentSource` from the PayPal API response to the DB entity after both capture and authorize flows, so the order summary displays the actual PayPal account email instead of the PrestaShop customer email
- Add `PayPalOrderRepositoryInterface` dependency to `AuthorizePayPalOrderAction` and wire it in all three service containers (ps8, ps9, ps17)
- Update PHPStan baselines to reflect the new usage of `$payPalOrderRepository` in `CapturePayPalOrderAction`

## Test plan
- [x] **AUTHORIZE + PayPal funding**: place an order, verify order summary shows the PayPal account email (not the PrestaShop email)
- [x] **CAPTURE + PayPal funding**: same check
- [x] **Card funding**: verify card brand + last 4 digits still display correctly
- [x] `make phpstan` passes for ps8, ps9, and ps17
- [x] `make unit-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)