### PR TITLE
[PAYSHIP-3983] harden payment authorization actions

### DIFF
--- a/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/CaptureAuthorizationAction.php
@@ -29,9 +29,15 @@ use PsCheckout\Core\PayPal\Order\Configuration\PayPalOrderStatus;
 use PsCheckout\Core\PayPal\Order\Entity\PayPalOrderAuthorization;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryInterface;
 use PsCheckout\Core\PayPal\Payment\Authorization\Configuration\AuthorizationAction;
+use Psr\Log\LoggerInterface;
 
 final class CaptureAuthorizationAction implements AuthorizationActionInterface
 {
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     /**
      * @var PaymentHttpClientInterface
      */
@@ -43,9 +49,11 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
     private $authorizationRepository;
 
     public function __construct(
+        LoggerInterface $logger,
         PaymentHttpClientInterface $paymentHttpClient,
         PayPalOrderAuthorizationRepositoryInterface $authorizationRepository
     ) {
+        $this->logger = $logger;
         $this->paymentHttpClient = $paymentHttpClient;
         $this->authorizationRepository = $authorizationRepository;
     }
@@ -131,6 +139,12 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
             );
         }
 
+        $this->logger->info('Capturing authorization', [
+            'order_id' => $payPalOrder->getId(),
+            'authorization_id' => $authorizationId,
+            'authorization_status' => $authorizationStatus,
+        ]);
+
         $captureResponse = $this->paymentHttpClient->captureAuthorization($authorizationId, $payload);
 
         /**
@@ -139,9 +153,21 @@ final class CaptureAuthorizationAction implements AuthorizationActionInterface
          *     status: string,
          *     create_time: string,
          *     update_time: string
-         * } $capturedAuthorization
+         * }|null $capturedAuthorization
          */
         $capturedAuthorization = json_decode($captureResponse->getBody(), true);
+
+        if (empty($capturedAuthorization)) {
+            $this->logger->error('Invalid capture response for authorization', [
+                'order_id' => $payPalOrder->getId(),
+                'authorization_id' => $authorizationId,
+            ]);
+
+            throw new PsCheckoutException(
+                sprintf('Invalid capture response for authorization %s', $authorizationId),
+                PsCheckoutException::PAYPAL_AUTHORIZATION_NOT_FOUND
+            );
+        }
 
         $authorizationEntity = $this->authorizationRepository->getById($authorizationId);
 

--- a/core/src/PayPal/Payment/Authorization/Action/ReauthorizeAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/ReauthorizeAuthorizationAction.php
@@ -96,9 +96,9 @@ final class ReauthorizeAuthorizationAction implements AuthorizationActionInterfa
         }
 
         try {
-            $authorizations = array_filter($payPalOrder->getAuthorizations(), static function (array $authorization) {
+            $authorizations = array_values(array_filter($payPalOrder->getAuthorizations(), static function (array $authorization) {
                 return in_array($authorization['status'], [PayPalAuthorizationStatus::CREATED, PayPalAuthorizationStatus::PARTIALLY_CAPTURED], true);
-            });
+            }));
         } catch (\Throwable $exception) {
             $this->logger->error('PayPal Order authorizations retrieval failed', ['exception' => $exception, 'order_id' => $payPalOrder->getId()]);
 

--- a/core/src/PayPal/Payment/Authorization/Action/VoidAuthorizationAction.php
+++ b/core/src/PayPal/Payment/Authorization/Action/VoidAuthorizationAction.php
@@ -24,12 +24,19 @@ use PsCheckout\Api\Http\PaymentHttpClientInterface;
 use PsCheckout\Api\ValueObject\PayPalOrderResponse;
 use PsCheckout\Core\Exception\PsCheckoutException;
 use PsCheckout\Core\PayPal\Order\Configuration\PayPalAuthorizationStatus;
+use PsCheckout\Core\PayPal\Order\Configuration\PayPalOrderIntent;
 use PsCheckout\Core\PayPal\Order\Entity\PayPalOrderAuthorization;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryInterface;
 use PsCheckout\Core\PayPal\Payment\Authorization\Configuration\AuthorizationAction;
+use Psr\Log\LoggerInterface;
 
 final class VoidAuthorizationAction implements AuthorizationActionInterface
 {
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     /**
      * @var PaymentHttpClientInterface
      */
@@ -41,9 +48,11 @@ final class VoidAuthorizationAction implements AuthorizationActionInterface
     private $authorizationRepository;
 
     public function __construct(
+        LoggerInterface $logger,
         PaymentHttpClientInterface $paymentHttpClient,
         PayPalOrderAuthorizationRepositoryInterface $authorizationRepository
     ) {
+        $this->logger = $logger;
         $this->paymentHttpClient = $paymentHttpClient;
         $this->authorizationRepository = $authorizationRepository;
     }
@@ -62,7 +71,7 @@ final class VoidAuthorizationAction implements AuthorizationActionInterface
     public function execute(PayPalOrderResponse $payPalOrder, array $payload = []): PayPalOrderAuthorization
     {
         // Check intent must be AUTHORIZE
-        if ($payPalOrder->getIntent() !== 'AUTHORIZE') {
+        if ($payPalOrder->getIntent() !== PayPalOrderIntent::AUTHORIZE) {
             throw new PsCheckoutException(
                 sprintf('PayPal Order %s intent must be AUTHORIZE, current intent: %s', $payPalOrder->getId(), $payPalOrder->getIntent()),
                 PsCheckoutException::PAYPAL_ORDER_INTENT_INVALID
@@ -97,7 +106,13 @@ final class VoidAuthorizationAction implements AuthorizationActionInterface
             );
         }
 
-        // Call captureAuthorization in PaymentHttpClient
+        $this->logger->info('Voiding authorization', [
+            'order_id' => $payPalOrder->getId(),
+            'authorization_id' => $authorizationId,
+            'authorization_status' => $authorizationStatus,
+        ]);
+
+        // Call voidAuthorization in PaymentHttpClient
         $voidResponse = $this->paymentHttpClient->voidAuthorization($authorizationId);
 
         /**
@@ -107,11 +122,16 @@ final class VoidAuthorizationAction implements AuthorizationActionInterface
          *      expiration_time: string,
          *      create_time: string,
          *      update_time: string
-         *  }|empty $voidedAuthorization
+         *  }|null $voidedAuthorization
          */
         $voidedAuthorization = json_decode($voidResponse->getBody(), true);
 
         if (empty($voidedAuthorization)) {
+            $this->logger->error('Invalid void response for authorization', [
+                'order_id' => $payPalOrder->getId(),
+                'authorization_id' => $authorizationId,
+            ]);
+
             throw new PsCheckoutException(
                 sprintf('Invalid void response for authorization %s', $authorizationId),
                 PsCheckoutException::PAYPAL_AUTHORIZATION_NOT_FOUND

--- a/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
+++ b/core/tests/Unit/PayPal/Payment/Authorization/Action/CaptureAuthorizationActionTest.php
@@ -33,9 +33,13 @@ use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryIn
 use PsCheckout\Core\Tests\Integration\Factory\PayPalOrderResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 
 class CaptureAuthorizationActionTest extends TestCase
 {
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
     /** @var PaymentHttpClientInterface|MockObject */
     private $paymentHttpClient;
 
@@ -49,10 +53,12 @@ class CaptureAuthorizationActionTest extends TestCase
     {
         parent::setUp();
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->paymentHttpClient = $this->createMock(PaymentHttpClientInterface::class);
         $this->authorizationRepository = $this->createMock(PayPalOrderAuthorizationRepositoryInterface::class);
 
         $this->action = new CaptureAuthorizationAction(
+            $this->logger,
             $this->paymentHttpClient,
             $this->authorizationRepository
         );

--- a/core/tests/Unit/PayPal/Payment/Authorization/Action/VoidAuthorizationActionTest.php
+++ b/core/tests/Unit/PayPal/Payment/Authorization/Action/VoidAuthorizationActionTest.php
@@ -33,26 +33,32 @@ use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderAuthorizationRepositoryIn
 use PsCheckout\Core\Tests\Integration\Factory\PayPalOrderResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 
 class VoidAuthorizationActionTest extends TestCase
 {
-    /** @var MockObject|PaymentHttpClientInterface  */
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    /** @var MockObject|PaymentHttpClientInterface */
     private $paymentHttpClient;
 
-    /** @var MockObject|PayPalOrderAuthorizationRepositoryInterface  */
+    /** @var MockObject|PayPalOrderAuthorizationRepositoryInterface */
     private $authorizationRepository;
 
-    /** @var VoidAuthorizationAction  */
+    /** @var VoidAuthorizationAction */
     private $action;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->paymentHttpClient = $this->createMock(PaymentHttpClientInterface::class);
         $this->authorizationRepository = $this->createMock(PayPalOrderAuthorizationRepositoryInterface::class);
 
         $this->action = new VoidAuthorizationAction(
+            $this->logger,
             $this->paymentHttpClient,
             $this->authorizationRepository
         );

--- a/ps17/config/shared/process.yml
+++ b/ps17/config/shared/process.yml
@@ -170,6 +170,7 @@ services:
   PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 
@@ -185,6 +186,7 @@ services:
   PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 

--- a/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1025,13 +1025,8 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         if ($amount) {
             $payload['amount'] = [
                 'value' => $amount,
+                'currency_code' => $currency ?: $paypalOrderResponse->getOrderAmount()['currency_code'],
             ];
-        }
-
-        if ($currency) {
-            $payload['amount']['currency_code'] = $currency;
-        } else {
-            $payload['amount']['currency_code'] = $paypalOrderResponse->getOrderAmount()['currency_code'];
         }
 
         /** @var AuthorizationActionProcessor $processor */

--- a/ps8/config/shared/process.yml
+++ b/ps8/config/shared/process.yml
@@ -179,12 +179,14 @@ services:
   PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 
   PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 

--- a/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1008,13 +1008,8 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         if ($amount) {
             $payload['amount'] = [
                 'value' => $amount,
+                'currency_code' => $currency ?: $paypalOrderResponse->getOrderAmount()['currency_code'],
             ];
-        }
-
-        if ($currency) {
-            $payload['amount']['currency_code'] = $currency;
-        } else {
-            $payload['amount']['currency_code'] = $paypalOrderResponse->getOrderAmount()['currency_code'];
         }
 
         /** @var AuthorizationActionProcessor $processor */

--- a/ps9/config/shared/process.yml
+++ b/ps9/config/shared/process.yml
@@ -170,6 +170,7 @@ services:
   PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\CaptureAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 
@@ -185,6 +186,7 @@ services:
   PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction:
     class: PsCheckout\Core\PayPal\Payment\Authorization\Action\VoidAuthorizationAction
     arguments:
+      - '@Psr\Log\LoggerInterface'
       - '@PsCheckout\Api\Http\PaymentHttpClient'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderAuthorizationRepository'
 

--- a/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1009,13 +1009,8 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
         if ($amount) {
             $payload['amount'] = [
                 'value' => $amount,
+                'currency_code' => $currency ?: $paypalOrderResponse->getOrderAmount()['currency_code'],
             ];
-        }
-
-        if ($currency) {
-            $payload['amount']['currency_code'] = $currency;
-        } else {
-            $payload['amount']['currency_code'] = $paypalOrderResponse->getOrderAmount()['currency_code'];
         }
 
         /** @var AuthorizationActionProcessor $processor */


### PR DESCRIPTION
## Summary

- **Validate `json_decode` result** in `CaptureAuthorizationAction` before accessing fields, preventing undefined index errors on malformed PayPal responses
- **Fix capture payload** in admin controllers (`ps{8,9,17}`) to only include `amount` when a value is present — PayPal requires both `value` and `currency_code` or neither
- **Wrap `array_filter` with `array_values`** in `ReauthorizeAuthorizationAction` to prevent index mismatch when first authorization is filtered out
- **Add `LoggerInterface`** to `CaptureAuthorizationAction` and `VoidAuthorizationAction` for action-level debugging (matching `ReauthorizeAuthorizationAction`)
- **Replace hardcoded `'AUTHORIZE'`** with `PayPalOrderIntent::AUTHORIZE` constant in `VoidAuthorizationAction`
- **Fix invalid PHPDoc** `|empty` type → `|null` and correct copy-paste comment in `VoidAuthorizationAction`

Jira: https://forge.prestashop.com/browse/PAYSHIP-3983

## Test plan

- [x] Verify full capture (no amount) from admin panel sends valid payload to PayPal (no `amount` key)
- [x] Verify partial capture (with amount) includes both `value` and `currency_code`
- [x] Verify void authorization action logs and validates response correctly
- [x] Verify reauthorization works when first authorization in list doesn't match filter criteria
- [x] Run `make phpstan` for all versions
- [x] Run `make unit-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)