### PR TITLE
[PAYSHIP-3996] Fix order stuck in Partial payment after full multi-capture

### DIFF
--- a/core/src/OrderState/Action/SetCompletedOrderStateAction.php
+++ b/core/src/OrderState/Action/SetCompletedOrderStateAction.php
@@ -25,6 +25,7 @@ use PsCheckout\Core\Order\Validator\OrderAmountValidator;
 use PsCheckout\Core\Order\Validator\OrderAmountValidatorInterface;
 use PsCheckout\Core\OrderState\Configuration\OrderStateConfiguration;
 use PsCheckout\Core\OrderState\Service\OrderStateMapperInterface;
+use PsCheckout\Core\PayPal\Order\Configuration\PayPalCaptureStatus;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProviderInterface;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Infrastructure\Repository\OrderRepositoryInterface;
@@ -99,7 +100,11 @@ class SetCompletedOrderStateAction implements SetOrderStateActionInterface
             return;
         }
 
-        $totalCaptured = array_reduce($payPalOrderResponse->getCaptures(), function ($totalCaptured, $capture) {
+        $completedCaptures = array_filter($payPalOrderResponse->getCaptures(), function ($capture) {
+            return isset($capture['status']) && $capture['status'] === PayPalCaptureStatus::COMPLETED;
+        });
+
+        $totalCaptured = array_reduce($completedCaptures, function ($totalCaptured, $capture) {
             return $totalCaptured + (float) $capture['amount']['value'];
         }, 0.0);
 

--- a/core/src/OrderState/Action/SetCompletedOrderStateAction.php
+++ b/core/src/OrderState/Action/SetCompletedOrderStateAction.php
@@ -93,13 +93,19 @@ class SetCompletedOrderStateAction implements SetOrderStateActionInterface
         /** @var \Order|null $order */
         $order = $this->orderRepository->getOneBy(['id_cart' => $payPalOrder->getIdCart()]);
 
-        if (!$order || $order->hasBeenPaid()) {
+        $completedStateId = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+
+        if (!$order || (int) $order->getCurrentState() === $completedStateId) {
             return;
         }
 
+        $totalCaptured = array_reduce($payPalOrderResponse->getCaptures(), function ($totalCaptured, $capture) {
+            return $totalCaptured + (float) $capture['amount']['value'];
+        }, 0.0);
+
         switch ($this->orderAmountValidator->validate(
             (string) $order->total_paid,
-            (string) $payPalOrderResponse->getCapture()['amount']['value']
+            (string) round($totalCaptured, 2)
         )) {
             case OrderAmountValidator::ORDER_FULL_PAID:
             case OrderAmountValidator::ORDER_TO_MUCH_PAID:

--- a/core/src/OrderState/Action/SetCompletedOrderStateAction.php
+++ b/core/src/OrderState/Action/SetCompletedOrderStateAction.php
@@ -94,9 +94,14 @@ class SetCompletedOrderStateAction implements SetOrderStateActionInterface
         /** @var \Order|null $order */
         $order = $this->orderRepository->getOneBy(['id_cart' => $payPalOrder->getIdCart()]);
 
-        $completedStateId = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+        if (!$order) {
+            return;
+        }
 
-        if (!$order || (int) $order->getCurrentState() === $completedStateId) {
+        $completedStateId = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+        $hasBeenCompleted = count($order->getHistory($order->id_lang, $completedStateId)) > 0;
+
+        if ($hasBeenCompleted) {
             return;
         }
 

--- a/core/src/OrderState/Action/SetCompletedOrderStateAction.php
+++ b/core/src/OrderState/Action/SetCompletedOrderStateAction.php
@@ -105,8 +105,14 @@ class SetCompletedOrderStateAction implements SetOrderStateActionInterface
             return;
         }
 
-        $completedCaptures = array_filter($payPalOrderResponse->getCaptures(), function ($capture) {
-            return isset($capture['status']) && $capture['status'] === PayPalCaptureStatus::COMPLETED;
+        $capturedStatuses = [
+            PayPalCaptureStatus::COMPLETED,
+            PayPalCaptureStatus::PARTIALLY_REFUNDED,
+            PayPalCaptureStatus::REFUND,
+        ];
+
+        $completedCaptures = array_filter($payPalOrderResponse->getCaptures(), function ($capture) use ($capturedStatuses) {
+            return isset($capture['status']) && in_array($capture['status'], $capturedStatuses, true);
         });
 
         $totalCaptured = array_reduce($completedCaptures, function ($totalCaptured, $capture) {

--- a/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
+++ b/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
@@ -164,6 +164,60 @@ class SetCompletedOrderStateActionTest extends BaseTestCase
         $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
     }
 
+    public function testItShouldChangeStateToCompletedWithMultiplePartialCaptures(): void
+    {
+        $partiallyPaidStateId = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_PARTIALLY_PAID);
+        $order = OrderFactory::create(['total_paid' => 34.80, 'current_state' => $partiallyPaidStateId]);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [
+                        [
+                            'amount' => [
+                                'currency_code' => 'EUR',
+                                'value' => '14.80',
+                            ],
+                        ],
+                        [
+                            'amount' => [
+                                'currency_code' => 'EUR',
+                                'value' => '20.00',
+                            ],
+                        ],
+                    ],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        $expectedStatus = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
+    }
+
     public function testItShouldThrowPayPalOrderDoesNotExistException(): void
     {
         $this->expectException(PsCheckoutException::class);

--- a/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
+++ b/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
@@ -222,6 +222,283 @@ class SetCompletedOrderStateActionTest extends BaseTestCase
         $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
     }
 
+    public function testItShouldNotChangeStateWhenOrderHasAlreadyBeenCompleted(): void
+    {
+        $completedStateId = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+        $order = OrderFactory::create(['total_paid' => 29.00, 'current_state' => $completedStateId]);
+
+        // Simulate that order has been moved past Completed by another module
+        $shippedStateId = 4; // PS default "Shipped" state
+        $order->setCurrentState($shippedStateId);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [[
+                        'status' => 'COMPLETED',
+                        'amount' => [
+                            'currency_code' => 'EUR',
+                            'value' => '29.00',
+                        ],
+                    ]],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        // Order should remain in Shipped state, not regress to Completed
+        $this->assertEquals($shippedStateId, (int) (new \Order($order->id))->current_state);
+    }
+
+    public function testItShouldChangeStateToCompletedWhenCaptureIsPartiallyRefunded(): void
+    {
+        $order = OrderFactory::create(['total_paid' => 29.00]);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [[
+                        'status' => 'PARTIALLY_REFUNDED',
+                        'amount' => [
+                            'currency_code' => 'EUR',
+                            'value' => '29.00',
+                        ],
+                    ]],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        $expectedStatus = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
+    }
+
+    public function testItShouldChangeStateToCompletedWhenCaptureIsFullyRefunded(): void
+    {
+        $order = OrderFactory::create(['total_paid' => 29.00]);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [[
+                        'status' => 'REFUND',
+                        'amount' => [
+                            'currency_code' => 'EUR',
+                            'value' => '29.00',
+                        ],
+                    ]],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        $expectedStatus = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
+    }
+
+    public function testItShouldNotCountPendingCapturesInTotal(): void
+    {
+        $order = OrderFactory::create(['total_paid' => 29.00]);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [
+                        [
+                            'status' => 'COMPLETED',
+                            'amount' => [
+                                'currency_code' => 'EUR',
+                                'value' => '15.00',
+                            ],
+                        ],
+                        [
+                            'status' => 'PENDING',
+                            'amount' => [
+                                'currency_code' => 'EUR',
+                                'value' => '14.00',
+                            ],
+                        ],
+                    ],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        $expectedStatus = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_PARTIALLY_PAID);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
+    }
+
+    public function testItShouldChangeStateToCompletedWhenOverpaid(): void
+    {
+        $order = OrderFactory::create(['total_paid' => 29.00]);
+
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [[
+                        'status' => 'COMPLETED',
+                        'amount' => [
+                            'currency_code' => 'EUR',
+                            'value' => '35.00',
+                        ],
+                    ]],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_order' => $order->id,
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn($order);
+
+        $expectedStatus = $this->orderStateMapper->getIdByKey(OrderStateConfiguration::PS_CHECKOUT_STATE_COMPLETED);
+
+        try {
+            $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+        } catch (Exception $e) {
+            if ($e->getCode() === OrderException::FAILED_UPDATE_ORDER_STATUS) {
+                // NOTE: Email sending causes this error
+            }
+        }
+
+        $this->assertEquals($expectedStatus, (new \Order($order->id))->current_state);
+    }
+
+    public function testItShouldReturnEarlyWhenOrderNotFound(): void
+    {
+        $payPalOrderResponseData = [
+            'purchase_units' => [[
+                'payments' => [
+                    'captures' => [[
+                        'status' => 'COMPLETED',
+                        'amount' => [
+                            'currency_code' => 'EUR',
+                            'value' => '29.00',
+                        ],
+                    ]],
+                ],
+            ]],
+        ];
+
+        $payPalOrderResponse = PayPalOrderResponseFactory::create($payPalOrderResponseData);
+
+        $this->payPalOrderRepository->save(PayPalOrderFactory::create([
+            'id_paypal_order' => $payPalOrderResponse->getId(),
+        ]));
+
+        $this->payPalOrderProviderMock->expects($this->once())
+            ->method('getById')
+            ->willReturn($payPalOrderResponse);
+
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('getOneBy')
+            ->willReturn(null);
+
+        // Should not throw any exception
+        $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
+    }
+
     public function testItShouldThrowPayPalOrderDoesNotExistException(): void
     {
         $this->expectException(PsCheckoutException::class);

--- a/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
+++ b/core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
@@ -79,6 +79,7 @@ class SetCompletedOrderStateActionTest extends BaseTestCase
             'purchase_units' => [[
                 'payments' => [
                     'captures' => [[
+                        'status' => 'COMPLETED',
                         'amount' => [
                             'currency_code' => 'EUR',
                             'value' => '29.00',
@@ -126,6 +127,7 @@ class SetCompletedOrderStateActionTest extends BaseTestCase
             'purchase_units' => [[
                 'payments' => [
                     'captures' => [[
+                        'status' => 'COMPLETED',
                         'amount' => [
                             'currency_code' => 'EUR',
                             'value' => '15.00',
@@ -174,12 +176,14 @@ class SetCompletedOrderStateActionTest extends BaseTestCase
                 'payments' => [
                     'captures' => [
                         [
+                            'status' => 'COMPLETED',
                             'amount' => [
                                 'currency_code' => 'EUR',
                                 'value' => '14.80',
                             ],
                         ],
                         [
+                            'status' => 'COMPLETED',
                             'amount' => [
                                 'currency_code' => 'EUR',
                                 'value' => '20.00',

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -2989,24 +2989,6 @@ parameters:
 			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Offset ''amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
 			message: '#^Parameter \#1 \$orderId of method PsCheckout\\Core\\OrderState\\Action\\ChangeOrderStateActionInterface\:\:execute\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7431,49 +7413,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -7413,49 +7413,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -7407,49 +7407,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -2977,24 +2977,6 @@ parameters:
 			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Offset ''amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
 			message: '#^Parameter \#1 \$orderId of method PsCheckout\\Core\\OrderState\\Action\\ChangeOrderStateActionInterface\:\:execute\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7425,49 +7407,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -7407,49 +7407,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 10
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 9
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 18
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -2977,24 +2977,6 @@ parameters:
 			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
-			message: '#^Offset ''amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: ../core/src/OrderState/Action/SetCompletedOrderStateAction.php
-
-		-
 			message: '#^Parameter \#1 \$orderId of method PsCheckout\\Core\\OrderState\\Action\\ChangeOrderStateActionInterface\:\:execute\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7425,49 +7407,49 @@ parameters:
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$orderRepositoryMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Access to an undefined property PsCheckout\\Core\\Tests\\Integration\\OrderState\\Action\\SetCompletedOrderStateActionTest\:\:\$payPalOrderProviderMock\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on PsCheckout\\Core\\OrderState\\Action\\SetCompletedOrderStateAction\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method getIdByKey\(\) on PsCheckout\\Core\\OrderState\\Service\\OrderStateMapper\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 4
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method save\(\) on PsCheckout\\Infrastructure\\Repository\\PayPalOrderRepository\|null\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 6
 			path: ../core/tests/Integration/OrderState/Action/SetCompletedOrderStateActionTest.php
 
 		-


### PR DESCRIPTION
## Summary

- Fix order status not transitioning from "Partial payment" to "Payment accepted" when multiple partial captures sum to the full authorization amount
- Replace `hasBeenPaid()` guard with a check against the COMPLETED state only, allowing partially-paid orders to be re-evaluated on subsequent capture webhooks
- Sum all captures using `getCaptures()` + `array_reduce()` instead of comparing only the first capture via `getCapture()`

## Related

- [PAYSHIP-3996](https://forge.prestashop.com/browse/PAYSHIP-3996)

## Test plan

- [x] Create an order with AUTHORIZE intent
- [x] Perform a first partial capture (amount < order total) → order should transition to "Partial payment"
- [x] Perform a second capture for the remaining amount → order should transition to "Payment accepted"
- [x] Verify a single full capture still transitions directly to "Payment accepted"
- [x] Verify an already-completed order is not re-processed on duplicate webhooks
- [x] Run `make phpstan` for all MODULE_VERSION values
- [x] Run `make integration-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)