### PR TITLE
[XO-2933] Fix untranslated authorization confirmation modal messages

### DIFF
--- a/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps17/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1060,7 +1060,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1077,7 +1080,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1094,7 +1100,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization reauthorized successfully.'));
     }
 
     /**

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -12363,7 +12363,7 @@ parameters:
 		-
 			message: '#^Call to method l\(\) on an unknown class Ps_Checkout\.$#'
 			identifier: class.notFound
-			count: 142
+			count: 145
 			path: src/Presentation/Translator.php
 
 		-

--- a/ps17/src/Presentation/Translator.php
+++ b/ps17/src/Presentation/Translator.php
@@ -186,6 +186,9 @@ class Translator implements TranslatorInterface
             'No PrestaShop Order identifier received' => $this->module->l('No PrestaShop Order identifier received', 'Translator'),
             'Unable to find PayPal Order associated to this PrestaShop Order %s' => $this->module->l('Unable to find PayPal Order associated to this PrestaShop Order %s', 'Translator'),
             'PayPal Order %s is not in the same environment as PrestaShop Checkout' => $this->module->l('PayPal Order %s is not in the same environment as PrestaShop Checkout', 'Translator'),
+            'Authorization captured successfully.' => $this->module->l('Authorization captured successfully.', 'Translator'),
+            'Authorization voided successfully.' => $this->module->l('Authorization voided successfully.', 'Translator'),
+            'Authorization reauthorized successfully.' => $this->module->l('Authorization reauthorized successfully.', 'Translator'),
 
             'Eligible' => $this->module->l('Eligible', 'Translator'),
             'Partially eligible' => $this->module->l('Partially eligible', 'Translator'),

--- a/ps17/translations/en.php
+++ b/ps17/translations/en.php
@@ -275,3 +275,6 @@ $_MODULE['<{ps_checkout}prestashop>payuponinvoicefields_10803b83a68db8f7e7a33e3b
 $_MODULE['<{ps_checkout}prestashop>payuponinvoicefields_1e4dbc7eaa78468a3bc1448a3d68d906'] = 'Phone Number';
 $_MODULE['<{ps_checkout}prestashop>create_ae5057b6f8ec245f3ab53add8cee8bbe'] = 'The payment is not valid: the amount is not eligible.';
 $_MODULE['<{ps_checkout}prestashop>translator_92d485617457c66799814fa3ea9cc50b'] = 'An unexpected refund error occurred.';
+$_MODULE['<{ps_checkout}prestashop>translator_3369ba2ed7cf53ddee6687b80ca28724'] = 'Authorization captured successfully.';
+$_MODULE['<{ps_checkout}prestashop>translator_46b0801bbbd67d6f88169ac8d958176d'] = 'Authorization voided successfully.';
+$_MODULE['<{ps_checkout}prestashop>translator_d7711b029221c7de1444292a4068bfee'] = 'Authorization reauthorized successfully.';

--- a/ps17/translations/fr.php
+++ b/ps17/translations/fr.php
@@ -269,3 +269,6 @@ $_MODULE['<{ps_checkout}prestashop>translator_a995e3f4789afc5c69be0f2c4a283fe3']
 $_MODULE['<{ps_checkout}prestashop>translator_a973592aec4f4e71998a112ec707c8ee'] = 'Le payeur a payé un article qu\'il n\'a pas reçu.';
 $_MODULE['<{ps_checkout}prestashop>translator_0c27df1feb8791f6c99a775a03b3293b'] = 'Le payeur n\'a pas autorisé le paiement.';
 $_MODULE['<{ps_checkout}prestashop>translator_92d485617457c66799814fa3ea9cc50b'] = 'Une erreur inattendue s\'est produite lors du remboursement.';
+$_MODULE['<{ps_checkout}prestashop>translator_3369ba2ed7cf53ddee6687b80ca28724'] = 'L\'autorisation a été capturée avec succès.';
+$_MODULE['<{ps_checkout}prestashop>translator_46b0801bbbd67d6f88169ac8d958176d'] = 'L\'autorisation a été annulée avec succès.';
+$_MODULE['<{ps_checkout}prestashop>translator_d7711b029221c7de1444292a4068bfee'] = 'L\'autorisation a été renouvelée avec succès.';

--- a/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps8/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1052,7 +1052,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1069,7 +1072,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1086,7 +1092,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization reauthorized successfully.'));
     }
 
     /**

--- a/ps8/src/Presentation/Translator.php
+++ b/ps8/src/Presentation/Translator.php
@@ -186,6 +186,9 @@ class Translator implements TranslatorInterface
             'No PrestaShop Order identifier received' => $this->translator->trans('No PrestaShop Order identifier received', $parameters, 'Modules.Checkout.Pscheckout'),
             'Unable to find PayPal Order associated to this PrestaShop Order %s' => $this->translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', $parameters, 'Modules.Checkout.Pscheckout'),
             'PayPal Order %s is not in the same environment as PrestaShop Checkout' => $this->translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization captured successfully.' => $this->translator->trans('Authorization captured successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization voided successfully.' => $this->translator->trans('Authorization voided successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization reauthorized successfully.' => $this->translator->trans('Authorization reauthorized successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
 
             'Eligible' => $this->translator->trans('Eligible', $parameters, 'Modules.Checkout.Pscheckout'),
             'Partially eligible' => $this->translator->trans('Partially eligible', $parameters, 'Modules.Checkout.Pscheckout'),

--- a/ps8/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
+++ b/ps8/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
@@ -2491,6 +2491,18 @@
         <source>An unexpected refund error occurred.</source>
         <target>An unexpected refund error occurred.</target>
       </trans-unit>
+      <trans-unit id="3369ba2ed7cf53ddee6687b80ca28724">
+        <source>Authorization captured successfully.</source>
+        <target>Authorization captured successfully.</target>
+      </trans-unit>
+      <trans-unit id="46b0801bbbd67d6f88169ac8d958176d">
+        <source>Authorization voided successfully.</source>
+        <target>Authorization voided successfully.</target>
+      </trans-unit>
+      <trans-unit id="d7711b029221c7de1444292a4068bfee">
+        <source>Authorization reauthorized successfully.</source>
+        <target>Authorization reauthorized successfully.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ps8/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
+++ b/ps8/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
@@ -2467,6 +2467,18 @@
         <source>An unexpected refund error occurred.</source>
         <target>Une erreur inattendue s'est produite lors du remboursement.</target>
       </trans-unit>
+      <trans-unit id="3369ba2ed7cf53ddee6687b80ca28724">
+        <source>Authorization captured successfully.</source>
+        <target>L'autorisation a été capturée avec succès.</target>
+      </trans-unit>
+      <trans-unit id="46b0801bbbd67d6f88169ac8d958176d">
+        <source>Authorization voided successfully.</source>
+        <target>L'autorisation a été annulée avec succès.</target>
+      </trans-unit>
+      <trans-unit id="d7711b029221c7de1444292a4068bfee">
+        <source>Authorization reauthorized successfully.</source>
+        <target>L'autorisation a été renouvelée avec succès.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
+++ b/ps9/controllers/admin/AdminAjaxPrestashopCheckoutController.php
@@ -1053,7 +1053,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization captured successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization captured successfully.'));
     }
 
     public function ajaxProcessVoidAuthorization()
@@ -1070,7 +1073,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization voided successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization voided successfully.'));
     }
 
     public function ajaxProcessReauthorizeAuthorization()
@@ -1087,7 +1093,10 @@ class AdminAjaxPrestashopCheckoutController extends AbstractAdminController
             $this->exitWithResponse($result);
         }
 
-        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $this->module->l('Authorization reauthorized successfully.'));
+        /** @var Translator $translator */
+        $translator = $this->module->getService(Translator::class);
+
+        $this->exitWithRefreshedOrderData($payPalOrder->getId(), $isProductionEnv, $translator->trans('Authorization reauthorized successfully.'));
     }
 
     /**

--- a/ps9/src/Presentation/Translator.php
+++ b/ps9/src/Presentation/Translator.php
@@ -186,6 +186,9 @@ class Translator implements TranslatorInterface
             'No PrestaShop Order identifier received' => $this->translator->trans('No PrestaShop Order identifier received', $parameters, 'Modules.Checkout.Pscheckout'),
             'Unable to find PayPal Order associated to this PrestaShop Order %s' => $this->translator->trans('Unable to find PayPal Order associated to this PrestaShop Order %s', $parameters, 'Modules.Checkout.Pscheckout'),
             'PayPal Order %s is not in the same environment as PrestaShop Checkout' => $this->translator->trans('PayPal Order %s is not in the same environment as PrestaShop Checkout', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization captured successfully.' => $this->translator->trans('Authorization captured successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization voided successfully.' => $this->translator->trans('Authorization voided successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
+            'Authorization reauthorized successfully.' => $this->translator->trans('Authorization reauthorized successfully.', $parameters, 'Modules.Checkout.Pscheckout'),
 
             'Eligible' => $this->translator->trans('Eligible', $parameters, 'Modules.Checkout.Pscheckout'),
             'Partially eligible' => $this->translator->trans('Partially eligible', $parameters, 'Modules.Checkout.Pscheckout'),

--- a/ps9/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
+++ b/ps9/translations/en-US/ModulesCheckoutPscheckout.en-US.xlf
@@ -2491,6 +2491,18 @@
         <source>An unexpected refund error occurred.</source>
         <target>An unexpected refund error occurred.</target>
       </trans-unit>
+      <trans-unit id="3369ba2ed7cf53ddee6687b80ca28724">
+        <source>Authorization captured successfully.</source>
+        <target>Authorization captured successfully.</target>
+      </trans-unit>
+      <trans-unit id="46b0801bbbd67d6f88169ac8d958176d">
+        <source>Authorization voided successfully.</source>
+        <target>Authorization voided successfully.</target>
+      </trans-unit>
+      <trans-unit id="d7711b029221c7de1444292a4068bfee">
+        <source>Authorization reauthorized successfully.</source>
+        <target>Authorization reauthorized successfully.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ps9/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
+++ b/ps9/translations/fr-FR/ModulesCheckoutPscheckout.fr-FR.xlf
@@ -2467,6 +2467,18 @@
         <source>An unexpected refund error occurred.</source>
         <target>Une erreur inattendue s'est produite lors du remboursement.</target>
       </trans-unit>
+      <trans-unit id="3369ba2ed7cf53ddee6687b80ca28724">
+        <source>Authorization captured successfully.</source>
+        <target>L'autorisation a été capturée avec succès.</target>
+      </trans-unit>
+      <trans-unit id="46b0801bbbd67d6f88169ac8d958176d">
+        <source>Authorization voided successfully.</source>
+        <target>L'autorisation a été annulée avec succès.</target>
+      </trans-unit>
+      <trans-unit id="d7711b029221c7de1444292a4068bfee">
+        <source>Authorization reauthorized successfully.</source>
+        <target>L'autorisation a été renouvelée avec succès.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

- Replaced `$this->module->l()` with `$translator->trans()` for authorization capture, void, and reauthorize success messages in admin AJAX controllers (ps8, ps9, ps17)
- Added corresponding translation mappings in each version's `Translator.php`
- Added French translations to XLIFF catalogues (ps8, ps9) and PHP translation files (ps17)

## Test plan

- [x] Set shop language to French
- [x] Capture an authorization → confirmation modal should show "L'autorisation a été capturée avec succès."
- [x] Void an authorization → confirmation modal should show "L'autorisation a été annulée avec succès."
- [x] Verify English locale still shows English messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)