### PR TITLE
[XO-2944] Added int casting for order state

### DIFF
--- a/core/src/OrderState/Action/ChangeOrderStateAction.php
+++ b/core/src/OrderState/Action/ChangeOrderStateAction.php
@@ -79,7 +79,7 @@ class ChangeOrderStateAction implements ChangeOrderStateActionInterface
             throw new OrderException(sprintf('The OrderState #%d does not exist', $newOrderStateId), OrderStateException::INVALID_ID);
         }
 
-        if ($order->getCurrentState() === $newOrderState->id) {
+        if ((int) $order->getCurrentState() === (int) $newOrderState->id) {
             throw new OrderException(sprintf('The order #%d has already been assigned to OrderState #%d', $orderId, $newOrderState->id), OrderException::ORDER_HAS_ALREADY_THIS_STATUS);
         }
 


### PR DESCRIPTION
Casts order state in ChangeOrderStateAction, which as we suspect could be the cause for having the same order state applied few times in a row.