### PR TITLE
fix(paypal): send single purchase_unit object in PATCH instead of array

### DIFF
--- a/core/src/PayPal/Order/Processor/UpdateExternalPayPalOrderProcessor.php
+++ b/core/src/PayPal/Order/Processor/UpdateExternalPayPalOrderProcessor.php
@@ -159,7 +159,7 @@ class UpdateExternalPayPalOrderProcessor implements UpdateExternalPayPalOrderPro
             [
                 'op' => 'replace',
                 'path' => "/purchase_units/@reference_id=='$purchaseUnitReferenceId'",
-                'value' => $payload['purchase_units'],
+                'value' => $payload['purchase_units'][0],
             ],
         ];
 

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -4311,7 +4311,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 5
 			path: ../core/src/PayPal/Order/Processor/UpdateExternalPayPalOrderProcessor.php
 
 		-
@@ -8753,6 +8753,126 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/tests/Unit/PayPal/Card3DSecure/Card3DSecureValidatorTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
 
 		-
 			message: '#^Class PsCheckout\\Api\\ValueObject\\PayPalOrderResponse constructor invoked with 8 parameters, 7 required\.$#'

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -4311,7 +4311,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 5
 			path: ../core/src/PayPal/Order/Processor/UpdateExternalPayPalOrderProcessor.php
 
 		-
@@ -8759,6 +8759,126 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/tests/Unit/PayPal/Card3DSecure/Card3DSecureValidatorTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
 
 		-
 			message: '#^Class PsCheckout\\Api\\ValueObject\\PayPalOrderResponse constructor invoked with 8 parameters, 7 required\.$#'

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -4311,7 +4311,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 5
 			path: ../core/src/PayPal/Order/Processor/UpdateExternalPayPalOrderProcessor.php
 
 		-
@@ -8759,6 +8759,126 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/tests/Unit/PayPal/Card3DSecure/Card3DSecureValidatorTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderApprovedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#1 \$id of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#10 \$customerIntent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#2 \$idCart of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#3 \$intent of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#4 \$fundingSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#5 \$status of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#6 \$paymentSource of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#7 \$environment of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#8 \$isCardFields of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
+
+		-
+			message: '#^Parameter \#9 \$isExpressCheckout of class PsCheckout\\Core\\PayPal\\Order\\Entity\\PayPalOrder constructor expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../core/tests/Unit/PayPal/Order/Handler/OrderCompletedEventHandlerTest.php
 
 		-
 			message: '#^Class PsCheckout\\Api\\ValueObject\\PayPalOrderResponse constructor invoked with 8 parameters, 7 required\.$#'


### PR DESCRIPTION
The PATCH operation on /purchase_units/@reference_id=='default' was incorrectly sending the full purchase_units array as value, causing INVALID_PARAMETER_SYNTAX.

PayPal expects a single purchase_unit object for this path, not an array.

## Self-Checks
- [ ] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: [XXXX](https://forge.prestashop.com/browse/XXXX)

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->

## QA Checklist Labels
- [ ] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->

## Additional Context
<!-- Provide a concise description of the changes made in this PR. -->

## Frontend Changes
<!-- If applicable, provide visual elements such as screenshots, GIFs, or videos to demonstrate frontend changes. -->
<br><br>

[!] Don't forget to include JIRA task number in PR name or branch name. [!]

[!] Don't forget to update *changelog.md* with new changes. [!]

- [ ] Verify if the version is correct.
- [ ] Update demo environments used for testing.
- [ ] Ensure changelog contains all changes.
- [ ] Update documentation if needed.
- [ ] Test if everything works properly.