### PR TITLE
Fix/duplicate order on cart race

### DIFF
--- a/core/src/Order/Action/CreateOrderAction.php
+++ b/core/src/Order/Action/CreateOrderAction.php
@@ -23,6 +23,7 @@ namespace PsCheckout\Core\Order\Action;
 use PsCheckout\Api\ValueObject\PayPalOrderResponse;
 use PsCheckout\Core\Exception\PsCheckoutException;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderMatrixRepositoryInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Infrastructure\Adapter\ContextInterface;
 use PsCheckout\Infrastructure\Repository\OrderRepositoryInterface;
 
@@ -53,18 +54,25 @@ class CreateOrderAction implements CreateOrderActionInterface
      */
     private $orderMatrixRepository;
 
+    /**
+     * @var PayPalOrderRepositoryInterface
+     */
+    private $payPalOrderRepository;
+
     public function __construct(
         ContextInterface $context,
         CreateValidateOrderDataActionInterface $createValidateOrderDataAction,
         ValidateOrderActionInterface $validateOrderAction,
         OrderRepositoryInterface $orderRepository,
-        PayPalOrderMatrixRepositoryInterface $orderMatrixRepository
+        PayPalOrderMatrixRepositoryInterface $orderMatrixRepository,
+        PayPalOrderRepositoryInterface $payPalOrderRepository
     ) {
         $this->context = $context;
         $this->createValidateOrderDataAction = $createValidateOrderDataAction;
         $this->validateOrderAction = $validateOrderAction;
         $this->orderRepository = $orderRepository;
         $this->orderMatrixRepository = $orderMatrixRepository;
+        $this->payPalOrderRepository = $payPalOrderRepository;
     }
 
     /**
@@ -72,6 +80,21 @@ class CreateOrderAction implements CreateOrderActionInterface
      */
     public function execute(PayPalOrderResponse $payPalOrder)
     {
+        $localPayPalOrder = $this->payPalOrderRepository->getOneBy(['id' => $payPalOrder->getId()]);
+        if ($localPayPalOrder !== null) {
+            $expectedCartId = (int) $localPayPalOrder->getIdCart();
+            $contextCart = $this->context->getCart();
+            if ($expectedCartId > 0 && (!$contextCart || (int) $contextCart->id !== $expectedCartId)) {
+                $cart = new \Cart($expectedCartId);
+                if (\Validate::isLoadedObject($cart)) {
+                    $this->context->setCurrentCart($cart);
+                    if ($cart->id_customer) {
+                        $this->context->updateCustomer(new \Customer($cart->id_customer));
+                    }
+                }
+            }
+        }
+
         $cartId = (int) $this->context->getCart()->id;
         $db = null;
 

--- a/core/src/Order/Action/CreateOrderAction.php
+++ b/core/src/Order/Action/CreateOrderAction.php
@@ -72,7 +72,24 @@ class CreateOrderAction implements CreateOrderActionInterface
      */
     public function execute(PayPalOrderResponse $payPalOrder)
     {
+        $cartId = (int) $this->context->getCart()->id;
+        $db = null;
+
         try {
+            if ($cartId > 0) {
+                $db = \Db::getInstance();
+                $db->execute('SELECT GET_LOCK("ps_checkout_cart_' . $cartId . '", 10)');
+
+                $existingOrders = $this->orderRepository->getAllBy(['id_cart' => $cartId]);
+                if (!empty($existingOrders)) {
+                    foreach ($existingOrders as $order) {
+                        $this->orderMatrixRepository->upsert((int) $order->id, $cartId);
+                    }
+
+                    return;
+                }
+            }
+
             $validateOrderData = $this->createValidateOrderDataAction->execute($payPalOrder);
 
             $this->validateOrderAction->execute($validateOrderData);
@@ -86,6 +103,10 @@ class CreateOrderAction implements CreateOrderActionInterface
             throw $exception;
         } catch (\Exception $exception) {
             throw new PsCheckoutException($exception->getMessage(), PsCheckoutException::UNKNOWN);
+        } finally {
+            if ($db !== null) {
+                $db->execute('SELECT RELEASE_LOCK("ps_checkout_cart_' . $cartId . '")');
+            }
         }
     }
 }

--- a/core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
+++ b/core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
@@ -24,6 +24,7 @@ use PsCheckout\Api\ValueObject\PayPalOrderResponse;
 use PsCheckout\Core\Order\Action\CreateOrderActionInterface;
 use PsCheckout\Core\Order\Action\CreateOrderPaymentActionInterface;
 use PsCheckout\Core\OrderState\Action\SetOrderStateActionInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Infrastructure\Adapter\ContextInterface;
 
 class PaymentCompletedEventHandler implements EventHandlerInterface
@@ -48,16 +49,23 @@ class PaymentCompletedEventHandler implements EventHandlerInterface
      */
     private $context;
 
+    /**
+     * @var PayPalOrderRepositoryInterface
+     */
+    private $payPalOrderRepository;
+
     public function __construct(
         CreateOrderActionInterface $createOrderAction,
         CreateOrderPaymentActionInterface $createOrderPaymentAction,
         SetOrderStateActionInterface $setCompletedOrderStateAction,
-        ContextInterface $context
+        ContextInterface $context,
+        PayPalOrderRepositoryInterface $payPalOrderRepository
     ) {
         $this->createOrderAction = $createOrderAction;
         $this->createOrderPaymentAction = $createOrderPaymentAction;
         $this->setCompletedOrderStateAction = $setCompletedOrderStateAction;
         $this->context = $context;
+        $this->payPalOrderRepository = $payPalOrderRepository;
     }
 
     /**
@@ -65,6 +73,19 @@ class PaymentCompletedEventHandler implements EventHandlerInterface
      */
     public function handle(PayPalOrderResponse $payPalOrderResponse)
     {
+        if (!$this->context->getCart()->id) {
+            $payPalOrder = $this->payPalOrderRepository->getOneBy(['id' => $payPalOrderResponse->getId()]);
+            if ($payPalOrder && $payPalOrder->getIdCart()) {
+                $cart = new \Cart($payPalOrder->getIdCart());
+                if (\Validate::isLoadedObject($cart)) {
+                    $this->context->setCurrentCart($cart);
+                    if ($cart->id_customer) {
+                        $this->context->updateCustomer(new \Customer($cart->id_customer));
+                    }
+                }
+            }
+        }
+
         if ($this->context->getCart()->id) {
             $this->createOrderAction->execute($payPalOrderResponse);
             $this->createOrderPaymentAction->execute($payPalOrderResponse);

--- a/ps17/config/front/process.yml
+++ b/ps17/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction

--- a/ps17/config/front/process.yml
+++ b/ps17/config/front/process.yml
@@ -174,6 +174,7 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
       - '@PsCheckout\Infrastructure\Adapter\Context'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -1005,37 +1005,37 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\OrderRepositoryInterface\:\:getAllBy\(\)\.$#'
 			identifier: method.notFound
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Parameter \#1 \$payPalOrderId of method PsCheckout\\Core\\PayPal\\Order\\Repository\\PayPalOrderMatrixRepositoryInterface\:\:upsert\(\) expects string, int given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4107,7 +4107,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
 
 		-

--- a/ps8/config/front/process.yml
+++ b/ps8/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction

--- a/ps8/config/front/process.yml
+++ b/ps8/config/front/process.yml
@@ -174,6 +174,7 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
       - '@PsCheckout\Infrastructure\Adapter\Context'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -1041,37 +1041,37 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\OrderRepositoryInterface\:\:getAllBy\(\)\.$#'
 			identifier: method.notFound
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Parameter \#1 \$payPalOrderId of method PsCheckout\\Core\\PayPal\\Order\\Repository\\PayPalOrderMatrixRepositoryInterface\:\:upsert\(\) expects string, int given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4149,7 +4149,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
 
 		-

--- a/ps9/config/front/process.yml
+++ b/ps9/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction

--- a/ps9/config/front/process.yml
+++ b/ps9/config/front/process.yml
@@ -174,6 +174,7 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
       - '@PsCheckout\Infrastructure\Adapter\Context'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -1041,37 +1041,37 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\OrderRepositoryInterface\:\:getAllBy\(\)\.$#'
 			identifier: method.notFound
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot access property \$id on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
 			message: '#^Parameter \#1 \$payPalOrderId of method PsCheckout\\Core\\PayPal\\Order\\Repository\\PayPalOrderMatrixRepositoryInterface\:\:upsert\(\) expects string, int given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4149,7 +4149,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
 
 		-


### PR DESCRIPTION

## Self-Checks
- [x] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: N/A (bug reported from production logs)

## Summary

A `TypeError` thrown in the webhook event handlers when no customer session is bound to `Context` caused the webhook path to fail silently: no PrestaShop order was created, the customer saw an apparent payment failure, retried, and PrestaShop allocated a new cart (keeping the same products) — producing a second successful order on a different `id_cart`. The observed duplicate orders therefore appear on **distinct `id_cart` values**, not the same one.

A second, theoretical race condition between the front `/validate` request and the webhook (`PAYMENT.CAPTURE.COMPLETED`) is also addressed as defence-in-depth: both paths call `CreateOrderAction` concurrently without serialisation and can each read an empty `ps_orders` for the cart before either commits. In practice the dominant failure mode is the TypeError→retry chain above, but the lock is retained as it is low-cost and closes a real gap.

## QA Checklist Labels
- [x] Bug fix?
- [ ] New feature?
- [ ] Improvement?
- [ ] Technical debt?
- [ ] Covered by tests?

## QA Checklist

Tested in production on PrestaShop 8.2.4 over 24h+ after deployment. Validation criteria:

- **Logs**: `var/logs/ps_checkout-*` no longer contain occurrences of `TypeError: Argument 1 passed to ValidateOrderData::create() must be of the type int, null given` originating from `DispatchWebHookController` for either `PAYMENT.CAPTURE.COMPLETED` or `PAYMENT.CAPTURE.PENDING` events.
- **Support**: cessation of customer reports of duplicate orders after the patch.

> **Note:** the production duplicates appear on **different `id_cart` values** (new cart allocated on retry), so a `SELECT id_cart, COUNT(*) … GROUP BY id_cart HAVING n > 1` probe does not detect them and is not used as a validation signal here.

## Additional Context

**Three root causes (three commits):**

**1. TypeError in `PaymentCompletedEventHandler` for `PAYMENT.CAPTURE.COMPLETED`**

When PayPal fires this webhook, the front controller has no customer session. `Context->cart` is not properly bound. The existing `if ($this->context->getCart()->id)` guard was supposed to skip order creation in this case, but on some PHP/PS configurations a `Cart` object exists with a usable `id` from a prior initialisation. Downstream, `CreateValidateOrderDataAction` reads `$cart->id` (which is `null`) and passes it to `ValidateOrderData::create(int $cartId, ...)`, throwing:
```
Argument 1 passed to PsCheckout\Core\Order\ValueObject\ValidateOrderData::create()
must be of the type int, null given
```

**Fix (commit 1):** inject `PayPalOrderRepositoryInterface` into `PaymentCompletedEventHandler`. At the start of `handle()`, when `Context->cart` has no id, look up the local `PayPalOrder` entity by PayPal order id, load the `\Cart` (and `\Customer`) from it, and bind them in `Context` before delegating. Service definitions updated in `ps8`, `ps9`, `ps17` `config/front/process.yml`.

**2. Defence-in-depth: front/webhook race condition** (`CreateOrderAction`)

Two code paths create the PrestaShop order for a given cart:
- **Front**: `validate.php` → `CreateOrderProcessor` → `CheckoutValidator` (SELECT on `ps_orders.id_cart`) → `CreateOrderAction::execute()`
- **Webhook**: `DispatchWebHook.php` → any event handler → `CreateOrderAction::execute()` (no `CheckoutValidator` guard)

Both paths can read an empty `ps_orders` for the cart before either commits, then each inserts an order — producing a duplicate on the **same `id_cart`**. This is a theoretical risk; the dominant failure mode observed in production is the TypeError→retry→new-cart chain described in fix 1 above.

**Fix (commit 2):** make `CreateOrderAction::execute()` idempotent per cart:
- acquire `GET_LOCK("ps_checkout_cart_<id>", 10)` to serialise concurrent paths,
- re-check `ps_orders` for the cart under the lock; if an order exists, only upsert the `PayPalOrderMatrix` mapping and return early,
- release the lock in a `finally` block (covers success, `PsCheckoutException` rethrow, and wrapped `\Exception`).

**3. TypeError persists for `PAYMENT.CAPTURE.PENDING` and other webhook events**

`PayPalEventDispatcher` routes events to 10 handlers. `PaymentPendingEventHandler` (event `PaymentCapturePending` — triggered when a payment is subject to 3DS challenge, fraud review, or manual validation) also calls `CreateOrderAction::execute()` directly, but the cart-context restoration from commit 1 was only in `PaymentCompletedEventHandler`. The same `TypeError` was therefore thrown for pending payment webhooks.

**Fix (commit 3):** move the cart-restoration logic into `CreateOrderAction::execute()` itself — the single convergence point for all event handlers. The local `PayPalOrder` entity (persisted by `CreatePayPalOrderProcessor` at order creation time) is the source of truth for `id_cart`; `Context->cart` is rebound only if it doesn't already match. The patch in `PaymentCompletedEventHandler` is kept as defense-in-depth (it also covers `createOrderPaymentAction` which runs afterwards). Service definitions updated in `ps8`, `ps9`, `ps17` `config/front/process.yml`.

## Frontend Changes

None.