### PR TITLE
[XO-3020] Webhook reliability: context reconstruction and event idemp…

### DIFF
--- a/core/src/Order/Action/CreateOrderAction.php
+++ b/core/src/Order/Action/CreateOrderAction.php
@@ -22,6 +22,7 @@ namespace PsCheckout\Core\Order\Action;
 
 use PsCheckout\Api\ValueObject\PayPalOrderResponse;
 use PsCheckout\Core\Exception\PsCheckoutException;
+use PsCheckout\Core\Order\Validator\CheckoutValidatorInterface;
 use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderMatrixRepositoryInterface;
 use PsCheckout\Infrastructure\Adapter\ContextInterface;
 use PsCheckout\Infrastructure\Repository\OrderRepositoryInterface;
@@ -53,18 +54,25 @@ class CreateOrderAction implements CreateOrderActionInterface
      */
     private $orderMatrixRepository;
 
+    /**
+     * @var CheckoutValidatorInterface
+     */
+    private $checkoutValidator;
+
     public function __construct(
         ContextInterface $context,
         CreateValidateOrderDataActionInterface $createValidateOrderDataAction,
         ValidateOrderActionInterface $validateOrderAction,
         OrderRepositoryInterface $orderRepository,
-        PayPalOrderMatrixRepositoryInterface $orderMatrixRepository
+        PayPalOrderMatrixRepositoryInterface $orderMatrixRepository,
+        CheckoutValidatorInterface $checkoutValidator
     ) {
         $this->context = $context;
         $this->createValidateOrderDataAction = $createValidateOrderDataAction;
         $this->validateOrderAction = $validateOrderAction;
         $this->orderRepository = $orderRepository;
         $this->orderMatrixRepository = $orderMatrixRepository;
+        $this->checkoutValidator = $checkoutValidator;
     }
 
     /**
@@ -73,6 +81,16 @@ class CreateOrderAction implements CreateOrderActionInterface
     public function execute(PayPalOrderResponse $payPalOrder)
     {
         try {
+            // Guard against duplicate PS order creation. This covers both the normal case
+            // where the synchronous front-office path already created the order (CapturePayPalOrderAction
+            // calls PaymentCompletedEventHandler synchronously, then PayPal sends the same event as a webhook)
+            // and the retry-after-partial-failure case.
+            // CheckoutValidator also validates the PayPal order record, cart existence, and cart products.
+            $this->checkoutValidator->validate(
+                $payPalOrder->getId(),
+                (int) $this->context->getCart()->id
+            );
+
             $validateOrderData = $this->createValidateOrderDataAction->execute($payPalOrder);
 
             $this->validateOrderAction->execute($validateOrderData);

--- a/core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
+++ b/core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
@@ -21,10 +21,10 @@
 namespace PsCheckout\Core\PayPal\Order\Handler;
 
 use PsCheckout\Api\ValueObject\PayPalOrderResponse;
+use PsCheckout\Core\Exception\PsCheckoutException;
 use PsCheckout\Core\Order\Action\CreateOrderActionInterface;
 use PsCheckout\Core\Order\Action\CreateOrderPaymentActionInterface;
 use PsCheckout\Core\OrderState\Action\SetOrderStateActionInterface;
-use PsCheckout\Infrastructure\Adapter\ContextInterface;
 
 class PaymentCompletedEventHandler implements EventHandlerInterface
 {
@@ -43,21 +43,14 @@ class PaymentCompletedEventHandler implements EventHandlerInterface
      */
     private $setCompletedOrderStateAction;
 
-    /**
-     * @var ContextInterface
-     */
-    private $context;
-
     public function __construct(
         CreateOrderActionInterface $createOrderAction,
         CreateOrderPaymentActionInterface $createOrderPaymentAction,
-        SetOrderStateActionInterface $setCompletedOrderStateAction,
-        ContextInterface $context
+        SetOrderStateActionInterface $setCompletedOrderStateAction
     ) {
         $this->createOrderAction = $createOrderAction;
         $this->createOrderPaymentAction = $createOrderPaymentAction;
         $this->setCompletedOrderStateAction = $setCompletedOrderStateAction;
-        $this->context = $context;
     }
 
     /**
@@ -65,10 +58,17 @@ class PaymentCompletedEventHandler implements EventHandlerInterface
      */
     public function handle(PayPalOrderResponse $payPalOrderResponse)
     {
-        if ($this->context->getCart()->id) {
+        try {
             $this->createOrderAction->execute($payPalOrderResponse);
-            $this->createOrderPaymentAction->execute($payPalOrderResponse);
+        } catch (PsCheckoutException $e) {
+            if ($e->getCode() !== PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS) {
+                throw $e;
+            }
+            // Order already exists (duplicate webhook delivery or retry after partial failure).
+            // Fall through: createOrderPaymentAction and setCompletedOrderStateAction are both
+            // idempotent and must still run to ensure the payment record and order state are set.
         }
+        $this->createOrderPaymentAction->execute($payPalOrderResponse);
         $this->setCompletedOrderStateAction->execute($payPalOrderResponse->getId());
     }
 }

--- a/core/src/WebhookDispatcher/Entity/WebhookEvent.php
+++ b/core/src/WebhookDispatcher/Entity/WebhookEvent.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsCheckout\Core\WebhookDispatcher\Entity;
+
+class WebhookEvent
+{
+    const STATUS_PROCESSING = 'processing';
+
+    const STATUS_SUCCEEDED = 'succeeded';
+
+    const STATUS_FAILED = 'failed';
+
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $eventType;
+
+    /**
+     * @var string|null
+     */
+    private $paypalOrderId;
+
+    /**
+     * @var string
+     */
+    private $status;
+
+    public function __construct(
+        string $id,
+        string $eventType,
+        ?string $paypalOrderId,
+        string $status
+    ) {
+        $this->id = $id;
+        $this->eventType = $eventType;
+        $this->paypalOrderId = $paypalOrderId;
+        $this->status = $status;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getEventType(): string
+    {
+        return $this->eventType;
+    }
+
+    public function getPaypalOrderId(): ?string
+    {
+        return $this->paypalOrderId;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}

--- a/core/src/WebhookDispatcher/Entity/index.php
+++ b/core/src/WebhookDispatcher/Entity/index.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+
+exit;

--- a/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+++ b/core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
@@ -27,9 +27,13 @@ use PsCheckout\Core\PaymentToken\Repository\PaymentTokenRepositoryInterface;
 use PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCacheInterface;
 use PsCheckout\Core\PayPal\Order\Handler\PayPalEventDispatcherInterface;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProviderInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Core\Webhook\Configuration\WebhookCategoryConfiguration;
 use PsCheckout\Core\Webhook\Configuration\WebhookEventTypeConfiguration;
+use PsCheckout\Core\WebhookDispatcher\Repository\WebhookEventRepositoryInterface;
 use PsCheckout\Core\WebhookDispatcher\ValueObject\DispatchWebhookRequest;
+use PsCheckout\Infrastructure\Adapter\ContextInterface;
+use PsCheckout\Infrastructure\Repository\CartRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
 class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
@@ -64,13 +68,37 @@ class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
      */
     private $paymentTokenRepository;
 
+    /**
+     * @var WebhookEventRepositoryInterface
+     */
+    private $webhookEventRepository;
+
+    /**
+     * @var PayPalOrderRepositoryInterface
+     */
+    private $payPalOrderRepository;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @var ContextInterface
+     */
+    private $context;
+
     public function __construct(
         LoggerInterface $logger,
         PayPalOrderProviderInterface $payPalOrderProvider,
         PayPalEventDispatcherInterface $eventDispatcher,
         PayPalOrderCacheInterface $payPalOrderCache,
         SavePaymentTokenActionInterface $savePaymentTokenAction,
-        PaymentTokenRepositoryInterface $paymentTokenRepository
+        PaymentTokenRepositoryInterface $paymentTokenRepository,
+        WebhookEventRepositoryInterface $webhookEventRepository,
+        PayPalOrderRepositoryInterface $payPalOrderRepository,
+        CartRepositoryInterface $cartRepository,
+        ContextInterface $context
     ) {
         $this->logger = $logger;
         $this->payPalOrderProvider = $payPalOrderProvider;
@@ -78,6 +106,10 @@ class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
         $this->payPalOrderCache = $payPalOrderCache;
         $this->savePaymentTokenAction = $savePaymentTokenAction;
         $this->paymentTokenRepository = $paymentTokenRepository;
+        $this->webhookEventRepository = $webhookEventRepository;
+        $this->payPalOrderRepository = $payPalOrderRepository;
+        $this->cartRepository = $cartRepository;
+        $this->context = $context;
     }
 
     /**
@@ -102,32 +134,104 @@ class DispatchWebhookProcessor implements DispatchWebhookProcessorInterface
             throw new PsCheckoutException('orderId must not be empty', PsCheckoutException::PSCHECKOUT_WEBHOOK_ORDER_ID_EMPTY);
         }
 
+        $resourceId = $dispatchWebhookRequest->getResourceId();
+
+        if (!$resourceId) {
+            throw new PsCheckoutException('resourceId must not be empty', PsCheckoutException::PSCHECKOUT_WEBHOOK_RESOURCE_EMPTY);
+        }
+
         if ($this->payPalOrderCache->has($orderId)) {
             $this->payPalOrderCache->delete($orderId);
         }
 
-        $payPalOrderResponse = $this->payPalOrderProvider->getById($orderId);
+        // Atomic idempotency claim — drops duplicate deliveries and guards against concurrent retries.
+        // PayPal reuses the same webhookId on retries; claim() handles all status transitions correctly.
+        $claimed = $this->webhookEventRepository->claim(
+            $dispatchWebhookRequest->getWebhookId(),
+            $dispatchWebhookRequest->getEventType(),
+            $resourceId
+        );
 
-        if (!$payPalOrderResponse) {
-            $this->logger->warning(
-                'PayPal order not found',
+        if (!$claimed) {
+            $this->logger->info(
+                'Webhook event already processed or currently processing, skipping.',
                 [
+                    'webhookId' => $dispatchWebhookRequest->getWebhookId(),
+                    'eventType' => $dispatchWebhookRequest->getEventType(),
                     'orderId' => $orderId,
+                    'resourceId' => $resourceId,
                 ]
             );
 
-            throw new PsCheckoutException('PayPal order not found', PsCheckoutException::PSCHECKOUT_WEBHOOK_ORDER_ID_EMPTY);
-        }
-
-        if ($this->handlePaymentTokenEvents($dispatchWebhookRequest->getEventType(), $payPalOrderResponse)) {
             return true;
         }
 
+        // All post-claim logic is wrapped so that any failure — including unexpected exceptions
+        // like TypeError — calls markFailed() and leaves the row in a state that PayPal can retry,
+        // rather than leaving it stuck in "processing" until the stale threshold.
         try {
+            // Bootstrap context from the local pscheckout_order record.
+            // Webhook requests carry no customer session cookie, so context->cart is empty or stale.
+            $payPalOrder = $this->payPalOrderRepository->getOneBy(['id' => $orderId]);
+            if ($payPalOrder) {
+                $cart = $this->cartRepository->getOneBy(['id_cart' => $payPalOrder->getIdCart()]);
+                if ($cart && $cart->id) {
+                    $this->context->loadCartForWebhook($cart);
+                }
+            }
+
+            $payPalOrderResponse = $this->payPalOrderProvider->getById($orderId);
+
+            if (!$payPalOrderResponse) {
+                $this->logger->warning(
+                    'PayPal order not found',
+                    [
+                        'orderId' => $orderId,
+                    ]
+                );
+
+                throw new PsCheckoutException('PayPal order not found', PsCheckoutException::PSCHECKOUT_WEBHOOK_ORDER_ID_EMPTY);
+            }
+
+            if ($this->handlePaymentTokenEvents($dispatchWebhookRequest->getEventType(), $payPalOrderResponse)) {
+                $this->webhookEventRepository->markSucceeded($dispatchWebhookRequest->getWebhookId());
+
+                return true;
+            }
+
             $this->eventDispatcher->dispatch($dispatchWebhookRequest->getEventType(), $payPalOrderResponse);
+            $this->webhookEventRepository->markSucceeded($dispatchWebhookRequest->getWebhookId());
         } catch (PsCheckoutException $e) {
+            if ($e->getCode() === PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS) {
+                // The PS order was already created — either by the synchronous front-office path
+                // (CapturePayPalOrderAction fires the same handler before PayPal sends the webhook)
+                // or by a prior webhook delivery. Return 200 so PayPal does not retry.
+                $this->webhookEventRepository->markSucceeded($dispatchWebhookRequest->getWebhookId());
+                $this->logger->info(
+                    'Order already exists for webhook, marking event succeeded.',
+                    [
+                        'webhookId' => $dispatchWebhookRequest->getWebhookId(),
+                        'orderId' => $orderId,
+                    ]
+                );
+
+                return true;
+            }
+
+            $this->webhookEventRepository->markFailed($dispatchWebhookRequest->getWebhookId(), $e->getMessage());
             $this->logger->error(
                 'Error processing webhook',
+                [
+                    'payload' => $dispatchWebhookRequest->toArray(),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+
+            throw $e;
+        } catch (\Throwable $e) {
+            $this->webhookEventRepository->markFailed($dispatchWebhookRequest->getWebhookId(), $e->getMessage());
+            $this->logger->error(
+                'Unexpected error processing webhook',
                 [
                     'payload' => $dispatchWebhookRequest->toArray(),
                     'exception' => $e->getMessage(),

--- a/core/src/WebhookDispatcher/Repository/WebhookEventRepositoryInterface.php
+++ b/core/src/WebhookDispatcher/Repository/WebhookEventRepositoryInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsCheckout\Core\WebhookDispatcher\Repository;
+
+interface WebhookEventRepositoryInterface
+{
+    /**
+     * Atomically claims a webhook event for processing.
+     *
+     * PayPal reuses the same webhookId on retries, so claim() must distinguish:
+     *   - New event             → INSERT succeeds                         → return true
+     *   - Concurrent duplicate → row exists, status=processing (recent)  → return false
+     *   - Retry after crash    → row exists, status=processing (stale)   → reclaim, return true
+     *   - Retry after failure  → row exists, status=failed               → reclaim, return true
+     *   - Retry after success  → row exists, status=succeeded            → return false
+     *
+     * @param string $webhookId  PayPal webhook event ID (idempotency key)
+     * @param string $eventType  e.g. PAYMENT.CAPTURE.COMPLETED
+     * @param string $resourceId resource.id from the webhook payload (capture, refund, authorization, or order ID) — must not be empty
+     *
+     * @return bool True if the event was claimed and processing should proceed
+     */
+    public function claim(string $webhookId, string $eventType, string $resourceId): bool;
+
+    /**
+     * Marks a previously claimed webhook event as successfully processed.
+     *
+     * @param string $webhookId
+     *
+     * @return void
+     */
+    public function markSucceeded(string $webhookId): void;
+
+    /**
+     * Marks a previously claimed webhook event as failed.
+     *
+     * @param string $webhookId
+     * @param string $error     Error message for observability
+     *
+     * @return void
+     */
+    public function markFailed(string $webhookId, string $error): void;
+}

--- a/core/src/WebhookDispatcher/Repository/index.php
+++ b/core/src/WebhookDispatcher/Repository/index.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+
+exit;

--- a/core/src/WebhookDispatcher/ValueObject/DispatchWebhookRequest.php
+++ b/core/src/WebhookDispatcher/ValueObject/DispatchWebhookRequest.php
@@ -122,6 +122,14 @@ class DispatchWebhookRequest
     }
 
     /**
+     * @return string
+     */
+    public function getWebhookId(): string
+    {
+        return $this->webhookId;
+    }
+
+    /**
      * @return array
      */
     public function getResource(): array
@@ -159,6 +167,29 @@ class DispatchWebhookRequest
     public function getOrderId(): ?string
     {
         return $this->orderId;
+    }
+
+    /**
+     * Returns the best available identifier for the resource delivered in this webhook event.
+     *
+     * Resolution order:
+     *   1. resource.id  — present for captures, refunds, authorizations, and most orders
+     *   2. resource.order_id — used by CHECKOUT.PAYMENT-APPROVAL.REVERSED which carries no resource.id
+     *   3. orderId (top-level payload field) — last resort for events with neither resource field
+     *
+     * @return string|null
+     */
+    public function getResourceId(): ?string
+    {
+        if (isset($this->resource['id']) && $this->resource['id'] !== '') {
+            return (string) $this->resource['id'];
+        }
+
+        if (isset($this->resource['order_id']) && $this->resource['order_id'] !== '') {
+            return (string) $this->resource['order_id'];
+        }
+
+        return $this->orderId ?: null;
     }
 
     /**

--- a/core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+++ b/core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsCheckout\Core\Tests\Integration\WebhookDispatcher\Repository;
+
+use PsCheckout\Core\Tests\Integration\BaseTestCase;
+use PsCheckout\Infrastructure\Repository\WebhookEventRepository;
+
+/**
+ * Integration tests for WebhookEventRepository::claim() atomicity and status transitions.
+ *
+ * These tests verify the two-step INSERT IGNORE + conditional UPDATE protocol that provides
+ * event-level idempotency for PayPal webhook deliveries. Each test runs inside a DB transaction
+ * that is rolled back in tearDown() by BaseTestCase, leaving no persistent test data.
+ *
+ * Run manually inside Docker: make php-integration-core
+ */
+class WebhookEventRepositoryTest extends BaseTestCase
+{
+    /**
+     * @var WebhookEventRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new WebhookEventRepository(\Db::getInstance());
+    }
+
+    // -------------------------------------------------------------------------
+    // claim() — five scenarios
+    // -------------------------------------------------------------------------
+
+    public function testClaimNewEventReturnsTrue(): void
+    {
+        $result = $this->repository->claim('wh-new-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->assertTrue($result);
+
+        $row = $this->fetchRow('wh-new-001');
+        $this->assertNotNull($row);
+        $this->assertSame('processing', $row['status']);
+        $this->assertSame('PAYMENT.CAPTURE.COMPLETED', $row['event_type']);
+        $this->assertSame('order-abc', $row['resource_id']);
+    }
+
+    public function testClaimDuplicateRecentProcessingReturnsFalse(): void
+    {
+        // Insert a "processing" row with date_upd = now to simulate in-flight processing
+        \Db::getInstance()->insert(
+            'pscheckout_webhook_event',
+            [
+                'id' => 'wh-dup-001',
+                'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
+                'resource_id' => 'order-abc',
+                'status' => 'processing',
+                'date_add' => date('Y-m-d H:i:s'),
+                'date_upd' => date('Y-m-d H:i:s'),
+            ]
+        );
+
+        $result = $this->repository->claim('wh-dup-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->assertFalse($result);
+    }
+
+    public function testClaimStaleProcessingReturnsTrue(): void
+    {
+        // Insert a "processing" row with date_upd > 10 minutes ago to simulate a PHP-FPM crash.
+        // PHP time is used here for consistency with WebhookEventRepository::claim().
+        \Db::getInstance()->insert(
+            'pscheckout_webhook_event',
+            [
+                'id' => 'wh-stale-001',
+                'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
+                'resource_id' => 'order-abc',
+                'status' => 'processing',
+                'date_add' => date('Y-m-d H:i:s', time() - 20 * 60),
+                'date_upd' => date('Y-m-d H:i:s', time() - 11 * 60),
+            ]
+        );
+
+        $result = $this->repository->claim('wh-stale-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->assertTrue($result);
+
+        $row = $this->fetchRow('wh-stale-001');
+        $this->assertSame('processing', $row['status']);
+    }
+
+    public function testClaimFailedReturnsTrue(): void
+    {
+        \Db::getInstance()->insert(
+            'pscheckout_webhook_event',
+            [
+                'id' => 'wh-fail-001',
+                'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
+                'resource_id' => 'order-abc',
+                'status' => 'failed',
+                'date_add' => date('Y-m-d H:i:s'),
+                'date_upd' => date('Y-m-d H:i:s'),
+            ]
+        );
+
+        $result = $this->repository->claim('wh-fail-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->assertTrue($result);
+
+        $row = $this->fetchRow('wh-fail-001');
+        $this->assertSame('processing', $row['status']);
+    }
+
+    public function testClaimSucceededReturnsFalse(): void
+    {
+        \Db::getInstance()->insert(
+            'pscheckout_webhook_event',
+            [
+                'id' => 'wh-done-001',
+                'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
+                'resource_id' => 'order-abc',
+                'status' => 'succeeded',
+                'date_add' => date('Y-m-d H:i:s'),
+                'date_upd' => date('Y-m-d H:i:s'),
+            ]
+        );
+
+        $result = $this->repository->claim('wh-done-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->assertFalse($result);
+
+        // Row must remain unchanged
+        $row = $this->fetchRow('wh-done-001');
+        $this->assertSame('succeeded', $row['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // markSucceeded() / markFailed()
+    // -------------------------------------------------------------------------
+
+    public function testMarkSucceeded(): void
+    {
+        $this->repository->claim('wh-ms-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->repository->markSucceeded('wh-ms-001');
+
+        $row = $this->fetchRow('wh-ms-001');
+        $this->assertSame('succeeded', $row['status']);
+        $this->assertNull($row['error']);
+    }
+
+    public function testMarkFailed(): void
+    {
+        $this->repository->claim('wh-mf-001', 'PAYMENT.CAPTURE.COMPLETED', 'order-abc');
+
+        $this->repository->markFailed('wh-mf-001', 'Something went wrong');
+
+        $row = $this->fetchRow('wh-mf-001');
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('Something went wrong', $row['error']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param string $id
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchRow(string $id): ?array
+    {
+        $result = \Db::getInstance()->getRow(
+            'SELECT * FROM `' . _DB_PREFIX_ . 'pscheckout_webhook_event` WHERE `id` = \'' . pSQL($id) . '\''
+        );
+
+        return $result ?: null;
+    }
+}

--- a/core/tests/Integration/WebhookDispatcher/Repository/index.php
+++ b/core/tests/Integration/WebhookDispatcher/Repository/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+
+exit;

--- a/core/tests/Integration/WebhookDispatcher/index.php
+++ b/core/tests/Integration/WebhookDispatcher/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+
+exit;

--- a/core/tests/Unit/Order/Action/CreateOrderActionTest.php
+++ b/core/tests/Unit/Order/Action/CreateOrderActionTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PHPUnit\Framework\TestCase;
+use PsCheckout\Api\ValueObject\PayPalOrderResponse;
+use PsCheckout\Core\Exception\PsCheckoutException;
+use PsCheckout\Core\Order\Action\CreateOrderAction;
+use PsCheckout\Core\Order\Action\CreateValidateOrderDataActionInterface;
+use PsCheckout\Core\Order\Action\ValidateOrderActionInterface;
+use PsCheckout\Core\Order\Validator\CheckoutValidatorInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderMatrixRepositoryInterface;
+use PsCheckout\Infrastructure\Adapter\ContextInterface;
+use PsCheckout\Infrastructure\Repository\OrderRepositoryInterface;
+
+class CreateOrderActionTest extends TestCase
+{
+    private $context;
+
+    private $createValidateOrderDataAction;
+
+    private $validateOrderAction;
+
+    private $orderRepository;
+
+    private $orderMatrixRepository;
+
+    private $checkoutValidator;
+
+    private $action;
+
+    protected function setUp(): void
+    {
+        $this->context = $this->createMock(ContextInterface::class);
+        $this->createValidateOrderDataAction = $this->createMock(CreateValidateOrderDataActionInterface::class);
+        $this->validateOrderAction = $this->createMock(ValidateOrderActionInterface::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->orderMatrixRepository = $this->createMock(PayPalOrderMatrixRepositoryInterface::class);
+        $this->checkoutValidator = $this->createMock(CheckoutValidatorInterface::class);
+
+        $this->action = new CreateOrderAction(
+            $this->context,
+            $this->createValidateOrderDataAction,
+            $this->validateOrderAction,
+            $this->orderRepository,
+            $this->orderMatrixRepository,
+            $this->checkoutValidator
+        );
+    }
+
+    public function testExecuteThrowsWhenOrderAlreadyExistsForCart(): void
+    {
+        $this->expectException(PsCheckoutException::class);
+        $this->expectExceptionCode(PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS);
+
+        $request = $this->createMock(PayPalOrderResponse::class);
+        $request->method('getId')->willReturn('PAYPAL-ORDER-123');
+
+        $cart = $this->createMock(\Cart::class);
+        $cart->id = 42;
+        $this->context->method('getCart')->willReturn($cart);
+
+        $this->checkoutValidator
+            ->method('validate')
+            ->willThrowException(
+                new PsCheckoutException('Order already exist', PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS)
+            );
+
+        // createValidateOrderDataAction must never be reached when validator throws
+        $this->createValidateOrderDataAction->expects($this->never())->method('execute');
+
+        $this->action->execute($request);
+    }
+}

--- a/core/tests/Unit/Order/Action/index.php
+++ b/core/tests/Unit/Order/Action/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+
+exit;

--- a/core/tests/Unit/PayPal/Order/Handler/PaymentCompletedEventHandlerTest.php
+++ b/core/tests/Unit/PayPal/Order/Handler/PaymentCompletedEventHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PHPUnit\Framework\TestCase;
+use PsCheckout\Api\ValueObject\PayPalOrderResponse;
+use PsCheckout\Core\Exception\PsCheckoutException;
+use PsCheckout\Core\Order\Action\CreateOrderActionInterface;
+use PsCheckout\Core\Order\Action\CreateOrderPaymentActionInterface;
+use PsCheckout\Core\OrderState\Action\SetOrderStateActionInterface;
+use PsCheckout\Core\PayPal\Order\Handler\PaymentCompletedEventHandler;
+
+class PaymentCompletedEventHandlerTest extends TestCase
+{
+    /** @var CreateOrderActionInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $createOrderAction;
+
+    /** @var CreateOrderPaymentActionInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $createOrderPaymentAction;
+
+    /** @var SetOrderStateActionInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $setCompletedOrderStateAction;
+
+    /** @var PaymentCompletedEventHandler */
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->createOrderAction = $this->createMock(CreateOrderActionInterface::class);
+        $this->createOrderPaymentAction = $this->createMock(CreateOrderPaymentActionInterface::class);
+        $this->setCompletedOrderStateAction = $this->createMock(SetOrderStateActionInterface::class);
+
+        $this->handler = new PaymentCompletedEventHandler(
+            $this->createOrderAction,
+            $this->createOrderPaymentAction,
+            $this->setCompletedOrderStateAction
+        );
+    }
+
+    public function testHandleCallsAllThreeActionsOnHappyPath(): void
+    {
+        $response = $this->createMock(PayPalOrderResponse::class);
+        $response->method('getId')->willReturn('paypal-order-123');
+
+        $this->createOrderAction->expects($this->once())->method('execute')->with($response);
+        $this->createOrderPaymentAction->expects($this->once())->method('execute')->with($response);
+        $this->setCompletedOrderStateAction->expects($this->once())->method('execute')->with('paypal-order-123');
+
+        $this->handler->handle($response);
+    }
+
+    public function testHandleWhenOrderAlreadyExistsStillCallsPaymentAndStateActions(): void
+    {
+        $response = $this->createMock(PayPalOrderResponse::class);
+        $response->method('getId')->willReturn('paypal-order-123');
+
+        // Simulate crash-then-retry: the PS order already exists from the first attempt.
+        $this->createOrderAction
+            ->method('execute')
+            ->willThrowException(new PsCheckoutException('Order already exist', PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS));
+
+        // createOrderPaymentAction and setCompletedOrderStateAction must still be called —
+        // both are idempotent and must run to ensure the payment record and state are set.
+        $this->createOrderPaymentAction->expects($this->once())->method('execute')->with($response);
+        $this->setCompletedOrderStateAction->expects($this->once())->method('execute')->with('paypal-order-123');
+
+        $this->handler->handle($response);
+    }
+
+    public function testHandleWhenOtherPsCheckoutExceptionPropagates(): void
+    {
+        $this->expectException(PsCheckoutException::class);
+        $this->expectExceptionMessage('Cart not found');
+
+        $response = $this->createMock(PayPalOrderResponse::class);
+
+        $this->createOrderAction
+            ->method('execute')
+            ->willThrowException(new PsCheckoutException('Cart not found', PsCheckoutException::PRESTASHOP_CART_NOT_FOUND));
+
+        // Must not reach payment or state steps when a non-duplicate exception fires.
+        $this->createOrderPaymentAction->expects($this->never())->method('execute');
+        $this->setCompletedOrderStateAction->expects($this->never())->method('execute');
+
+        $this->handler->handle($response);
+    }
+
+    public function testHandleWhenUnexpectedExceptionPropagates(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected failure');
+
+        $response = $this->createMock(PayPalOrderResponse::class);
+
+        $this->createOrderAction
+            ->method('execute')
+            ->willThrowException(new \RuntimeException('Unexpected failure'));
+
+        $this->createOrderPaymentAction->expects($this->never())->method('execute');
+        $this->setCompletedOrderStateAction->expects($this->never())->method('execute');
+
+        $this->handler->handle($response);
+    }
+}

--- a/core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+++ b/core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
@@ -26,8 +26,12 @@ use PsCheckout\Core\PaymentToken\Repository\PaymentTokenRepositoryInterface;
 use PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCacheInterface;
 use PsCheckout\Core\PayPal\Order\Handler\PayPalEventDispatcherInterface;
 use PsCheckout\Core\PayPal\Order\Provider\PayPalOrderProviderInterface;
+use PsCheckout\Core\PayPal\Order\Repository\PayPalOrderRepositoryInterface;
 use PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor;
+use PsCheckout\Core\WebhookDispatcher\Repository\WebhookEventRepositoryInterface;
 use PsCheckout\Core\WebhookDispatcher\ValueObject\DispatchWebhookRequest;
+use PsCheckout\Infrastructure\Adapter\ContextInterface;
+use PsCheckout\Infrastructure\Repository\CartRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
 class DispatchWebhookProcessorTest extends TestCase
@@ -44,6 +48,14 @@ class DispatchWebhookProcessorTest extends TestCase
 
     private $paymentTokenRepository;
 
+    private $webhookEventRepository;
+
+    private $payPalOrderRepository;
+
+    private $cartRepository;
+
+    private $context;
+
     private $processor;
 
     protected function setUp(): void
@@ -54,6 +66,10 @@ class DispatchWebhookProcessorTest extends TestCase
         $this->payPalOrderCache = $this->createMock(PayPalOrderCacheInterface::class);
         $this->savePaymentTokenAction = $this->createMock(SavePaymentTokenActionInterface::class);
         $this->paymentTokenRepository = $this->createMock(PaymentTokenRepositoryInterface::class);
+        $this->webhookEventRepository = $this->createMock(WebhookEventRepositoryInterface::class);
+        $this->payPalOrderRepository = $this->createMock(PayPalOrderRepositoryInterface::class);
+        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+        $this->context = $this->createMock(ContextInterface::class);
 
         $this->processor = new DispatchWebhookProcessor(
             $this->logger,
@@ -61,7 +77,11 @@ class DispatchWebhookProcessorTest extends TestCase
             $this->eventDispatcher,
             $this->payPalOrderCache,
             $this->savePaymentTokenAction,
-            $this->paymentTokenRepository
+            $this->paymentTokenRepository,
+            $this->webhookEventRepository,
+            $this->payPalOrderRepository,
+            $this->cartRepository,
+            $this->context
         );
     }
 
@@ -87,6 +107,19 @@ class DispatchWebhookProcessorTest extends TestCase
         $this->processor->process($request);
     }
 
+    public function testProcessWithMissingResourceId(): void
+    {
+        $this->expectException(PsCheckoutException::class);
+        $this->expectExceptionMessage('resourceId must not be empty');
+
+        $request = $this->createMock(DispatchWebhookRequest::class);
+        $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
+        $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn(null);
+
+        $this->processor->process($request);
+    }
+
     public function testProcessWithNonexistentPayPalOrder(): void
     {
         $this->expectException(PsCheckoutException::class);
@@ -95,8 +128,13 @@ class DispatchWebhookProcessorTest extends TestCase
         $request = $this->createMock(DispatchWebhookRequest::class);
         $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
         $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
+        $request->method('getEventType')->willReturn('SomeEvent');
 
         $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
         $this->payPalOrderProvider
         ->method('getById')
         ->will($this->throwException(new PsCheckoutException('PayPal order not found', PsCheckoutException::PSCHECKOUT_WEBHOOK_ORDER_ID_EMPTY)));
@@ -109,13 +147,18 @@ class DispatchWebhookProcessorTest extends TestCase
         $request = $this->createMock(DispatchWebhookRequest::class);
         $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
         $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
         $request->method('getEventType')->willReturn('SomeEvent');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
 
         $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
 
         $this->payPalOrderCache->method('has')->willReturn(true);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
         $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
         $this->eventDispatcher->expects($this->once())->method('dispatch')->with('SomeEvent', $payPalOrderResponse);
+        $this->webhookEventRepository->expects($this->once())->method('markSucceeded')->with('webhook-abc');
         $this->payPalOrderCache->expects($this->once())
         ->method('delete')
         ->with($this->equalTo('12345'));
@@ -128,12 +171,17 @@ class DispatchWebhookProcessorTest extends TestCase
         $request = $this->createMock(DispatchWebhookRequest::class);
         $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
         $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('token-001');
         $request->method('getEventType')->willReturn('VaultPaymentTokenCreated');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
 
         $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
 
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
         $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
         $this->savePaymentTokenAction->expects($this->once())->method('execute')->with($payPalOrderResponse);
+        $this->webhookEventRepository->expects($this->once())->method('markSucceeded')->with('webhook-abc');
 
         $this->assertTrue($this->processor->process($request));
     }
@@ -143,13 +191,18 @@ class DispatchWebhookProcessorTest extends TestCase
         $request = $this->createMock(DispatchWebhookRequest::class);
         $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
         $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('auth-001');
         $request->method('getEventType')->willReturn('PaymentAuthorizationVoided');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
 
         $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
 
         $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
         $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
         $this->eventDispatcher->expects($this->once())->method('dispatch')->with('PaymentAuthorizationVoided', $payPalOrderResponse);
+        $this->webhookEventRepository->expects($this->once())->method('markSucceeded')->with('webhook-abc');
 
         $this->assertTrue($this->processor->process($request));
     }
@@ -159,14 +212,123 @@ class DispatchWebhookProcessorTest extends TestCase
         $request = $this->createMock(DispatchWebhookRequest::class);
         $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
         $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('token-001');
         $request->method('getEventType')->willReturn('VaultPaymentTokenDeleted');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
 
         $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
         $payPalOrderResponse->method('getVault')->willReturn(['id' => 'token123']);
 
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
         $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
         $this->paymentTokenRepository->expects($this->once())->method('delete')->with('token123');
+        $this->webhookEventRepository->expects($this->once())->method('markSucceeded')->with('webhook-abc');
 
         $this->assertTrue($this->processor->process($request));
+    }
+
+    public function testProcessSkipsWhenEventAlreadyClaimed(): void
+    {
+        $request = $this->createMock(DispatchWebhookRequest::class);
+        $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
+        $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
+        $request->method('getEventType')->willReturn('SomeEvent');
+
+        $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(false);
+
+        $this->payPalOrderProvider->expects($this->never())->method('getById');
+        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $this->webhookEventRepository->expects($this->never())->method('markSucceeded');
+
+        $this->assertTrue($this->processor->process($request));
+    }
+
+    public function testProcessDispatchThrowsUnexpectedExceptionCallsMarkFailed(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Something unexpected');
+
+        $request = $this->createMock(DispatchWebhookRequest::class);
+        $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
+        $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
+        $request->method('getEventType')->willReturn('SomeEvent');
+
+        $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
+
+        $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
+        $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
+        $this->eventDispatcher->method('dispatch')
+            ->willThrowException(new \RuntimeException('Something unexpected'));
+
+        $this->webhookEventRepository->expects($this->once())
+            ->method('markFailed')
+            ->with('webhook-abc', 'Something unexpected');
+        $this->webhookEventRepository->expects($this->never())->method('markSucceeded');
+
+        $this->processor->process($request);
+    }
+
+    public function testProcessOrderAlreadyExistsMarksSucceeded(): void
+    {
+        $request = $this->createMock(DispatchWebhookRequest::class);
+        $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
+        $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
+        $request->method('getEventType')->willReturn('SomeEvent');
+
+        $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
+
+        $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
+        $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
+        $this->eventDispatcher->method('dispatch')
+            ->willThrowException(new PsCheckoutException('Order already exist', PsCheckoutException::PRESTASHOP_ORDER_ALREADY_EXISTS));
+
+        // PRESTASHOP_ORDER_ALREADY_EXISTS is a success case: the order exists, so mark succeeded
+        $this->webhookEventRepository->expects($this->once())
+            ->method('markSucceeded')
+            ->with('webhook-abc');
+        $this->webhookEventRepository->expects($this->never())->method('markFailed');
+
+        $this->assertTrue($this->processor->process($request));
+    }
+
+    public function testProcessPsCheckoutExceptionCallsMarkFailed(): void
+    {
+        $this->expectException(PsCheckoutException::class);
+        $this->expectExceptionMessage('Business rule failed');
+
+        $request = $this->createMock(DispatchWebhookRequest::class);
+        $request->method('getCategory')->willReturn('ShopNotificationOrderChange');
+        $request->method('getOrderId')->willReturn('12345');
+        $request->method('getResourceId')->willReturn('capture-001');
+        $request->method('getWebhookId')->willReturn('webhook-abc');
+        $request->method('getEventType')->willReturn('SomeEvent');
+
+        $payPalOrderResponse = $this->createMock(PayPalOrderResponse::class);
+
+        $this->payPalOrderCache->method('has')->willReturn(false);
+        $this->webhookEventRepository->method('claim')->willReturn(true);
+        $this->payPalOrderRepository->method('getOneBy')->willReturn(null);
+        $this->payPalOrderProvider->method('getById')->willReturn($payPalOrderResponse);
+        $this->eventDispatcher->method('dispatch')
+            ->willThrowException(new PsCheckoutException('Business rule failed', 0));
+
+        $this->webhookEventRepository->expects($this->once())
+            ->method('markFailed')
+            ->with('webhook-abc', 'Business rule failed');
+        $this->webhookEventRepository->expects($this->never())->method('markSucceeded');
+
+        $this->processor->process($request);
     }
 }

--- a/infrastructure/src/Adapter/Context.php
+++ b/infrastructure/src/Adapter/Context.php
@@ -174,4 +174,79 @@ class Context implements ContextInterface
             ? (float) $cart->getOrderTotal(true, \Cart::BOTH)
             : null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadCartForWebhook(\Cart $cart): void
+    {
+        $idShop = (int) $cart->id_shop;
+        $idLang = (int) $cart->id_lang;
+
+        $this->context->cart = $cart;
+        $this->context->shop = new \Shop($idShop, $idLang);
+        // Align the static shop context so shop-scoped Configuration::get() calls (e.g. PS_TAX_ADDRESS_TYPE,
+        // PS_COUNTRY_DEFAULT) resolve from the correct shop in a multistore setup.
+        \Shop::setContext(\Shop::CONTEXT_SHOP, $idShop);
+        $this->context->language = new \Language($idLang, null, $idShop);
+        $this->context->currency = new \Currency((int) $cart->id_currency, $idLang, $idShop);
+
+        if ((int) $cart->id_customer > 0) {
+            // \Customer::__construct only accepts $id — no $id_lang / $id_shop override
+            $this->context->customer = new \Customer((int) $cart->id_customer);
+        }
+
+        // Country resolution: try the cart address, fallback to shop default, leave null rather
+        // than fatalling if neither resolves (webhook carts may have inconsistent address data).
+        $country = $this->resolveWebhookCountry($cart, $idShop);
+        if ($country instanceof \Country && \Validate::isLoadedObject($country)) {
+            $this->context->country = $country;
+        }
+    }
+
+    /**
+     * Resolves the tax country for a webhook cart.
+     *
+     * Priority:
+     *   1. Address pointed to by PS_TAX_ADDRESS_TYPE (shop-scoped configuration)
+     *   2. Shop default country (PS_COUNTRY_DEFAULT, shop-scoped)
+     *   3. null — leave context->country unchanged rather than fatalling
+     *
+     * All PS object loads are guarded with Validate::isLoadedObject() to tolerate deleted
+     * or inconsistent address data that is common in webhook-delivered carts.
+     *
+     * @param \Cart $cart
+     * @param int $idShop
+     *
+     * @return \Country|null
+     */
+    private function resolveWebhookCountry(\Cart $cart, int $idShop): ?\Country
+    {
+        // Step 1 — try the address selected by PS_TAX_ADDRESS_TYPE (shop-scoped read)
+        $addressType = (string) \Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $idShop);
+        $addressId = $addressType === 'id_address_invoice'
+            ? (int) $cart->id_address_invoice
+            : (int) $cart->id_address_delivery;
+
+        if ($addressId > 0) {
+            $address = new \Address($addressId);
+            if (\Validate::isLoadedObject($address) && (int) $address->id_country > 0) {
+                $country = new \Country((int) $address->id_country);
+                if (\Validate::isLoadedObject($country)) {
+                    return $country;
+                }
+            }
+        }
+
+        // Step 2 — fallback to the shop default country (shop-scoped read)
+        $defaultCountryId = (int) \Configuration::get('PS_COUNTRY_DEFAULT', null, null, $idShop);
+        if ($defaultCountryId > 0) {
+            $country = new \Country($defaultCountryId);
+            if (\Validate::isLoadedObject($country)) {
+                return $country;
+            }
+        }
+
+        return null;
+    }
 }

--- a/infrastructure/src/Adapter/ContextInterface.php
+++ b/infrastructure/src/Adapter/ContextInterface.php
@@ -104,4 +104,15 @@ interface ContextInterface
      * @return float|null
      */
     public function getCartOrderTotal(): ?float;
+
+    /**
+     * Initialise cart, language, currency, customer, country and shop in the context
+     * for a server-side webhook request that carries no customer session.
+     * Does not update the cart record or write to the response cookie.
+     *
+     * @param \Cart $cart
+     *
+     * @return void
+     */
+    public function loadCartForWebhook(\Cart $cart): void;
 }

--- a/infrastructure/src/Bootstrap/Install/DatabaseTableInstaller.php
+++ b/infrastructure/src/Bootstrap/Install/DatabaseTableInstaller.php
@@ -184,6 +184,17 @@ class DatabaseTableInstaller implements InstallerInterface
             PRIMARY KEY (`id_customer`, `checksum`),
             KEY `id_address` (`id_address`)
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;
+        ') && $this->db->execute('
+            CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'pscheckout_webhook_event` (
+            `id` varchar(50) NOT NULL,
+            `event_type` varchar(100) NOT NULL,
+            `resource_id` varchar(50) NOT NULL,
+            `status` varchar(20) NOT NULL DEFAULT \'processing\',
+            `error` text DEFAULT NULL,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=UTF8;
         ');
 
         $this->checkTable();

--- a/infrastructure/src/Repository/WebhookEventRepository.php
+++ b/infrastructure/src/Repository/WebhookEventRepository.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsCheckout\Infrastructure\Repository;
+
+use PsCheckout\Core\WebhookDispatcher\Repository\WebhookEventRepositoryInterface;
+
+class WebhookEventRepository implements WebhookEventRepositoryInterface
+{
+    const TABLE_NAME = 'pscheckout_webhook_event';
+
+    /**
+     * Minutes after which a "processing" row is considered stale and may be reclaimed.
+     * Covers PHP-FPM crashes and hard timeouts.
+     */
+    const STALE_PROCESSING_THRESHOLD_MINUTES = 10;
+
+    /**
+     * @var \Db
+     */
+    private $db;
+
+    public function __construct(\Db $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function claim(string $webhookId, string $eventType, string $resourceId): bool
+    {
+        // Use PHP time throughout so all timestamps share one controllable source of truth,
+        // consistent with markSucceeded() / markFailed() which already use date().
+        $now = date('Y-m-d H:i:s');
+        $staleThreshold = date('Y-m-d H:i:s', time() - self::STALE_PROCESSING_THRESHOLD_MINUTES * 60);
+
+        // Step 1: try to insert a new row (new event path).
+        $this->db->insert(
+            self::TABLE_NAME,
+            [
+                'id' => pSQL($webhookId),
+                'event_type' => pSQL($eventType),
+                'resource_id' => pSQL($resourceId),
+                'status' => 'processing',
+                'date_add' => $now,
+                'date_upd' => $now,
+            ],
+            false,
+            true,
+            \Db::INSERT_IGNORE
+        );
+
+        if ($this->db->Affected_Rows() > 0) {
+            return true;
+        }
+
+        // Step 2: row already exists — try to reclaim if it is failed or stale.
+        // Atomic conditional UPDATE: only one concurrent caller can get Affected_Rows() = 1.
+        $this->db->execute(
+            'UPDATE `' . _DB_PREFIX_ . self::TABLE_NAME . '`
+            SET `status` = \'processing\', `date_upd` = \'' . $now . '\'
+            WHERE `id` = \'' . pSQL($webhookId) . '\'
+              AND (
+                  `status` = \'failed\'
+                  OR (`status` = \'processing\'
+                      AND `date_upd` < \'' . $staleThreshold . '\')
+              )'
+        );
+
+        return $this->db->Affected_Rows() > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markSucceeded(string $webhookId): void
+    {
+        $this->db->update(
+            self::TABLE_NAME,
+            [
+                'status' => 'succeeded',
+                'date_upd' => date('Y-m-d H:i:s'),
+            ],
+            '`id` = \'' . pSQL($webhookId) . '\''
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function markFailed(string $webhookId, string $error): void
+    {
+        $this->db->update(
+            self::TABLE_NAME,
+            [
+                'status' => 'failed',
+                'error' => pSQL($error, true),
+                'date_upd' => date('Y-m-d H:i:s'),
+            ],
+            '`id` = \'' . pSQL($webhookId) . '\''
+        );
+    }
+}

--- a/ps17/config/front/process.yml
+++ b/ps17/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Core\Order\Validator\CheckoutValidator'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction
@@ -173,7 +174,6 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderAction'
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
-      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler
@@ -281,6 +281,11 @@ services:
     arguments:
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderCaptureRepository'
 
+  PsCheckout\Infrastructure\Repository\WebhookEventRepository:
+    class: PsCheckout\Infrastructure\Repository\WebhookEventRepository
+    arguments:
+      - '@ps_checkout.db'
+
   PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor:
     class: PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor
     arguments:
@@ -290,6 +295,10 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache'
       - '@PsCheckout\Core\PaymentToken\Action\SavePaymentTokenAction'
       - '@PsCheckout\Infrastructure\Repository\PaymentTokenRepository'
+      - '@PsCheckout\Infrastructure\Repository\WebhookEventRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@PsCheckout\Infrastructure\Repository\CartRepository'
+      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction

--- a/ps17/phpstan-baseline.neon
+++ b/ps17/phpstan-baseline.neon
@@ -1017,7 +1017,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4093,12 +4093,6 @@ parameters:
 			path: ../core/src/PayPal/Order/Handler/PayPalEventDispatcher.php
 
 		-
-			message: '#^Cannot access property \$id on Cart\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
-
-		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 3
@@ -6559,6 +6553,18 @@ parameters:
 			path: ../core/src/WebhookDispatcher/Action/VerifyWebhookActionInterface.php
 
 		-
+			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\CartRepositoryInterface\:\:getOneBy\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\Processor\\DispatchWebhookProcessor\:\:log\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -6573,6 +6579,12 @@ parameters:
 		-
 			message: '#^Offset ''id'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Parameter \#1 \$cart of method PsCheckout\\Infrastructure\\Adapter\\ContextInterface\:\:loadCartForWebhook\(\) expects Cart, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
 
@@ -6647,6 +6659,12 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/src/WebhookDispatcher/Validator/HeaderValuesValidatorInterface.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: ../core/src/WebhookDispatcher/ValueObject/DispatchWebhookRequest.php
 
 		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\ValueObject\\DispatchWebhookRequest\:\:__construct\(\) has parameter \$resource with no value type specified in iterable type array\.$#'
@@ -7921,10 +7939,100 @@ parameters:
 			path: ../core/tests/Integration/Response/CaptureOrderResponse.php
 
 		-
+			message: '#^Binary operation "\." between ''SELECT \* FROM `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Method PsCheckout\\Core\\Tests\\Integration\\WebhookDispatcher\\Repository\\WebhookEventRepositoryTest\:\:fetchRow\(\) should return array\<string, mixed\>\|null but returns array\|object\|true\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Offset ''status'' might not exist on array\<string, mixed\>\|null\.$#'
+			identifier: offsetAccess.notFound
+			count: 5
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
 			message: '#^Property CartCore\:\:\$id_address_delivery \(int\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: ../core/tests/Unit/Customer/Action/ExpressCheckoutActionTest.php
+
+		-
+			message: '#^Cannot call method execute\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method expects\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method method\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$action has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$checkoutValidator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$createValidateOrderDataAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderMatrixRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$validateOrderAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
 
 		-
 			message: '#^Method AmountBreakdownNodeTest\:\:buildDataProvider\(\) return type has no value type specified in iterable type array\.$#'
@@ -9063,19 +9171,19 @@ parameters:
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 19
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 14
+			count: 54
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method process\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 12
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9087,13 +9195,31 @@ parameters:
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 31
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method with\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 12
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$cartRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9121,6 +9247,12 @@ parameters:
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$payPalOrderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$paymentTokenRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -9134,6 +9266,12 @@ parameters:
 
 		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$savePaymentTokenAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$webhookEventRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
@@ -10059,7 +10197,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between "\\n            CREATE…" and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 12
+			count: 13
 			path: ../infrastructure/src/Bootstrap/Install/DatabaseTableInstaller.php
 
 		-
@@ -11495,6 +11633,18 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: ../infrastructure/src/Repository/StateRepository.php
+
+		-
+			message: '#^Binary operation "\." between ''UPDATE `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<min, 0\> and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
 
 		-
 			message: '#^Cannot access property \$iso_code on Country\|null\.$#'

--- a/ps17/upgrade/upgrade-7.5.5.0.php
+++ b/ps17/upgrade/upgrade-7.5.5.0.php
@@ -42,6 +42,19 @@ function upgrade_module_7_5_5_0(Ps_checkout $module)
             KEY `id_address` (`id_address`)
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8
         ');
+
+        $db->execute('
+            CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'pscheckout_webhook_event` (
+            `id` varchar(50) NOT NULL,
+            `event_type` varchar(100) NOT NULL,
+            `resource_id` varchar(50) NOT NULL,
+            `status` varchar(20) NOT NULL DEFAULT \'processing\',
+            `error` text DEFAULT NULL,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=UTF8
+        ');
     } catch (Exception $exception) {
         PrestaShopLogger::addLog($exception->getMessage(), 4, 1, 'Module', $module->id);
 

--- a/ps8/config/front/process.yml
+++ b/ps8/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Core\Order\Validator\CheckoutValidator'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction
@@ -173,7 +174,6 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderAction'
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
-      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler
@@ -281,6 +281,11 @@ services:
     arguments:
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderCaptureRepository'
 
+  PsCheckout\Infrastructure\Repository\WebhookEventRepository:
+    class: PsCheckout\Infrastructure\Repository\WebhookEventRepository
+    arguments:
+      - '@ps_checkout.db'
+
   PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor:
     class: PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor
     arguments:
@@ -290,6 +295,10 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache'
       - '@PsCheckout\Core\PaymentToken\Action\SavePaymentTokenAction'
       - '@PsCheckout\Infrastructure\Repository\PaymentTokenRepository'
+      - '@PsCheckout\Infrastructure\Repository\WebhookEventRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@PsCheckout\Infrastructure\Repository\CartRepository'
+      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction

--- a/ps8/phpstan-baseline.neon
+++ b/ps8/phpstan-baseline.neon
@@ -1053,7 +1053,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4135,12 +4135,6 @@ parameters:
 			path: ../core/src/PayPal/Order/Handler/PayPalEventDispatcher.php
 
 		-
-			message: '#^Cannot access property \$id on Cart\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
-
-		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 3
@@ -6607,6 +6601,18 @@ parameters:
 			path: ../core/src/WebhookDispatcher/Action/VerifyWebhookActionInterface.php
 
 		-
+			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\CartRepositoryInterface\:\:getOneBy\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\Processor\\DispatchWebhookProcessor\:\:log\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -6621,6 +6627,12 @@ parameters:
 		-
 			message: '#^Offset ''id'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Parameter \#1 \$cart of method PsCheckout\\Infrastructure\\Adapter\\ContextInterface\:\:loadCartForWebhook\(\) expects Cart, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
 
@@ -6695,6 +6707,12 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/src/WebhookDispatcher/Validator/HeaderValuesValidatorInterface.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: ../core/src/WebhookDispatcher/ValueObject/DispatchWebhookRequest.php
 
 		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\ValueObject\\DispatchWebhookRequest\:\:__construct\(\) has parameter \$resource with no value type specified in iterable type array\.$#'
@@ -7969,6 +7987,96 @@ parameters:
 			path: ../core/tests/Integration/Response/CaptureOrderResponse.php
 
 		-
+			message: '#^Binary operation "\." between ''SELECT \* FROM `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Method PsCheckout\\Core\\Tests\\Integration\\WebhookDispatcher\\Repository\\WebhookEventRepositoryTest\:\:fetchRow\(\) should return array\<string, mixed\>\|null but returns array\|object\|true\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Offset ''status'' might not exist on array\<string, mixed\>\|null\.$#'
+			identifier: offsetAccess.notFound
+			count: 5
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Cannot call method execute\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method expects\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method method\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$action has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$checkoutValidator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$createValidateOrderDataAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderMatrixRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$validateOrderAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
 			message: '#^Method AmountBreakdownNodeTest\:\:buildDataProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9105,19 +9213,19 @@ parameters:
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 19
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 14
+			count: 54
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method process\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 12
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9129,13 +9237,31 @@ parameters:
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 31
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method with\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 12
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$cartRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9163,6 +9289,12 @@ parameters:
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$payPalOrderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$paymentTokenRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -9176,6 +9308,12 @@ parameters:
 
 		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$savePaymentTokenAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$webhookEventRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
@@ -10125,7 +10263,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between "\\n            CREATE…" and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 12
+			count: 13
 			path: ../infrastructure/src/Bootstrap/Install/DatabaseTableInstaller.php
 
 		-
@@ -11405,6 +11543,18 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: ../infrastructure/src/Repository/StateRepository.php
+
+		-
+			message: '#^Binary operation "\." between ''UPDATE `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<min, 0\> and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
 
 		-
 			message: '#^Cannot access property \$iso_code on Country\|null\.$#'

--- a/ps8/upgrade/upgrade-8.5.5.0.php
+++ b/ps8/upgrade/upgrade-8.5.5.0.php
@@ -42,6 +42,19 @@ function upgrade_module_8_5_5_0(Ps_checkout $module)
             KEY `id_address` (`id_address`)
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8
         ');
+
+        $db->execute('
+            CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'pscheckout_webhook_event` (
+            `id` varchar(50) NOT NULL,
+            `event_type` varchar(100) NOT NULL,
+            `resource_id` varchar(50) NOT NULL,
+            `status` varchar(20) NOT NULL DEFAULT \'processing\',
+            `error` text DEFAULT NULL,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=UTF8
+        ');
     } catch (Exception $exception) {
         PrestaShopLogger::addLog($exception->getMessage(), 4, 1, 'Module', $module->id);
 

--- a/ps9/config/front/process.yml
+++ b/ps9/config/front/process.yml
@@ -56,6 +56,7 @@ services:
       - '@PsCheckout\Core\Order\Action\ValidateOrderAction'
       - '@PsCheckout\Infrastructure\Repository\OrderRepository'
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderMatrixRepository'
+      - '@PsCheckout\Core\Order\Validator\CheckoutValidator'
 
   PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\CapturePayPalOrderAction
@@ -173,7 +174,6 @@ services:
       - '@PsCheckout\Core\Order\Action\CreateOrderAction'
       - '@PsCheckout\Core\Order\Action\CreateOrderPaymentAction'
       - '@PsCheckout\Core\OrderState\Action\SetCompletedOrderStateAction'
-      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler:
     class: PsCheckout\Core\PayPal\Order\Handler\PaymentPendingEventHandler
@@ -281,6 +281,11 @@ services:
     arguments:
       - '@PsCheckout\Infrastructure\Repository\PayPalOrderCaptureRepository'
 
+  PsCheckout\Infrastructure\Repository\WebhookEventRepository:
+    class: PsCheckout\Infrastructure\Repository\WebhookEventRepository
+    arguments:
+      - '@ps_checkout.db'
+
   PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor:
     class: PsCheckout\Core\WebhookDispatcher\Processor\DispatchWebhookProcessor
     arguments:
@@ -290,6 +295,10 @@ services:
       - '@PsCheckout\Core\PayPal\Order\Cache\PayPalOrderCache'
       - '@PsCheckout\Core\PaymentToken\Action\SavePaymentTokenAction'
       - '@PsCheckout\Infrastructure\Repository\PaymentTokenRepository'
+      - '@PsCheckout\Infrastructure\Repository\WebhookEventRepository'
+      - '@PsCheckout\Infrastructure\Repository\PayPalOrderRepository'
+      - '@PsCheckout\Infrastructure\Repository\CartRepository'
+      - '@PsCheckout\Infrastructure\Adapter\Context'
 
   PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction:
     class: PsCheckout\Core\PayPal\Order\Action\AuthorizePayPalOrderAction

--- a/ps9/phpstan-baseline.neon
+++ b/ps9/phpstan-baseline.neon
@@ -1053,7 +1053,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$id on Cart\|null\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: ../core/src/Order/Action/CreateOrderAction.php
 
 		-
@@ -4135,12 +4135,6 @@ parameters:
 			path: ../core/src/PayPal/Order/Handler/PayPalEventDispatcher.php
 
 		-
-			message: '#^Cannot access property \$id on Cart\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: ../core/src/PayPal/Order/Handler/PaymentCompletedEventHandler.php
-
-		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 3
@@ -6607,6 +6601,18 @@ parameters:
 			path: ../core/src/WebhookDispatcher/Action/VerifyWebhookActionInterface.php
 
 		-
+			message: '#^Call to an undefined method PsCheckout\\Infrastructure\\Repository\\CartRepositoryInterface\:\:getOneBy\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\Processor\\DispatchWebhookProcessor\:\:log\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -6621,6 +6627,12 @@ parameters:
 		-
 			message: '#^Offset ''id'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
+			count: 1
+			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
+
+		-
+			message: '#^Parameter \#1 \$cart of method PsCheckout\\Infrastructure\\Adapter\\ContextInterface\:\:loadCartForWebhook\(\) expects Cart, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: ../core/src/WebhookDispatcher/Processor/DispatchWebhookProcessor.php
 
@@ -6695,6 +6707,12 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../core/src/WebhookDispatcher/Validator/HeaderValuesValidatorInterface.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: ../core/src/WebhookDispatcher/ValueObject/DispatchWebhookRequest.php
 
 		-
 			message: '#^Method PsCheckout\\Core\\WebhookDispatcher\\ValueObject\\DispatchWebhookRequest\:\:__construct\(\) has parameter \$resource with no value type specified in iterable type array\.$#'
@@ -7969,6 +7987,96 @@ parameters:
 			path: ../core/tests/Integration/Response/CaptureOrderResponse.php
 
 		-
+			message: '#^Binary operation "\." between ''SELECT \* FROM `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Method PsCheckout\\Core\\Tests\\Integration\\WebhookDispatcher\\Repository\\WebhookEventRepositoryTest\:\:fetchRow\(\) should return array\<string, mixed\>\|null but returns array\|object\|true\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Offset ''status'' might not exist on array\<string, mixed\>\|null\.$#'
+			identifier: offsetAccess.notFound
+			count: 5
+			path: ../core/tests/Integration/WebhookDispatcher/Repository/WebhookEventRepositoryTest.php
+
+		-
+			message: '#^Cannot call method execute\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method expects\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method method\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$action has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$checkoutValidator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$createValidateOrderDataAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderMatrixRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$orderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
+			message: '#^Property CreateOrderActionTest\:\:\$validateOrderAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/Order/Action/CreateOrderActionTest.php
+
+		-
 			message: '#^Method AmountBreakdownNodeTest\:\:buildDataProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9105,19 +9213,19 @@ parameters:
 		-
 			message: '#^Cannot call method expects\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 19
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method method\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 14
+			count: 54
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method process\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 12
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9129,13 +9237,31 @@ parameters:
 		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 7
+			count: 31
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Cannot call method willThrowException\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
 			message: '#^Cannot call method with\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 12
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$cartRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$context has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
@@ -9163,6 +9289,12 @@ parameters:
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
 
 		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$payPalOrderRepository has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$paymentTokenRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -9176,6 +9308,12 @@ parameters:
 
 		-
 			message: '#^Property DispatchWebhookProcessorTest\:\:\$savePaymentTokenAction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
+
+		-
+			message: '#^Property DispatchWebhookProcessorTest\:\:\$webhookEventRepository has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: ../core/tests/Unit/WebhookDispatcher/Processor/DispatchWebhookProcessorTest.php
@@ -10125,7 +10263,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between "\\n            CREATE…" and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 12
+			count: 13
 			path: ../infrastructure/src/Bootstrap/Install/DatabaseTableInstaller.php
 
 		-
@@ -11405,6 +11543,18 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: ../infrastructure/src/Repository/StateRepository.php
+
+		-
+			message: '#^Binary operation "\." between ''UPDATE `'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<min, 0\> and 0 is always false\.$#'
+			identifier: greater.alwaysFalse
+			count: 1
+			path: ../infrastructure/src/Repository/WebhookEventRepository.php
 
 		-
 			message: '#^Cannot access property \$iso_code on Country\|null\.$#'

--- a/ps9/upgrade/upgrade-9.5.5.0.php
+++ b/ps9/upgrade/upgrade-9.5.5.0.php
@@ -42,6 +42,19 @@ function upgrade_module_9_5_5_0(Ps_checkout $module)
             KEY `id_address` (`id_address`)
             ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8
         ');
+
+        $db->execute('
+            CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'pscheckout_webhook_event` (
+            `id` varchar(50) NOT NULL,
+            `event_type` varchar(100) NOT NULL,
+            `resource_id` varchar(50) NOT NULL,
+            `status` varchar(20) NOT NULL DEFAULT \'processing\',
+            `error` text DEFAULT NULL,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=UTF8
+        ');
     } catch (\Exception $exception) {
         PrestaShopLogger::addLog($exception->getMessage(), 4, 1, 'Module', $module->id);
 


### PR DESCRIPTION
…otency

## Self-Checks
- [x] I have performed a self-review of my code.
- [x] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

Resolves: [XO-3020](https://prestashop-jira.atlassian.net/browse/XO-3020)

## Summary

Webhook-driven order processing in `ps_checkout` could fail in production for two reasons:

1. **Invalid / stale PrestaShop context in webhook requests** caused order creation to crash or silently stop.
2. **No event-level idempotency** allowed duplicate processing of repeated PayPal/Svix deliveries, which could create duplicate PrestaShop orders or leave order side effects incomplete after partial failures.

This change hardens the webhook pipeline by:
- reconstructing a safe PrestaShop context from the cart during webhook processing
- adding DB-backed webhook event idempotency
- making duplicate-order detection explicit in `CreateOrderAction`
- ensuring retries can safely complete payment/state side effects after partial success

---

## Problem statement

### 1. Webhook requests do not have a customer checkout session
PayPal webhooks are processed server-to-server. In this context, `Context::getContext()->cart` is not reliably initialized from a live customer session. It may be:
- empty
- null
- or stale from a previous PHP-FPM request

Downstream order-creation code assumes a valid cart exists in context. When `CreateValidateOrderDataAction` passes `$cart->id` into `ValidateOrderData::create()`, a null cart ID causes a `TypeError`. In other cases, a stale cart ID can pass an upstream guard and fail later in the flow.

### 2. Webhook delivery is retried by providers
PayPal retries webhooks when the module returns a non-2xx HTTP response. Svix may also deliver duplicates. Before this change, the module had **no persistent record of processed webhook events**, so each delivery re-entered the full pipeline.

This created two failure modes:
- **duplicate order creation** when multiple deliveries processed the same business event
- **partial-success retries** where an order was created on a first attempt, but later side effects failed before the webhook completed successfully

### 3. Duplicate protection existed only on the front path
The front-office flow already used `CheckoutValidator`, which checks whether a PrestaShop order already exists for the cart. The webhook path did not pass through that validator, so retries after partial success could still re-enter `CreateOrderAction` without a duplicate guard.

---

## Impact

### Business impact
- lost or delayed order creation from successful PayPal payments
- duplicate PrestaShop orders for the same payment event
- inconsistent order state after retry scenarios
- manual merchant support work to reconcile orders/payments

### Technical impact
- non-deterministic behavior in webhook processing
- low observability into webhook retries and failures
- multistore risk from incorrect shop context resolution in server-side requests

---

## Root cause

### Root cause A — invalid context in webhook execution
Webhook execution is not tied to a front-office session, but the order-creation flow relied on context-based cart/customer/shop data as if it were.

### Root cause B — no event-level idempotency
The module did not persist webhook event processing state, so retries and duplicates were indistinguishable from first deliveries.

### Root cause C — duplicate-order guard missing in reusable action
`CreateOrderAction` was reusable but did not enforce duplicate-order validation itself; that validation existed only in the front-office orchestration path.

---

## Solution implemented

### A. Reconstruct PrestaShop context for webhook requests
Added `loadCartForWebhook(\Cart $cart)` on `ContextInterface` / `Context`.

This method reconstructs:
- `context->cart`
- `context->language`
- `context->currency`
- `context->customer` when available
- `context->shop`
- `context->country`

Important implementation details:
- **no cart update**
- **no cookie write**
- **no front-office session side effects**
- `\Shop::setContext(\Shop::CONTEXT_SHOP, $idShop)` aligns static shop context for multistore safety
- country resolution:
  1. resolve from address defined by `PS_TAX_ADDRESS_TYPE`
  2. fallback to `PS_COUNTRY_DEFAULT`
  3. leave unchanged if neither loads safely

This is called in `DispatchWebhookProcessor` before webhook event handlers run.

### B. Add webhook event idempotency
Added a new table: `pscheckout_webhook_event`

Purpose:
- claim webhook event processing atomically
- mark events as `processing`, `succeeded`, or `failed`
- skip duplicates safely
- reclaim failed or stale events on retry

Processing model:
- `claim()` uses `INSERT IGNORE` + conditional `UPDATE`
- only one processor can successfully claim a given `webhookId`
- stale `processing` rows older than 10 minutes can be reclaimed
- `failed` rows can be retried
- `succeeded` rows are skipped with HTTP 200

### C. Make duplicate-order protection action-level
`CreateOrderAction` now depends on `CheckoutValidatorInterface` and validates before creating the order.

This ensures the webhook path gets the same duplicate-order guard as the front-office path.

If a retry occurs after the order was already created:
- validator throws `PRESTASHOP_ORDER_ALREADY_EXISTS`
- processor treats that as a **successful terminal state**
- webhook event is marked `succeeded`
- HTTP 200 is returned, so PayPal stops retrying

### D. Catch unexpected failures too
`DispatchWebhookProcessor` now catches `\Throwable`, not just `PsCheckoutException`, so:
- `TypeError`
- unexpected null errors
- runtime/infrastructure exceptions

also trigger `markFailed()` before rethrow.

This avoids leaving events stuck in `processing` after application-level crashes.

### E. Make retries self-healing after partial success
`PaymentCompletedEventHandler` now continues with:
- payment creation
- completed-state update

even when order creation throws `PRESTASHOP_ORDER_ALREADY_EXISTS`.

This covers the case where:
- first attempt created the order
- crash happened before payment record or order state update
- retry should complete the missing side effects rather than stop early

### F. Normalize repository time handling
`WebhookEventRepository::claim()` now uses PHP-generated timestamps consistently, matching `markSucceeded()` and `markFailed()`, instead of mixing PHP time with SQL `NOW()`.

---

## Why this change was necessary

This was not just a cleanup or refactor.

It fixes **production-facing reliability gaps** that can directly affect merchants:
- successful payments not turning into orders
- duplicate orders from the same payment event
- incomplete order/payment state after retries
- harder diagnosis during incident handling

Without these changes, webhook processing remained vulnerable to both:
- request-context instability
- delivery retries/concurrency behavior that are normal for payment providers

---

## Scope of change

### Main components touched
- `DispatchWebhookProcessor`
- `ContextInterface` / `Context`
- `CreateOrderAction`
- `PaymentCompletedEventHandler`
- `WebhookEventRepository` and related entity/repository contracts
- DB install / upgrade scripts
- front service wiring for PS 1.7 / 8 / 9
- unit and integration tests

### New persistence
- `pscheckout_webhook_event`

---

## Risks / compatibility notes

- webhook behavior is now intentionally more defensive and stateful
- multistore handling is improved by aligning shop context explicitly
- duplicate-order detection now happens closer to order creation, which is safer for retries
- retries may still occur after true infrastructure/process crashes, but stale-row reclaim covers recovery

---

## Validation

### Automated
- 603 tests green

### Added coverage
- duplicate-order success path in webhook processor
- duplicate-order validation in `CreateOrderAction`
- repository integration tests for all `claim()` transitions
- `markSucceeded()` / `markFailed()` repository behavior

### Manual scenarios covered
- first successful delivery
- duplicate delivery of same `webhookId`
- retry after failed row
- retry after stale processing row
- order already created before webhook retry
- partial-success retry completing payment/state side effects

---

## Expected outcome

After this fix:
- webhook requests no longer depend on an accidental or stale front-office context
- repeated delivery of the same webhook event is safe
- duplicate order creation is prevented
- retries can complete missing side effects instead of making the state worse
- webhook operational state is observable in DB

---

## Acceptance criteria
- webhook order processing reconstructs a valid cart/shop/language/currency/customer context from persisted cart data
- repeated delivery of the same webhook event does not create duplicate orders
- `PRESTASHOP_ORDER_ALREADY_EXISTS` is treated as successful webhook completion
- failed/stale webhook events can be retried safely
- payment record and order state can still be completed on retry after partial success
- multistore shop-scoped configuration resolves correctly during webhook execution
- tests remain green

## QA Checklist Labels
- [x] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [x] Technical debt? <!-- Maps to "debt" label -->
- [x] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->

## Additional Context
<!-- Provide a concise description of the changes made in this PR. -->

## Frontend Changes
<!-- If applicable, provide visual elements such as screenshots, GIFs, or videos to demonstrate frontend changes. -->
<br><br>

[!] Don't forget to include JIRA task number in PR name or branch name. [!]

[!] Don't forget to update *changelog.md* with new changes. [!]

- [x] Verify if the version is correct.
- [x] Update demo environments used for testing.
- [x] Ensure changelog contains all changes.
- [x] Update documentation if needed.
- [x] Test if everything works properly.

[XO-3020]: https://prestashop-jira.atlassian.net/browse/XO-3020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ