### PR TITLE
fix(googlepay): use shop name as Google Pay merchant name

### DIFF
--- a/core/src/PayPal/GooglePay/Builder/GooglePayPaymentRequestDataBuilder.php
+++ b/core/src/PayPal/GooglePay/Builder/GooglePayPaymentRequestDataBuilder.php
@@ -22,8 +22,10 @@ namespace PsCheckout\Core\PayPal\GooglePay\Builder;
 
 use PsCheckout\Core\Order\Builder\OrderPayloadBuilderInterface;
 use PsCheckout\Core\PayPal\GooglePay\ValueObject\GooglePayPaymentRequestData;
+use PsCheckout\Infrastructure\Adapter\ConfigurationInterface;
 use PsCheckout\Presentation\Presenter\PresenterInterface;
 use PsCheckout\Presentation\TranslatorInterface;
+use PsCheckout\Utility\Common\StringUtility;
 
 class GooglePayPaymentRequestDataBuilder implements GooglePayPaymentRequestDataBuilderInterface
 {
@@ -42,14 +44,21 @@ class GooglePayPaymentRequestDataBuilder implements GooglePayPaymentRequestDataB
      */
     private $translator;
 
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
     public function __construct(
         OrderPayloadBuilderInterface $orderPayloadBuilder,
         PresenterInterface $cartPresenter,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        ConfigurationInterface $configuration
     ) {
         $this->orderPayloadBuilder = $orderPayloadBuilder;
         $this->cartPresenter = $cartPresenter;
         $this->translator = $translator;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -66,7 +75,7 @@ class GooglePayPaymentRequestDataBuilder implements GooglePayPaymentRequestDataB
             $payload['purchase_units'][0]['amount']['currency_code'],
             $payload['purchase_units'][0]['amount']['value'],
             $this->translator->trans('Total GooglePay'),
-            $payload['application_context']['brand_name']
+            StringUtility::normalizeBrandName((string) $this->configuration->get('PS_SHOP_NAME'))
         );
     }
 }

--- a/ps17/config/front/builder.yml
+++ b/ps17/config/front/builder.yml
@@ -8,6 +8,7 @@ services:
       - '@PsCheckout\Core\Order\Builder\OrderPayloadBuilder'
       - '@PsCheckout\Presentation\Presenter\Cart\CartPresenter'
       - '@PsCheckout\Module\Presentation\Translator'
+      - '@PsCheckout\Infrastructure\Adapter\Configuration'
 
   PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder:
     class: 'PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder'

--- a/ps8/config/front/builder.yml
+++ b/ps8/config/front/builder.yml
@@ -8,6 +8,7 @@ services:
       - '@PsCheckout\Core\Order\Builder\OrderPayloadBuilder'
       - '@PsCheckout\Presentation\Presenter\Cart\CartPresenter'
       - '@PsCheckout\Module\Presentation\Translator'
+      - '@PsCheckout\Infrastructure\Adapter\Configuration'
 
   PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder:
     class: 'PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder'

--- a/ps9/config/front/builder.yml
+++ b/ps9/config/front/builder.yml
@@ -8,6 +8,7 @@ services:
       - '@PsCheckout\Core\Order\Builder\OrderPayloadBuilder'
       - '@PsCheckout\Presentation\Presenter\Cart\CartPresenter'
       - '@PsCheckout\Module\Presentation\Translator'
+      - '@PsCheckout\Infrastructure\Adapter\Configuration'
 
   PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder:
     class: 'PsCheckout\Core\PayPal\ApplePay\Builder\ApplePayPaymentRequestDataBuilder'


### PR DESCRIPTION
## Self-Checks
- [x] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

N/A — external contribution (no JIRA access).

## Summary
Fix an HTTP 500 (`TypeError`) thrown when a customer pays with Google Pay: the builder read a payload key that is never produced, so the Google Pay merchant name was `null`. It is now resolved from the shop name.

## QA Checklist Labels
- [x] Bug fix?
- [ ] New feature?
- [ ] Improvement?
- [ ] Technical debt?
- [ ] Covered by tests?

## QA Checklist
Steps to reproduce / verify:
1. Configure ps_checkout with PayPal connected and enable Google Pay.
2. Add a product to the cart and proceed to checkout.
3. Click the Google Pay button to start the payment.

- Before: the `googlepay` controller returns HTTP 500 `{"error":{"code":0,"message":"An error occurred while processing the Google Pay request."}}`.
- After: it returns 200 with the transaction info and the Google Pay sheet shows the shop name as merchant.

## Additional Context
`Ps_CheckoutGooglepayModuleFrontController` (`getTransactionInfo`) calls `GooglePayPaymentRequestDataBuilder::build()`, which reads `$payload['application_context']['brand_name']`. The payload built by `OrderPayloadBuilder` never sets `application_context` (the brand name is set under `experience_context` by the payment-source node builders), so the value is always `null`. Passing `null` to the `string $merchantName` parameter of `GooglePayPaymentRequestData` throws a `TypeError`, caught by the controller's `catch (Throwable)` and returned as a generic HTTP 500.

Fix: resolve the merchant name from `PS_SHOP_NAME` through the injected `ConfigurationInterface` adapter, normalized with `StringUtility::normalizeBrandName()` — the same approach used for `brand_name` everywhere else in the module. The dependency is wired in `config/front/builder.yml` for `ps17`/`ps8`/`ps9`.

Apple Pay's builder does not use `brand_name`, so it is unaffected.

## Frontend Changes
N/A
